### PR TITLE
Setup first release of Reaper and Publisher Command Center

### DIFF
--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -11,6 +11,11 @@
 			"package_file": "requirements.txt"
 		}
 	},
+	"environment": {
+		"python": {
+			"requires": ">=3.8, <4"
+		}
+	},
 	"packages": {},
 	"files": {
 		"app.py": {
@@ -58,6 +63,6 @@
 		"title": "Publisher Command Center",
 		"description": "A dashboard for publishers to help manage and track their content",
 		"homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/publisher-command-center",
-		"version": "0.0.0"
+		"version": "0.0.1"
 	}
 }

--- a/extensions/reaper/manifest.json
+++ b/extensions/reaper/manifest.json
@@ -13,6 +13,11 @@
       "package_file": "requirements.txt"
     }
   },
+  "environment": {
+    "python": {
+      "requires": ">=3.8, <4"
+    }
+  },
   "files": {
     "requirements.txt": {
       "checksum": "969fde50a8798a04a638e60adbae9ba7"
@@ -29,6 +34,6 @@
     "title": "Reaper",
     "description": "A view to a kill.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/reaper",
-    "version": "0.0.0"
+    "version": "0.0.1"
   }
 }


### PR DESCRIPTION
This PR sets up the initial releases of two extensions:
- Reaper
- Publisher Command Center

It also utilizes the new version constraint section of the `manifest.json` to broaden the Python versions the two extensions can be used with.