### PR TITLE
Create extension PR workflows to create TAR bundles

### DIFF
--- a/.github/workflows/integration-session-manager.yml
+++ b/.github/workflows/integration-session-manager.yml
@@ -1,0 +1,22 @@
+name: Integration Session Manager Extension
+
+on:
+  pull_request:
+    paths:
+      - 'extensions/integration-session-manager/**'
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create tar
+        working-directory: ./extensions
+        run: tar -czf integration-session-manager.tar.gz integration-session-manager
+
+      - name: Upload extension tar
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-session-manager.tar.gz
+          path: extensions/integration-session-manager.tar.gz

--- a/.github/workflows/integration-session-manager.yml
+++ b/.github/workflows/integration-session-manager.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'extensions/integration-session-manager/**'
 
+env:
+  EXTENSION_NAME: integration-session-manager
+
 jobs:
   package:
     runs-on: ubuntu-latest
@@ -13,10 +16,10 @@ jobs:
 
       - name: Create tar
         working-directory: ./extensions
-        run: tar -czf integration-session-manager.tar.gz integration-session-manager
+        run: tar -czf $EXTENSION_NAME.tar.gz $EXTENSION_NAME
 
       - name: Upload extension tar
         uses: actions/upload-artifact@v4
         with:
-          name: integration-session-manager.tar.gz
-          path: extensions/integration-session-manager.tar.gz
+          name: ${{ env.EXTENSION_NAME }}.tar.gz
+          path: extensions/${{ env.EXTENSION_NAME }}.tar.gz

--- a/.github/workflows/reaper.yml
+++ b/.github/workflows/reaper.yml
@@ -1,4 +1,4 @@
-name: Reaper Extension Pull Request
+name: Reaper Extension
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ jobs:
         working-directory: ./extensions
         run: tar -czf reaper.tar.gz reaper
 
-      - name: Upload Reaper extension tar
+      - name: Upload extension tar
         uses: actions/upload-artifact@v4
         with:
           name: reaper.tar.gz

--- a/.github/workflows/reaper.yml
+++ b/.github/workflows/reaper.yml
@@ -12,11 +12,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Create tar
-        working-directory: ./extensions/reaper
-        run: tar -czf reaper.tar.gz .
+        working-directory: ./extensions
+        run: tar -czf reaper.tar.gz reaper
 
       - name: Upload Reaper extension tar
         uses: actions/upload-artifact@v4
         with:
           name: reaper.tar.gz
-          path: extensions/reaper/reaper.tar.gz
+          path: extensions/reaper.tar.gz

--- a/.github/workflows/reaper.yml
+++ b/.github/workflows/reaper.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'extensions/reaper/**'
 
+env:
+  EXTENSION_NAME: reaper
+
 jobs:
   package:
     runs-on: ubuntu-latest
@@ -13,10 +16,10 @@ jobs:
 
       - name: Create tar
         working-directory: ./extensions
-        run: tar -czf reaper.tar.gz reaper
+        run: tar -czf $EXTENSION_NAME.tar.gz $EXTENSION_NAME
 
       - name: Upload extension tar
         uses: actions/upload-artifact@v4
         with:
-          name: reaper.tar.gz
-          path: extensions/reaper.tar.gz
+          name: ${{ env.EXTENSION_NAME }}.tar.gz
+          path: extensions/${{ env.EXTENSION_NAME }}.tar.gz

--- a/.github/workflows/reaper.yml
+++ b/.github/workflows/reaper.yml
@@ -1,0 +1,22 @@
+name: Reaper Extension Pull Request
+
+on:
+  pull_request:
+    paths:
+      - 'extensions/reaper/**'
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create tar
+        working-directory: ./extensions/reaper
+        run: tar -czf reaper.tar.gz .
+
+      - name: Upload Reaper extension tar
+        uses: actions/upload-artifact@v4
+        with:
+          name: reaper.tar.gz
+          path: extensions/reaper/reaper.tar.gz


### PR DESCRIPTION
This PR introduces two new GitHub workflows for the `reaper` and `integration-session-manager` extensions.

The workflows do the same thing, but are independent to each extension. They both only run when Pull Requests contain changes in the folder of the extensions using the [`pull_request.paths` feature](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore).

The jobs in the workflows:
1. Checkout the repository
2. Creates a TAR bundle of the extension folder
3. Uploads the TAR file as an artifact of the workflow

When the workflows run the TAR bundles are accessible as artifacts of the workflow runs, which we can use to:
- open up testing to ensure extension installation on Connect works as expected
- easy installation using the "Add a Connect Extension" feature uploading a bundle

Note that the artifacts are Zip archives. For GitHub Workflows:
> When an Artifact is uploaded, all the files are assembled into an immutable Zip archive. There is currently no way to download artifacts in a format other than a Zip or to download individual artifact contents.

Source: https://github.com/actions/upload-artifact?tab=readme-ov-file#zip-archives

This means we cannot use the "Bundle URL" of a TAR Bundle GitHub Artifact for the "Add a Connect Extension" feature. At least the way they are made available as artifacts for workflows using [`actions/upload-artifact@v4`](https://github.com/actions/upload-artifact).