### PR TITLE
Use ssh-key to bypass PR requirement for extension list updates

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -154,6 +154,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - uses: actions/setup-node@v4
         with:

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -63,6 +63,6 @@
 		"title": "Publisher Command Center",
 		"description": "A dashboard for publishers to help manage and track their content",
 		"homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/publisher-command-center",
-		"version": "0.0.1"
+		"version": "0.0.0"
 	}
 }

--- a/extensions/reaper/manifest.json
+++ b/extensions/reaper/manifest.json
@@ -34,6 +34,6 @@
     "title": "Reaper",
     "description": "A view to a kill.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/reaper",
-    "version": "0.0.1"
+    "version": "0.0.0"
   }
 }


### PR DESCRIPTION
This PR undoes the version bump to the two extensions released in #44 and adds an `ssh-key` to be utilized by the `update-extension-list` action to bypass Pull Request requirements to `main`.

The associated git tags and GitHub releases for the extensions have already been removed to avoid duplication for when we update the extension list with a re-release. 

References:
- https://github.com/orgs/community/discussions/25305
> Anyone with collaborator access to this repository can use these secrets and variables for actions.