### PR TITLE
Improve workflow readability with better names, and add release summaries

### DIFF
--- a/.github/actions/release-extension/action.yml
+++ b/.github/actions/release-extension/action.yml
@@ -42,13 +42,21 @@ runs:
       id: should_release
       run: |
         echo "The manifest version is '$MANIFEST_VERSION' and the released version is '$LATEST_VERSION'"
-        HIGHER_VERSION=$(semver "$MANIFEST_VERSION" "$LATEST_VERSION" | tail -n 1)
-          if [ "$MANIFEST_VERSION" = "$HIGHER_VERSION" ] && [ "$MANIFEST_VERSION" != "$LATEST_VERSION" ]; then
-          echo "🚀 Will release! The manifest version is greater than the released version."
-          echo "should_release=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "😴 Holding back from release: The manifest version is not greater than the released version."
+        
+        # Special case: Never release version 0.0.0
+        if [ "$MANIFEST_VERSION" = "0.0.0" ]; then
+          echo "⚠️ Version 0.0.0 is reserved and will never be released."
           echo "should_release=false" >> "$GITHUB_OUTPUT"
+        else
+          # Normal version comparison logic
+          HIGHER_VERSION=$(semver "$MANIFEST_VERSION" "$LATEST_VERSION" | tail -n 1)
+          if [ "$MANIFEST_VERSION" = "$HIGHER_VERSION" ] && [ "$MANIFEST_VERSION" != "$LATEST_VERSION" ]; then
+            echo "🚀 Will release! The manifest version is greater than the released version."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "😴 Holding back from release: The manifest version is not greater than the released version."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
         fi
       shell: bash
 

--- a/.github/actions/release-extension/action.yml
+++ b/.github/actions/release-extension/action.yml
@@ -45,11 +45,6 @@ runs:
         echo "# Extension: ${{ inputs.extension-name }}" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        VERSION_INFO="The manifest version is '$MANIFEST_VERSION' and the released version is '$LATEST_VERSION'"
-        echo "$VERSION_INFO"
-        echo "$VERSION_INFO" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        
         if [ "$MANIFEST_VERSION" = "0.0.0" ]; then
           MESSAGE="⚠️ Version 0.0.0 is reserved and will never be released."
           echo "$MESSAGE"
@@ -57,6 +52,11 @@ runs:
           echo "should_release=false" >> "$GITHUB_OUTPUT"
         else
           # Normal version comparison logic
+          VERSION_INFO="The manifest version is '$MANIFEST_VERSION' and the released version is '$LATEST_VERSION'"
+          echo "$VERSION_INFO"
+          echo "$VERSION_INFO" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
           HIGHER_VERSION=$(semver "$MANIFEST_VERSION" "$LATEST_VERSION" | tail -n 1)
           if [ "$MANIFEST_VERSION" = "$HIGHER_VERSION" ] && [ "$MANIFEST_VERSION" != "$LATEST_VERSION" ]; then
             MESSAGE="🚀 Will release! The manifest version is greater than the released version."

--- a/.github/actions/release-extension/action.yml
+++ b/.github/actions/release-extension/action.yml
@@ -41,20 +41,32 @@ runs:
     - name: Check if manifest has newer version
       id: should_release
       run: |
-        echo "The manifest version is '$MANIFEST_VERSION' and the released version is '$LATEST_VERSION'"
+        # Add the extension name to the summary header for clarity
+        echo "# Extension: ${{ inputs.extension-name }}" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
         
-        # Special case: Never release version 0.0.0
+        VERSION_INFO="The manifest version is '$MANIFEST_VERSION' and the released version is '$LATEST_VERSION'"
+        echo "$VERSION_INFO"
+        echo "$VERSION_INFO" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
         if [ "$MANIFEST_VERSION" = "0.0.0" ]; then
