### PR TITLE
Release reaper and publisher-command-center

### DIFF
--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -63,6 +63,6 @@
 		"title": "Publisher Command Center",
 		"description": "A dashboard for publishers to help manage and track their content",
 		"homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/publisher-command-center",
-		"version": "0.0.0"
+		"version": "0.0.1"
 	}
 }

--- a/extensions/reaper/manifest.json
+++ b/extensions/reaper/manifest.json
@@ -34,6 +34,6 @@
     "title": "Reaper",
     "description": "A view to a kill.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/reaper",
-    "version": "0.0.0"
+    "version": "0.0.1"
   }
 }


### PR DESCRIPTION
Increases the `version` for both the Reaper and Publisher Command Center extensions to trigger a release.