### PR TITLE
Add Gallery documentation to the contributing guide

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -100,6 +100,8 @@ jobs:
   # workflow
   publisher-command-center:
     needs: [complex-extension-changes]
+    # Only runs if the `complex-extension-changes` job detects changes in the
+    # publisher-command-center extension directory
     if: ${{ needs.complex-extension-changes.outputs.publisher-command-center == 'true' }}
     uses: ./.github/workflows/publisher-command-center.yml
 
@@ -112,6 +114,8 @@ jobs:
   # If no releases were triggered the output for releases will be `[]`
   fetch-releases:
     runs-on: ubuntu-latest
+    # Requires that the `simple-extensions` and all custom workflow jobs are
+    # completed before running this job
     needs: [simple-extensions, publisher-command-center]
     if: ${{ always() }}
     outputs:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # connect-extensions
 
 Home for connect extensions
+
+### Adding Content
+
+See the [contributing guide](https://posit-dev.github.io/connect-extensions/contributing.html)
+to learn how to contribute content, and add it to the Connect Gallery.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -2,6 +2,7 @@ project:
   type: website
   render:
     - "extensions/**/connect-extension.qmd"
+    - docs/*.qmd
     - contributing.qmd
     - extensions.qmd
     - index.qmd

--- a/_template/connect-extension.toml
+++ b/_template/connect-extension.toml
@@ -1,4 +1,0 @@
-name = "<extension-name>"
-title = "<extension-title>"
-description = "<extension-categories>"
-access_type = "logged_in|acl"

--- a/contributing.qmd
+++ b/contributing.qmd
@@ -24,11 +24,11 @@ A file that has the name of your extension, the categories it falls into, and a 
 
 # Connect Gallery
 
-The Connect Gallery displays content that can be easily added to Posit Connect
-servers.
+The Connect Gallery displays apps, dashboards, and reports that can be easily
+added to Posit Connect servers.
 
-This section covers how to ready your content for the gallery, adding it, and
-updating it.
+This section covers how to ready your content for the gallery, add it, and
+release new updates.
 
 ## Additional Requirements
 
@@ -56,7 +56,7 @@ to the `manifest.json`:
 
 It is recommended to begin with `"version": "0.0.0"` to avoid triggering a
 release during development of your content. When you are ready to release to
-the Gallery check the [Adding content to the Connect Gallery](#adding-content-to-the-connect-gallery) section.
+the gallery check the [Adding content to the Connect Gallery](#adding-content-to-the-connect-gallery) section.
 
 ### Language version constraints
 
@@ -250,3 +250,12 @@ And after the pull request is merged:
 
 - Remove all associated releases for the content from the [GitHub Releases page](https://github.com/posit-dev/connect-extensions/releases).
 - Remove all associated tags for the content from the [GitHub Tags page](https://github.com/posit-dev/connect-extensions/tags).
+
+# Removing Content
+
+Removing content from the `extensions/` subdirectory that has already been
+added to the Connect Gallery requires that you follow instructions in the 
+above [Removing an entire piece of content](#removing-an-entire-piece-of-content)
+section.
+
+In addition references to the content in GitHub workflows will need to removed.

--- a/contributing.qmd
+++ b/contributing.qmd
@@ -35,8 +35,8 @@ release new updates.
 ### The `extension` section in `manifest.json`
 
 Content in the gallery requires some additional details in the `manifest.json`
-file to display in the gallery, install on Connect, and automatically
-release using automation in this repository.
+file to display, install on Connect, and automatically release using automation
+in this repository.
 
 Below is an example of the additional details that need to be manually added
 to the `manifest.json`:
@@ -116,6 +116,8 @@ filters: |
   ...
   my-content-name: extensions/my-content-name/**
 ```
+
+A good example is how `reaper` is setup.
 
 This will make any code changes to your content trigger a few things:
 

--- a/contributing.qmd
+++ b/contributing.qmd
@@ -142,24 +142,8 @@ setting up the environment needed to build the content.
 #### Creating a custom workflow
 
 To faciliate control over how the content is being built we utilize custom
-GitHub Workflows, for example the [Publisher Command Center workflow](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/publisher-command-center.yml).
-
-A few steps will be common across custom workflows using
-[composite GitHub Actions](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action)
-in this repository.
-
-1. Start with checking out the repository so actions can run with no issues
-   using `actions/checkout`
-2. Lint the extension with `./.github/actions/lint-extension`
-3. Upload the built extension using `actions/upload-artifact` specifying the
-   path of all the required files.
-4. Package the extension using `./.github/actions/package-extension`
-5. Release the extension using `./.github/actions/release-extension`
-    - Automatically handles releasing when merged to `main` and does a
-      dry run when run on a pull request.
-
-The custom steps will entirely depend on the individual content and what
-environment it needs to setup, and what it needs to run.
+GitHub Workflows. See the [Creating a custom workflow](docs/creating-a-custom-workflow.qmd)
+guide how to get started.
 
 #### Calling the custom workflow
 
@@ -167,12 +151,8 @@ Once the custom workflow is created we need to head back to the general
 [.github/workflows/extensions.yml](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/extensions.yml)
 file.
 
-We can see how `publisher-command-center` is setup as an example.
-
-1. Add your content as an [output to the `complex-extension-changes` job](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/extensions.yml#L78)
-2. Add a [filter for your content](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/extensions.yml#L96) to trigger your workflow only when your content changes
-3. [Call your custom workflow as a job similar to `publisher-command-center`](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/extensions.yml#L101)
-4. Finally, make sure the [`fetch-releases` job needs your workflow to complete prior to running](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/extensions.yml#L115).
+It is recommended to see how `publisher-command-center` is setup as an example
+for how to use your new custom workflow.
 
 Once your custom workflow is setup, set the `version` in the `manifest.json`
 file to your initial release.

--- a/contributing.qmd
+++ b/contributing.qmd
@@ -22,10 +22,251 @@ A file that has the name of your extension, the categories it falls into, and a 
 {{< include _template/connect-extension.qmd >}}
 ```
 
-### `connect-extension.toml`
+# Connect Gallery
 
-A file with the name, title, a brief description of the extension, and the access type it should have on being created
+The Connect Gallery displays content that can be easily added to Posit Connect
+servers.
 
-```{filename="connect-extension.toml"}
-{{< include _template/connect-extension.toml >}}
+This section covers how to ready your content for the gallery, adding it, and
+updating it.
+
+## Additional Requirements
+
+### The `extension` section in `manifest.json`
+
+Content in the gallery requires some additional details in the `manifest.json`
+file to display in the gallery, install on Connect, and automatically
+release using automation in this repository.
+
+Below is an example of the additional details that need to be manually added
+to the `manifest.json`:
+
+```json {filename="manifest.json"} 
+{
+  ...
+  "extension": {
+    "name": "my-content-name",
+    "title": "My Content Name",
+    "description": "A lovely, detailed description of the content.",
+    "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/my-content-name",
+    "version": "0.0.0"
+  }
+}
 ```
+
+It is recommended to begin with `"version": "0.0.0"` to avoid triggering a
+release during development of your content. When you are ready to release to
+the Gallery check the [Adding content to the Connect Gallery](#adding-content-to-the-connect-gallery) section.
+
+### Language version constraints
+
+To ensure that content in the gallery is installable on as many Posit Connect
+servers as possible we use the language version constraints feature to broaden
+the language versions Connect can use for a piece of content.
+
+All content in the gallery should include `requires` specifications for the
+language(s) it utilizes.
+
+Here is an example of what needs to be included in a `manifest.json`:
+
+```json {filename="manifest.json"}
+{
+  ...
+  "environment": {
+    "python": {
+      "requires": ">=3.8, <4"
+    },
+    "r": {
+      "requires": ">=4.2, <5"
+    }
+  },
+  ...
+}
+```
+
+## Adding content to the Connect Gallery
+
+Once your content has the requirements above it is ready to be added to the
+Connect Gallery.
+
+The Connect Gallery uses GitHub Workflows to automate releases of new content
+when pull requests in this repo merge into `main`.
+
+To add content to the Connect Gallery, follow the steps below:
+
+### Adding simple content
+
+"Simple content" refers to content that can be bundled into a TAR file without
+any additional steps. Most content will fall into this category.
+
+::: {.callout-note}
+If you can run
+```bash
+tar -czf my-extension-name.tar.gz ./extensions/my-extension-name
+```
+and the resulting TAR file can be published by uploading the bundle to Posit
+Connect, then it is piece of simple content.
+:::
+
+To add simple content look for the [`simple-extension-changes` section in the `.github/workflows/extensions.yml`](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/extensions.yml#L31)
+file and add a new filter:
+
+```yml
+filters: |
+  ...
+  my-content-name: extensions/my-content-name/**
+```
+
+This will make any code changes to your content trigger a few things:
+
+- lint: ensuring your content has everything it needs to be added to the
+  gallery
+- package: creating a TAR file of the content's directory to test in pull
+  requests and to be released
+- release: When the `version` in the `manifest.json` is incrased and merged to
+  `main`, releases the content to users of Posit Connect
+
+Lastly set the `version` in the `manifest.json` file to your initial release.
+
+When the changes above are merged the first release will be kicked off, and
+your content will be in the gallery. 🚀
+
+### Adding custom built content
+
+"Custom built content" refers to content that requires additional steps prior to
+be being packaged into a TAR file.
+
+Setting up custom built content is a bit more complex since it involves
+setting up the environment needed to build the content.
+
+#### Creating a custom workflow
+
+To faciliate control over how the content is being built we utilize custom
+GitHub Workflows, for example the [Publisher Command Center workflow](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/publisher-command-center.yml).
+
+A few steps will be common across custom workflows using
+[composite GitHub Actions](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action)
+in this repository.
+
+1. Start with checking out the repository so actions can run with no issues
+   using `actions/checkout`
+2. Lint the extension with `./.github/actions/lint-extension`
+3. Upload the built extension using `actions/upload-artifact` specifying the
+   path of all the required files.
+4. Package the extension using `./.github/actions/package-extension`
+5. Release the extension using `./.github/actions/release-extension`
+    - Automatically handles releasing when merged to `main` and does a
+      dry run when run on a pull request.
+
+The custom steps will entirely depend on the individual content and what
+environment it needs to setup, and what it needs to run.
+
+#### Calling the custom workflow
+
+Once the custom workflow is created we need to head back to the general
+[.github/workflows/extensions.yml](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/extensions.yml)
+file.
+
+We can see how `publisher-command-center` is setup as an example.
+
+1. Add your content as an [output to the `complex-extension-changes` job](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/extensions.yml#L78)
+2. Add a [filter for your content](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/extensions.yml#L96) to trigger your workflow only when your content changes
+3. [Call your custom workflow as a job similar to `publisher-command-center`](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/extensions.yml#L101)
+4. Finally, make sure the [`fetch-releases` job needs your workflow to complete prior to running](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/extensions.yml#L115).
+
+Once your custom workflow is setup, set the `version` in the `manifest.json`
+file to your initial release.
+
+When the changes above are merged the first release will be kicked off, and
+your content will be in the gallery. 🚀
+
+## Updating content in the Connect Gallery
+
+To update already released content in the Connect Gallery simply increment the
+`version` field in the `extension` section of the `manifest.json` file and open
+a pull request with the changes.
+
+```json {filename="manifest.json"}
+{
+  ...
+  "extension": {
+    ...
+    "version": "1.1.0"
+  }
+}
+```
+
+When that pull request is merged, GitHub Workflows will automatically create a
+new GitHub Release for the content changed, update the content list, and update
+Connect Gallery.
+
+### Checking if your extension will release
+
+If you would like to check if merging a pull request will trigger a new release
+you can do that by looking at the logs for the GitHub Actions.
+
+Click on the "Checks" tab for a Pull Request and look at the Extension Workflow
+run.
+
+Click on the Job related to the content being updated and view the logs for the
+`/./.github/actions/release-extension` action.
+
+It will either say:
+
+> The manifest version is '1.1.0' and the released version is '1.0.0'
+>
+> 🚀 Will release! The manifest version is greater than the released version.
+
+or:
+
+> The manifest version is '1.0.0' and the released version is '1.0.0'
+>
+>😴 Holding back from release: The manifest version is not greater than the released version.
+
+## Manually testing content
+
+Packaged TAR files are included as artifacts in the Extension Workflow runs.
+
+Click on the "Checks" tab for a Pull Request and look at the Extension Workflow
+run. At the bottom, "Artifacts" are available, and if your content changed
+in the Pull Request then a `my-extension-name.tar.gz` file will be available.
+
+It can be downloaded, and tested using the publish via bundle feature in Posit
+Connect.
+
+## Removing a release from the Connect Gallery
+
+If released content needs to be reverted, or content removed entirely, follow
+the steps below:
+
+### Removing a single release
+
+Open a pull request to remove the release: 
+
+1. Remove the release from the content list in `extension.json`
+    - If the removed release is the latest release, update the `latestVersion`
+      field for that piece of content to the previous release
+    - Versions are sorted in descending order, so the latest release should be
+      the first element in the `versions` array
+2. Revert the content's `version` in the `manifest.json` file to the previous
+   release
+    
+Once the pull request is merged continue with the steps below:
+
+1. Remove the associated release from the [GitHub Releases page](https://github.com/posit-dev/connect-extensions/releases).
+2. Remove the associated tag from the [GitHub Tags page](https://github.com/posit-dev/connect-extensions/tags).
+
+### Removing an entire piece of content
+
+Removing an entire piece of content from the gallery is similar to removing a single release, but
+with a few additional notes:
+
+- Instead of removing a single list from the content list in `extension.json`
+  remove the entire content object.
+- Instead of reverting the `version` in the `manifest.json` file to the previous
+  release, instead set the version to `0.0.0` to avoid a release.
+
+And after the pull request is merged:
+
+- Remove all associated releases for the content from the [GitHub Releases page](https://github.com/posit-dev/connect-extensions/releases).
+- Remove all associated tags for the content from the [GitHub Tags page](https://github.com/posit-dev/connect-extensions/tags).

--- a/docs/creating-a-custom-workflow.qmd
+++ b/docs/creating-a-custom-workflow.qmd
@@ -1,0 +1,83 @@
+---
+title: Creating a custom workflow
+---
+
+Most custom workflows will have common steps. They utilize handy
+[composite GitHub Actions](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action)
+in the repository.
+
+A good place to start is looking at examples of custom workflows already in the
+repository like the [Publisher Command Center workflow](https://github.com/posit-dev/connect-extensions/blob/main/.github/workflows/publisher-command-center.yml).
+
+## Custom Workflow Template
+
+Use the template below to get started. It contains inline comments to explain
+each section.
+
+Replace the `EXTENSION_NAME` variable with your content's name, and add the
+custom build steps needed for your content. The custom steps will entirely
+depend on your content and what environment it needs to setup.
+
+```yaml {filename=".github/workflows/my-custom-content.yml"}
+name: My Custom Content
+
+# Re-usable workflows use the `workflow_call` trigger
+# https://docs.github.com/en/actions/sharing-automations/reusing-workflows#creating-a-reusable-workflow
+on:
+  workflow_call:
+
+# Setup the environment with the extension name for easy re-use
+# Also set the GH_TOKEN for the release-extension action to be able to use gh
+env:
+  EXTENSION_NAME: my-content-name
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  extension:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./extensions/${{ env.EXTENSION_NAME }}
+
+    steps:
+      # Checkout the repository so the rest of the actions can run with no issue
+      - uses: actions/checkout@v4
+
+      # We want to fail quickly if the linting fails, do that first
+      - uses: ./.github/actions/lint-extension
+        with:
+          extension-name: ${{ env.EXTENSION_NAME }}
+
+      # ---
+      # Add Custom Build Steps Here
+      # ---
+
+      # Now that the extension is built we need to upload an artifact to pass
+      # to the package-extension action that contains the files we want to be
+      # included in the extension
+      # This only includes necessary files for the extension to run leaving out
+      # the files that were used to build the /dist/ directory
+      - name: Upload built extension
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.EXTENSION_NAME }}
+          # Replace the below with the files your content needs
+          path: |
+            extensions/${{ env.EXTENSION_NAME }}/dist/
+            extensions/${{ env.EXTENSION_NAME }}/requirements.txt
+            extensions/${{ env.EXTENSION_NAME }}/app.py
+            extensions/${{ env.EXTENSION_NAME }}/manifest.json
+
+      # Package up the extension into a TAR using the package-extension action
+      - uses: ./.github/actions/package-extension
+        with:
+          extension-name: ${{ env.EXTENSION_NAME }}
+          artifact-name: ${{ env.EXTENSION_NAME }}
+
+      # Release the extension using the release-extension action
+      # Will only create a GitHub release if merged to `main` and the semver
+      # version has been updated
+      - uses: ./.github/actions/release-extension
+        with:
+          extension-name: ${{ env.EXTENSION_NAME }}
+```


### PR DESCRIPTION
This PR introduces documentation into the Contributing guide that covers:
- What is needed for content being added to the gallery
- How to add content to the gallery
- How to update content in the gallery
- How to revert an update to content, or remove the content entirely
- Tips for manually testing Pull Requests, and seeing if a PR will trigger a content release

This PR also removes the `connect-extension.toml` template file since it is no longer necessary, and includes a link to the Contributing doc in the README.