### PR TITLE
Set retention days for data-passing artifacts to 1

### DIFF
--- a/.github/actions/release-extension/action.yml
+++ b/.github/actions/release-extension/action.yml
@@ -92,3 +92,4 @@ runs:
       with:
         name: release-${{ inputs.extension-name }}.json
         path: release-${{ inputs.extension-name }}.json
+        retention-days: 1

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           name: ${{ matrix.extension }}.packaged.successfully
           path: ${{ matrix.extension }}.packaged.successfully
+          retention-days: 1
 
   # Collect success results from the matrix simple-extensions jobs for later use
   collect-simple-extensions:


### PR DESCRIPTION
This PR cleans up our `retention-days` on two types of artifacts we create during our workflows. Both are only used for data-passing between matrix jobs and only need to be around until the workflows finish.

This PR sets the `retention-days` to `1` (the minimum) 

References:
- https://github.com/actions/upload-artifact?tab=readme-ov-file#retention-period