### PR TITLE
Add concurrency to update-extension-list

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -100,9 +100,8 @@ jobs:
     if: ${{ needs.complex-extension-changes.outputs.publisher-command-center == 'true' }}
     uses: ./.github/workflows/publisher-command-center.yml
 
-
   # All extensions have been linted, packaged, and released, if necessary
-  # Continuing to update the extension list with the latest release data 
+  # Continuing to update the extension list with the latest release data
 
   # Gathers all release data from GitHub releases triggered by this workflow
   # For use in the `update-extension-list` job
@@ -135,6 +134,9 @@ jobs:
   # job output
   update-extension-list:
     runs-on: ubuntu-latest
+    concurrency:
+      group: update-extension-list
+      cancel-in-progress: false
     needs: [fetch-releases]
     # Only runs if there are releases to update the extension list with
     # https://github.com/actions/runner/issues/2205


### PR DESCRIPTION
This PR adds a concurrency setting to the `update-extension-list` workflow job:

```yaml
  update-extension-list:
    concurrency:
      group: update-extension-list
      cancel-in-progress: false
```

The group is set to `update-extension-list` rather than something like `${{ github.ref }}` to make every run of `update-extension-list` a part of the same group.

The `update-extension-list` job needs the `fetch-releases` job to complete, and for it to contain actual release data which only occurs when running on a `push` (read merge) to `main`. Meaning that a distinction of workflow, branch, or any other concurrency group isn't necessary.

`cancel-in-progress: false` explicitly prevents the concurrency setting from cancelling the currently running job if another `update-extension-list` job is pending. (I believe this is the default, but it is better to be specific here).

The `concurrency` settings further prevent any race conditions when attempting to checkout `main` and make a commit based on the output of the extension list updating script.