### PR TITLE
Create example of workflow with a build step

### DIFF
--- a/.github/workflows/publisher-command-center.yml
+++ b/.github/workflows/publisher-command-center.yml
@@ -1,0 +1,57 @@
+name: Publisher Commander Center Extension
+
+on:
+  pull_request:
+    paths:
+      - 'extensions/publisher-command-center/**'
+
+env:
+  EXTENSION_NAME: publisher-command-center
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./extensions/${{ env.EXTENSION_NAME }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+          cache-dependency-path: extensions/${{ env.EXTENSION_NAME }}/package-lock.json
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Upload built extension
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.EXTENSION_NAME }}
+          path: |
+            extensions/${{ env.EXTENSION_NAME }}/dist/
+            extensions/${{ env.EXTENSION_NAME }}/requirements.txt
+            extensions/${{ env.EXTENSION_NAME }}/app.py
+            extensions/${{ env.EXTENSION_NAME }}/manifest.json
+            extensions/${{ env.EXTENSION_NAME }}/connect-extension.toml
+
+  package:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+            name: ${{ env.EXTENSION_NAME}}
+            path: ${{ env.EXTENSION_NAME }}
+
+      - name: Create tar
+        run: tar -czf $EXTENSION_NAME.tar.gz $EXTENSION_NAME
+
+      - name: Upload extension tar
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.EXTENSION_NAME }}.tar.gz
+          path: ${{ env.EXTENSION_NAME }}.tar.gz

--- a/extensions/publisher-command-center/connect-extension.toml
+++ b/extensions/publisher-command-center/connect-extension.toml
@@ -1,0 +1,4 @@
+name = "publisher-command-center"
+title = "Publisher Command Center"
+description = "A dashboard for publishers to help manage and track their content."
+access_type = "acl"

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -49,9 +49,6 @@
 		"dist/index.html": {
 			"checksum": "4be76de8432e10c1b1ec25dc9e965a64"
 		},
-		"index.html": {
-			"checksum": "7433a22d0845c4d09abaaa8643c6c7f1"
-		},
 		"requirements.txt": {
 			"checksum": "a162a98758867a701ce693948ffdfa67"
 		}


### PR DESCRIPTION
This PR introduces a new GitHub Workflow for the Publisher Commander Center extension that illustrates how we can integrate a build job prior to the package job.

This is very similar to the workflows introduced in #20 with a few differences:
- There are now two jobs `build -> package`
- The build job does whatever it needs to do to create the extension code (in this case `npm run build`) and uploads an artifact for the next job to use.
- Rather than TARing up the extension's directory it TARs up the artifact from the build job

The PR also includes some changes to the `publisher-command-center` extension like:
- adding a `connect-extension.toml` which is required to install the extension via the TAR bundle
- removing the `index.html` from the `manifest.json` of the extension since it isn't needed (it uses `dist/index.html`)

### To Test

1. Grab the `publisher-command-center.tar.gz` Artifact from the "Publisher Command Center Extension" workflow.
    - This can be found by clicking "Checks" above and then "Publisher Command Center Extension" on the left. Artifacts are on the bottom of the page.
2. Install the extension using the "Add an Extension" via bundle feature on Dogfood verifying the installation and the content is working.