-          echo "⚠️ Version 0.0.0 is reserved and will never be released."
+          MESSAGE="⚠️ Version 0.0.0 is reserved and will never be released."
+          echo "$MESSAGE"
+          echo "$MESSAGE" >> $GITHUB_STEP_SUMMARY
           echo "should_release=false" >> "$GITHUB_OUTPUT"
         else
           # Normal version comparison logic
           HIGHER_VERSION=$(semver "$MANIFEST_VERSION" "$LATEST_VERSION" | tail -n 1)
           if [ "$MANIFEST_VERSION" = "$HIGHER_VERSION" ] && [ "$MANIFEST_VERSION" != "$LATEST_VERSION" ]; then
-            echo "🚀 Will release! The manifest version is greater than the released version."
+            MESSAGE="🚀 Will release! The manifest version is greater than the released version."
+            echo "$MESSAGE"
+            echo "$MESSAGE" >> $GITHUB_STEP_SUMMARY
             echo "should_release=true" >> "$GITHUB_OUTPUT"
           else
-            echo "😴 Holding back from release: The manifest version is not greater than the released version."
+            MESSAGE="😴 Holding back from release: The manifest version is not greater than the released version."
+            echo "$MESSAGE"
+            echo "$MESSAGE" >> $GITHUB_STEP_SUMMARY
             echo "should_release=false" >> "$GITHUB_OUTPUT"
           fi
         fi

--- a/.github/workflows/connect-integration-tests.yml
+++ b/.github/workflows/connect-integration-tests.yml
@@ -66,39 +66,6 @@ jobs:
           path: integration/reports/*.xml
           retention-days: 7
 
-  # Analyses the test result files and publishes the results on the GitHub Actions job summary page
-  test-report:
-    needs: test
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    # Create a matrix so each extension gets its own test report
-    strategy:
-      fail-fast: false
-      matrix:
-        extension: ${{ fromJson(inputs.extensions) }}
-    permissions:
-      checks: write
-      pull-requests: write
-    # Only run if tests weren't skipped or cancelled
-    if: |
-      always() && 
-      !contains(needs.test.result, 'skipped') &&
-      !contains(needs.test.result, 'cancelled')
-    steps:
-      - uses: actions/download-artifact@v4
-        id: download
-        with:
-          path: artifacts
-          pattern: "${{ matrix.extension }}-*-test-report"
-
-      - uses: EnricoMi/publish-unit-test-result-action@v2
-        if: ${{ steps.download.outputs.download-path != '' }}
-        with:
-          check_name: "Integration test results - ${{ matrix.extension }}"
-          comment_mode: off
-          files: "artifacts/**/*.xml"
-          report_individual_runs: true
-
   # Using the XML test reports provide a matrix of extensions that passed all of the Connect integration tests
   collect-results:
     needs: [test, setup-test]

--- a/.github/workflows/connect-integration-tests.yml
+++ b/.github/workflows/connect-integration-tests.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   # Determine the Connect versions to test against
-  setup-integration-test:
+  setup-test:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -35,16 +35,16 @@ jobs:
           echo "versions=$versions" >> "$GITHUB_OUTPUT"
 
   # Run the Connect integration tests for each extension against each Connect version
-  connect-integration-test:
+  test:
     runs-on: ubuntu-latest
     timeout-minutes: 15 # Max time to run the integration tests
-    needs: setup-integration-test
+    needs: setup-test
     strategy:
       # Do not fail fast so all extensions and Connect versions are processed
       fail-fast: false
       matrix:
         extension: ${{ fromJson(inputs.extensions) }}
