### PR TITLE
Add `*.lic` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ _site/
 __pycache__/
 *.py[cod]
 *$py.class
+
+# license files should not be commited to this repository
+*.lic


### PR DESCRIPTION
Adding `*.lic` to `.gitignore` so that accidentally committing license files requires additional steps.