### PR TITLE
add oauth integration validator

### DIFF
--- a/extensions/oauth-integration-validator/app.R
+++ b/extensions/oauth-integration-validator/app.R
@@ -72,7 +72,7 @@ server <- function(input, output, session) {
       # remind the user that they don't have a token 
       output$results <- renderUI({
         HTML('<span style="color:red; font-size:larger;">No access token found.',
-        '<br/>Try logging out and logging back in to the integration if you haven not ',
+        '<br/>Try logging out and logging back in to the integration if you have not ',
         'visited this content recently.<br/>If an integration is not associated with ',
         'the content then ask your publisher to add one.</span><br/>')
       })

--- a/extensions/oauth-integration-validator/app.R
+++ b/extensions/oauth-integration-validator/app.R
@@ -1,0 +1,118 @@
+library(shiny)
+library(httr2)
+library(bslib)
+library(connectapi)
+
+ui <- page_sidebar(
+  title = "OAuth Integration Validation in R",
+  sidebar = sidebar(
+    title = "Request an endpoint",
+    textInput("endpoint", "GET endpoint to request:", placeholder = "https://example.com/api/list"),
+    actionButton("request", "Request")
+  ),
+  layout_columns(
+    card(
+      card_header("Results"),
+      htmlOutput("results")
+    )
+  )
+)
+
+server <- function(input, output, session) {
+  
+  # check if running on Posit Connect
+  if (Sys.getenv("RSTUDIO_PRODUCT") == "CONNECT") {
+    # initialize Connect API client
+    client <- connect()
+    
+    # read the user-session-token header
+    user_session_token <- session$request$HTTP_POSIT_CONNECT_USER_SESSION_TOKEN
+    
+    # wrap client credentials exchange request for error handling
+    # and so the app does not fail to start on first deploy
+    credentials <- reactive({
+      tryCatch({
+        # exchange user session token for an access token using connectapi client
+        # checking for a client error in
+        credentials <- get_oauth_credentials(client, user_session_token)
+      }, error = function(e) {
+          return(list(error = "Unable to obtain access token: ", message = e$message))
+        })
+      })
+   
+    observeEvent(credentials(), {
+      creds <- credentials()
+      
+      # check if the credentials exchange was successful
+      if (is.null(creds$error)) {
+        token <- creds$access_token
+      } else {
+        # show notification to user
+        showNotification(creds$error, creds$message)
+      }
+    }) 
+  } else {
+    # grab the access token from the OAUTH_TOKEN environment variable if running
+    # locally
+    token <- Sys.getenv("OAUTH_TOKEN")
+  }
+  
+  # react to request button being pressed 
+  observeEvent(input$request, {
+    # do not allow empty value for endpoint
+    req(input$endpoint)
+    endpoint <- input$endpoint
+    
+    # do not allow request without an access token
+    if (!exists("token")) {
+      # remind the user that they don't have a token 
+      output$results <- renderUI({
+        HTML('<span style="color:red; font-size:larger;">No access token found.',
+        '<br/>Try logging out and logging back in to the integration if you haven not ',
+        'visited this content recently.<br/>If an integration is not associated with ',
+        'the content then ask your publisher to add one.</span><br/>')
+      })
+    } else {
+      # make the request 
+      resp <- httr2::request(endpoint) |>
+        httr2::req_headers("Accept" = "application/json") |>
+        httr2::req_auth_bearer_token(token) |>
+        # to avoid HTTP response error codes being surfaced as R errors
+        httr2::req_error(is_error = ~FALSE) |>
+        httr2::req_perform()
+    
+      # check the HTTP response code
+      http_code <- httr2::resp_status(resp)
+      if (http_code == 200) {
+        # format response body now that we have the HTTP status code
+        resp <- httr2::resp_body_json(resp)
+      
+        # save the results
+        results <- paste0("Endpoint ", input$endpoint, " returned: ", resp)
+      
+        # display success message and expandable results section 
+        output$results <- renderUI({
+          HTML('<span style="color:green; font-size:larger;">Success!</span><br/>', 
+            '<details><summary>Show results</summary><p>',
+            results,
+            '</p></details>'
+          )
+        })
+      }
+      
+      # output the unexpected HTTP code
+      if (http_code != 200) {
+        output$results <- renderUI({
+          # only display the HTTP error code to the user
+          error <- paste0("Received non-200 HTTP response code: ", http_code)
+          HTML('<span style="color:red; front-size:larger;">', error, '</span>')
+        })
+        # log the results for debugging
+        print(httr2::resp_body_json(resp))
+      }
+    }
+  })
+}
+
+shinyApp(ui, server)
+

--- a/extensions/oauth-integration-validator/app.R
+++ b/extensions/oauth-integration-validator/app.R
@@ -3,12 +3,14 @@ library(httr2)
 library(bslib)
 library(connectapi)
 
-ui <- page_sidebar(
+ui <- page_fluid(
   title = "OAuth Integration Validation in R",
-  sidebar = sidebar(
-    title = "Request an endpoint",
-    textInput("endpoint", "GET endpoint to request:", placeholder = "https://example.com/api/list"),
-    actionButton("request", "Request")
+  layout_columns(
+    card_header = "Request an endpoint",
+    card_body(
+      textInput("endpoint", "GET endpoint to request:", placeholder = "https://example.com/api/list", width = "640"),
+      actionButton("request", "Request", width = "640")
+    )
   ),
   layout_columns(
     card(
@@ -74,7 +76,7 @@ server <- function(input, output, session) {
         HTML('<span style="color:red; font-size:larger;">No access token found.',
         '<br/>Try logging out and logging back in to the integration if you have not ',
         'visited this content recently.<br/>If an integration is not associated with ',
-        'the content then ask your publisher to add one.</span><br/>')
+        'this content then request the content owner add one.</span><br/>')
       })
     } else {
       # make the request 

--- a/extensions/oauth-integration-validator/app.R
+++ b/extensions/oauth-integration-validator/app.R
@@ -40,12 +40,16 @@ server <- function(input, output, session) {
         })
       })
    
+    # set token to null
+    token <- reactiveVal(NULL)
+    
+    # react to the credentials request
     observeEvent(credentials(), {
       creds <- credentials()
       
       # check if the credentials exchange was successful
       if (is.null(creds$error)) {
-        token <- creds$access_token
+        token(creds$access_token)
       } else {
         # show notification to user
         showNotification(creds$error, creds$message)
@@ -64,7 +68,7 @@ server <- function(input, output, session) {
     endpoint <- input$endpoint
     
     # do not allow request without an access token
-    if (!exists("token")) {
+    if (is.null(token())) {
       # remind the user that they don't have a token 
       output$results <- renderUI({
         HTML('<span style="color:red; font-size:larger;">No access token found.',
@@ -76,7 +80,7 @@ server <- function(input, output, session) {
       # make the request 
       resp <- httr2::request(endpoint) |>
         httr2::req_headers("Accept" = "application/json") |>
-        httr2::req_auth_bearer_token(token) |>
+        httr2::req_auth_bearer_token(token()) |>
         # to avoid HTTP response error codes being surfaced as R errors
         httr2::req_error(is_error = ~FALSE) |>
         httr2::req_perform()

--- a/extensions/oauth-integration-validator/connect-extension.qmd
+++ b/extensions/oauth-integration-validator/connect-extension.qmd
@@ -10,11 +10,18 @@ This R Shiny extension allows Posit Connect content viewers to make a GET
 request to a specified endpoint using their OAuth access token obtained by 
 Connect. 
 
-If the request succeeds a message reflecting the same is displayed to the user, 
-and the results of the request can be viewed by expanding the "Show results" 
-section.
+If Connect is unable to obtain an access token the app does not fail to start, 
+but instead notifies the user of the failure. If the user attempts to request an 
+endpoint without a token then an error message is displayed that suggests logging 
+out and back in to the integration or associating an OAuth integration if one was 
+not added.
+
+The GET request is made to the provided endpoint with the access token in the 
+headers as `Authorization: Bearer <token>`. If the request succeeds a message 
+reflecting the same is displayed to the user, and the results of the request can 
+be viewed by expanding the "Show results" section.
 
 On failure an error message is displayed that includes the HTTP error code. The 
 results of the request are logged instead of displayed to the user, as the 
-Connect publisher or administrator is likely handling debugging the resource 
+Connect publisher or administrator is likely in charge of debugging the resource 
 request failure.

--- a/extensions/oauth-integration-validator/connect-extension.qmd
+++ b/extensions/oauth-integration-validator/connect-extension.qmd
@@ -1,0 +1,20 @@
+---
+title: OAuth Integration Validator 
+categories:
+    - OAuth
+    - shiny
+    - R
+---
+
+This R Shiny extension allows Posit Connect content viewers to make a GET 
+request to a specified endpoint using their OAuth access token obtained by 
+Connect. 
+
+If the request succeeds a message reflecting the same is displayed to the user, 
+and the results of the request can be viewed by expanding the "Show results" 
+section.
+
+On failure an error message is displayed that includes the HTTP error code. The 
+results of the request are logged instead of displayed to the user, as the 
+Connect publisher or administrator is likely handling debugging the resource 
+request failure.

--- a/extensions/oauth-integration-validator/connect-extension.toml
+++ b/extensions/oauth-integration-validator/connect-extension.toml
@@ -1,4 +1,4 @@
 name = "oauth-integration-validator"
 title = "Connect OAuth Integration Validator"
-description = "Allows Connect content viewers to perform a GET request to a specified endpoint using the access token obtained by Connect."
+description = "Test an OAuth integration by performing a GET request to a specified endpoint using the access token obtained by Connect."
 access_type = "logged_in"

--- a/extensions/oauth-integration-validator/connect-extension.toml
+++ b/extensions/oauth-integration-validator/connect-extension.toml
@@ -1,0 +1,4 @@
+name = "oauth-integration-validator"
+title = "Connect OAuth Integration Validator"
+description = "Allows Connect content viewers to perform a GET request to a specified endpoint using the access token obtained by Connect."
+access_type = "logged_in"

--- a/extensions/oauth-integration-validator/renv.lock
+++ b/extensions/oauth-integration-validator/renv.lock
@@ -1,0 +1,620 @@
+{
+  "R": {
+    "Version": "4.4.2",
+    "Repositories": [
+      {
+        "Name": "CRAN",
+        "URL": "https://cran.rstudio.com"
+      }
+    ]
+  },
+  "Packages": {
+    "R6": {
+      "Package": "R6",
+      "Version": "2.5.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "470851b6d5d0ac559e9d01bb352b4021"
+    },
+    "Rcpp": {
+      "Package": "Rcpp",
+      "Version": "1.0.14",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "methods",
+        "utils"
+      ],
+      "Hash": "e7bdd9ee90e96921ca8a0f1972d66682"
+    },
+    "askpass": {
+      "Package": "askpass",
+      "Version": "1.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "sys"
+      ],
+      "Hash": "c39f4155b3ceb1a9a2799d700fbd4b6a"
+    },
+    "base64enc": {
+      "Package": "base64enc",
+      "Version": "0.1-3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "543776ae6848fde2f48ff3816d0628bc"
+    },
+    "bit": {
+      "Package": "bit",
+      "Version": "4.5.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "f89f074e0e49bf1dbe3eba0a15a91476"
+    },
+    "bit64": {
+      "Package": "bit64",
+      "Version": "4.6.0-1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "bit",
+        "graphics",
+        "methods",
+        "stats",
+        "utils"
+      ],
+      "Hash": "4f572fbc586294afff277db583b9060f"
+    },
+    "bslib": {
+      "Package": "bslib",
+      "Version": "0.8.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "base64enc",
+        "cachem",
+        "fastmap",
+        "grDevices",
+        "htmltools",
+        "jquerylib",
+        "jsonlite",
+        "lifecycle",
+        "memoise",
+        "mime",
+        "rlang",
+        "sass"
+      ],
+      "Hash": "b299c6741ca9746fb227debcb0f9fb6c"
+    },
+    "cachem": {
+      "Package": "cachem",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "fastmap",
+        "rlang"
+      ],
+      "Hash": "cd9a672193789068eb5a2aad65a0dedf"
+    },
+    "cli": {
+      "Package": "cli",
+      "Version": "3.6.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "utils"
+      ],
+      "Hash": "b21916dd77a27642b447374a5d30ecf3"
+    },
+    "commonmark": {
+      "Package": "commonmark",
+      "Version": "1.9.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5d8225445acb167abf7797de48b2ee3c"
+    },
+    "connectapi": {
+      "Package": "connectapi",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R6",
+        "bit64",
+        "fs",
+        "glue",
+        "httr",
+        "jsonlite",
+        "lifecycle",
+        "magrittr",
+        "purrr",
+        "rlang",
+        "tibble",
+        "uuid",
+        "vctrs"
+      ],
+      "Hash": "f5206247a25db881071783261b837afb"
+    },
+    "crayon": {
+      "Package": "crayon",
+      "Version": "1.5.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "grDevices",
+        "methods",
+        "utils"
+      ],
+      "Hash": "859d96e65ef198fd43e82b9628d593ef"
+    },
+    "curl": {
+      "Package": "curl",
+      "Version": "6.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "b580cbb010099fd990df6bfe44459e1a"
+    },
+    "digest": {
+      "Package": "digest",
+      "Version": "0.6.37",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "utils"
+      ],
+      "Hash": "33698c4b3127fc9f506654607fb73676"
+    },
+    "fansi": {
+      "Package": "fansi",
+      "Version": "1.0.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "utils"
+      ],
+      "Hash": "962174cf2aeb5b9eea581522286a911f"
+    },
+    "fastmap": {
+      "Package": "fastmap",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "aa5e1cd11c2d15497494c5292d7ffcc8"
+    },
+    "fontawesome": {
+      "Package": "fontawesome",
+      "Version": "0.5.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "htmltools",
+        "rlang"
+      ],
+      "Hash": "c2efdd5f0bcd1ea861c2d4e2a883a67d"
+    },
+    "fs": {
+      "Package": "fs",
+      "Version": "1.6.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "methods"
+      ],
+      "Hash": "15aeb8c27f5ea5161f9f6a641fafd93a"
+    },
+    "glue": {
+      "Package": "glue",
+      "Version": "1.8.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "methods"
+      ],
+      "Hash": "5899f1eaa825580172bb56c08266f37c"
+    },
+    "htmltools": {
+      "Package": "htmltools",
+      "Version": "0.5.8.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "base64enc",
+        "digest",
+        "fastmap",
+        "grDevices",
+        "rlang",
+        "utils"
+      ],
+      "Hash": "81d371a9cc60640e74e4ab6ac46dcedc"
+    },
+    "httpuv": {
+      "Package": "httpuv",
+      "Version": "1.6.15",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "Rcpp",
+        "later",
+        "promises",
+        "utils"
+      ],
+      "Hash": "d55aa087c47a63ead0f6fc10f8fa1ee0"
+    },
+    "httr": {
+      "Package": "httr",
+      "Version": "1.4.7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "curl",
+        "jsonlite",
+        "mime",
+        "openssl"
+      ],
+      "Hash": "ac107251d9d9fd72f0ca8049988f1d7f"
+    },
+    "httr2": {
+      "Package": "httr2",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "cli",
+        "curl",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "openssl",
+        "rappdirs",
+        "rlang",
+        "vctrs",
+        "withr"
+      ],
+      "Hash": "0f14199bbd820a9fca398f2df40994f1"
+    },
+    "jquerylib": {
+      "Package": "jquerylib",
+      "Version": "0.1.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "htmltools"
+      ],
+      "Hash": "5aab57a3bd297eee1c1d862735972182"
+    },
+    "jsonlite": {
+      "Package": "jsonlite",
+      "Version": "1.8.8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "methods"
+      ],
+      "Hash": "e1b9c55281c5adc4dd113652d9e26768"
+    },
+    "later": {
+      "Package": "later",
+      "Version": "1.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Rcpp",
+        "rlang"
+      ],
+      "Hash": "a3e051d405326b8b0012377434c62b37"
+    },
+    "lifecycle": {
+      "Package": "lifecycle",
+      "Version": "1.0.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "rlang"
+      ],
+      "Hash": "b8552d117e1b808b09a832f589b79035"
+    },
+    "magrittr": {
+      "Package": "magrittr",
+      "Version": "2.0.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "7ce2733a9826b3aeb1775d56fd305472"
+    },
+    "memoise": {
+      "Package": "memoise",
+      "Version": "2.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "cachem",
+        "rlang"
+      ],
+      "Hash": "e2817ccf4a065c5d9d7f2cfbe7c1d78c"
+    },
+    "mime": {
+      "Package": "mime",
+      "Version": "0.12",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "tools"
+      ],
+      "Hash": "18e9c28c1d3ca1560ce30658b22ce104"
+    },
+    "openssl": {
+      "Package": "openssl",
+      "Version": "2.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "askpass"
+      ],
+      "Hash": "37a7f0abce0349f5950ce49f38c7626b"
+    },
+    "pillar": {
+      "Package": "pillar",
+      "Version": "1.9.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "cli",
+        "fansi",
+        "glue",
+        "lifecycle",
+        "rlang",
+        "utf8",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "15da5a8412f317beeee6175fbc76f4bb"
+    },
+    "pkgconfig": {
+      "Package": "pkgconfig",
+      "Version": "2.0.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "utils"
+      ],
+      "Hash": "01f28d4278f15c76cddbea05899c5d6f"
+    },
+    "promises": {
+      "Package": "promises",
+      "Version": "1.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R6",
+        "Rcpp",
+        "fastmap",
+        "later",
+        "magrittr",
+        "rlang",
+        "stats"
+      ],
+      "Hash": "434cd5388a3979e74be5c219bcd6e77d"
+    },
+    "purrr": {
+      "Package": "purrr",
+      "Version": "1.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "lifecycle",
+        "magrittr",
+        "rlang",
+        "vctrs"
+      ],
+      "Hash": "1cba04a4e9414bdefc9dcaa99649a8dc"
+    },
+    "rappdirs": {
+      "Package": "rappdirs",
+      "Version": "0.3.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
+    },
+    "renv": {
+      "Package": "renv",
+      "Version": "1.0.7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "utils"
+      ],
+      "Hash": "397b7b2a265bc5a7a06852524dabae20"
+    },
+    "rlang": {
+      "Package": "rlang",
+      "Version": "1.1.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "utils"
+      ],
+      "Hash": "724dcc1490cd7071ee75ca2994a5446e"
+    },
+    "sass": {
+      "Package": "sass",
+      "Version": "0.4.9",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R6",
+        "fs",
+        "htmltools",
+        "rappdirs",
+        "rlang"
+      ],
+      "Hash": "d53dbfddf695303ea4ad66f86e99b95d"
+    },
+    "shiny": {
+      "Package": "shiny",
+      "Version": "1.9.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "bslib",
+        "cachem",
+        "commonmark",
+        "crayon",
+        "fastmap",
+        "fontawesome",
+        "glue",
+        "grDevices",
+        "htmltools",
+        "httpuv",
+        "jsonlite",
+        "later",
+        "lifecycle",
+        "methods",
+        "mime",
+        "promises",
+        "rlang",
+        "sourcetools",
+        "tools",
+        "utils",
+        "withr",
+        "xtable"
+      ],
+      "Hash": "6a293995a66e12c48d13aa1f957d09c7"
+    },
+    "sourcetools": {
+      "Package": "sourcetools",
+      "Version": "0.1.7-1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "5f5a7629f956619d519205ec475fe647"
+    },
+    "sys": {
+      "Package": "sys",
+      "Version": "3.4.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "de342ebfebdbf40477d0758d05426646"
+    },
+    "tibble": {
+      "Package": "tibble",
+      "Version": "3.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "fansi",
+        "lifecycle",
+        "magrittr",
+        "methods",
+        "pillar",
+        "pkgconfig",
+        "rlang",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "a84e2cc86d07289b3b6f5069df7a004c"
+    },
+    "utf8": {
+      "Package": "utf8",
+      "Version": "1.2.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "62b65c52671e6665f803ff02954446e9"
+    },
+    "uuid": {
+      "Package": "uuid",
+      "Version": "1.2-1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "34e965e62a41fcafb1ca60e9b142085b"
+    },
+    "vctrs": {
+      "Package": "vctrs",
+      "Version": "0.6.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "lifecycle",
+        "rlang"
+      ],
+      "Hash": "c03fa420630029418f7e6da3667aac4a"
+    },
+    "withr": {
+      "Package": "withr",
+      "Version": "3.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics"
+      ],
+      "Hash": "cc2d62c76458d425210d1eb1478b30b4"
+    },
+    "xtable": {
+      "Package": "xtable",
+      "Version": "1.8-4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "stats",
+        "utils"
+      ],
+      "Hash": "b8acdf8af494d9ec19ccb2481a9b11c2"
+    }
+  }
+}


### PR DESCRIPTION
This R Shiny extension can be used with any Posit Connect viewer-based OAuth integration to validate a GET request against a given endpoint. 

Error handling around the credentials exchange request ensures that the application does not fail to start on initial deploy, when the user's refresh token expires, etc.

The results are only displayed to the user if the request succeeds; on failure a simple error message is output along with the HTTP response code, and the full error is logged for debugging.

![oauth integration validator extension](https://github.com/user-attachments/assets/f78aa23e-0a40-42ce-9c11-ddd492e854f2)
