### PR TITLE
Document integration test job in contributing

### DIFF
--- a/contributing.qmd
+++ b/contributing.qmd
@@ -136,7 +136,8 @@ This will make any code changes to your content trigger a few things:
   gallery
 - package: creating a TAR file of the content's directory to test in pull
   requests and to be released
-- release: When the `version` in the `manifest.json` is incrased and merged to
+- test: checking that the content will publish to Connect
+- release: When the `version` in the `manifest.json` is increased and merged to
   `main`, releases the content to users of Posit Connect
 
 Lastly set the `version` in the `manifest.json` file to your initial release.

--- a/docs/creating-a-custom-workflow.qmd
+++ b/docs/creating-a-custom-workflow.qmd
@@ -74,9 +74,23 @@ jobs:
           extension-name: ${{ env.EXTENSION_NAME }}
           artifact-name: ${{ env.EXTENSION_NAME }}
 
-      # Release the extension using the release-extension action
-      # Will only create a GitHub release if merged to `main` and the semver
-      # version has been updated
+  connect-integration-tests:
+    needs: extension
+    uses: ./.github/workflows/connect-integration-tests.yml
+    secrets: inherit
+    with:
+      extensions: '["publisher-command-center"]'  # JSON array format to match the workflow input schema
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [extension, connect-integration-tests]
+    # Release the extension using the release-extension action
+    # Will only create a GitHub release if merged to `main` and the semver
+    # version has been updated
+    steps:
+      # Checkout the repository so the rest of the actions can run with no issue
+      - uses: actions/checkout@v4
+
       - uses: ./.github/actions/release-extension
         with:
           extension-name: ${{ env.EXTENSION_NAME }}


### PR DESCRIPTION
Follow-up to #53 adding information to the contributing document about the integration tests. Mainly this includes adding the changes to custom workflows to the template.