-        connect_version: ${{ fromJson(needs.setup-integration-test.outputs.versions) }}
+        connect_version: ${{ fromJson(needs.setup-test.outputs.versions) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -55,6 +55,7 @@ jobs:
           connect-version: ${{ matrix.connect_version }}
           connect-license: ${{ secrets.CONNECT_LICENSE }}
 
+      # Upload the test report XML files as artifacts for use by downstream jobs
       - uses: actions/upload-artifact@v4
         if: |
           always() && 
@@ -66,8 +67,8 @@ jobs:
           retention-days: 7
 
   # Analyses the test result files and publishes the results on the GitHub Actions job summary page
-  integration-test-report:
-    needs: connect-integration-test
+  test-report:
+    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Create a matrix so each extension gets its own test report
@@ -81,8 +82,8 @@ jobs:
     # Only run if tests weren't skipped or cancelled
     if: |
       always() && 
-      !contains(needs.connect-integration-test.result, 'skipped') &&
-      !contains(needs.connect-integration-test.result, 'cancelled')
+      !contains(needs.test.result, 'skipped') &&
+      !contains(needs.test.result, 'cancelled')
     steps:
       - uses: actions/download-artifact@v4
         id: download
@@ -100,7 +101,7 @@ jobs:
 
   # Using the XML test reports provide a matrix of extensions that passed all of the Connect integration tests
   collect-results:
-    needs: [connect-integration-test, setup-integration-test]
+    needs: [test, setup-test]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -116,7 +117,7 @@ jobs:
       - id: collect
         run: |
           # Validate inputs first
-          all_versions='${{ needs.setup-integration-test.outputs.versions }}'
+          all_versions='${{ needs.setup-test.outputs.versions }}'
           extensions='${{ inputs.extensions }}'
 
           if [[ -z "$all_versions" || -z "$extensions" ]]; then

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -120,7 +120,13 @@ jobs:
   simple-extension-release:
     runs-on: ubuntu-latest
     needs: [simple-extension-connect-integration-tests]
-    if: always()
+    # Only run if connect integration tests actually ran and produced valid output
+    if: ${{ 
+      always() && 
+      needs.simple-extension-connect-integration-tests.result != 'skipped' && 
+      needs.simple-extension-connect-integration-tests.result != 'canceled' &&
+      needs.simple-extension-connect-integration-tests.outputs.successful_extensions != '[]'
+      }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:

--- a/contributing.qmd
+++ b/contributing.qmd
@@ -196,25 +196,29 @@ Connect Gallery.
 ### Checking if your extension will release
 
 If you would like to check if merging a pull request will trigger a new release
-you can do that by looking at the logs for the GitHub Actions.
-
-Click on the "Checks" tab for a Pull Request and look at the Extension Workflow
-run.
-
-Click on the Job related to the content being updated and view the logs for the
-`/./.github/actions/release-extension` action.
+you can do that by looking in the GitHub Actions summary. Click on the "Checks" 
+tab for a Pull Request and then click on the Extension Workflow run and the 
+summary will be displayed below the workflow graph.
 
 It will either say:
 
-> The manifest version is '1.1.0' and the released version is '1.0.0'
->
-> 🚀 Will release! The manifest version is greater than the released version.
+::: {.border}
+The manifest version is '1.1.0' and the released version is '1.0.0'  
+🚀 Will release! The manifest version is greater than the released version.
+:::
 
 or:
 
-> The manifest version is '1.0.0' and the released version is '1.0.0'
->
->😴 Holding back from release: The manifest version is not greater than the released version.
+::: {.border}
+The manifest version is '1.0.0' and the released version is '1.0.0'  
+😴 Holding back from release: The manifest version is not greater than the released version.
+:::
+
+or:
+
+::: {.border}
+⚠️ Version 0.0.0 is reserved and will never be released.
+:::
 
 ## Manually testing content
 

--- a/extensions/integration-session-manager/app.py
+++ b/extensions/integration-session-manager/app.py
@@ -1,3 +1,4 @@
+# CHANGED TO FORCE CI
 from posit.connect.client import Client
 from shiny import App, reactive, render, ui
 import pandas as pd

--- a/extensions/integration-session-manager/app.py
+++ b/extensions/integration-session-manager/app.py
@@ -1,4 +1,3 @@
-# CHANGED TO FORCE CI
 from posit.connect.client import Client
 from shiny import App, reactive, render, ui
 import pandas as pd


### PR DESCRIPTION
Fixes: https://github.com/posit-dev/connect/issues/30990


- Rename integration test job names so they are shorter and more readable in the GitHub action sidebar
- Remove integration test GitHub summary as it was not useful
- Improve release job logging when handling 0.0.0
- Add release GitHub summary so we don't have to dive into logs


