### PR TITLE
Lint match extension name and directory

### DIFF
--- a/.github/actions/lint-extension/action.yml
+++ b/.github/actions/lint-extension/action.yml
@@ -11,6 +11,16 @@ runs:
   using: "composite"
 
   steps:
+    - name: Check extension name matches directory
+      run: |
+        MANIFEST_NAME=$(jq -r '.extension.name' < ./extensions/${{ inputs.extension-name }}/manifest.json)
+        if [ ${{ inputs.extension-name }} != $MANIFEST_NAME ]; then
+          echo "Error: Extension name, directory, and manifest.json mismatch"
+          echo "Extension '${{ inputs.extension-name }}' must be in the folder '/extensions/${{ inputs.extension-name }}'" and have the name '${{ inputs.extension-name }}' in the manifest.json.
+          exit 1
+        fi
+      shell: bash
+
     # Ensures that the manifest.json for the given extension name
     # contains all the required fields for the rest of the release workflow
     - run: |

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -24,8 +24,9 @@ jobs:
         id: changes
         with:
           # Adding a new extension that has a directory that can be TARed?
-          # Add a new line here with the name of the extension and directory path
-          # Be sure the extension name and directory have the same name
+          # Add a new line here with the name of the extension as the name of
+          # the filter and the value as the extension's directory path
+          # Be sure the extension name and directory name are the same
           # e.g. `extension-name: extensions/extension-name/**`
           filters: |
             reaper: extensions/reaper/**
@@ -76,8 +77,10 @@ jobs:
       pull-requests: read
     outputs:
       # Adding a new extension with a complex build process?
-      # Add a new line here with the name of the extension step output variable below
+      # Add a new line here with the name of the extension as the name of the
+      # filter and the step output variable below
       # e.g. `extension-name: ${{ steps.changes.outputs.extension-name }}`
+      # Be sure the extension name and directory name it is in are the same
       publisher-command-center: ${{ steps.changes.outputs.publisher-command-center }}
 
     steps:


### PR DESCRIPTION
This PR adds another step to our extension linting action that checks that the extension directory name and the `extension.name` part of the `manifest.json` match.

If they do not the linting step fails avoiding issue further on in the workflow.