### PR TITLE
Add tool.uv to pyproject.toml to silence workflow warnings

### DIFF
--- a/extensions/integration-session-manager/app.py
+++ b/extensions/integration-session-manager/app.py
@@ -1,3 +1,4 @@
+# CHANGE TO FORCE CI
 from posit.connect.client import Client
 from shiny import App, reactive, render, ui
 import pandas as pd

--- a/extensions/integration-session-manager/app.py
+++ b/extensions/integration-session-manager/app.py
@@ -1,4 +1,3 @@
-# CHANGE TO FORCE CI
 from posit.connect.client import Client
 from shiny import App, reactive, render, ui
 import pandas as pd

--- a/integration/pyproject.toml
+++ b/integration/pyproject.toml
@@ -17,3 +17,6 @@ packages = ["tests"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.uv]
+# Configuration for uv without pinning to a specific version to silence warnings in our GitHub workflows

--- a/integration/pyproject.toml
+++ b/integration/pyproject.toml
@@ -19,4 +19,4 @@ packages = ["tests"]
 testpaths = ["tests"]
 
 [tool.uv]
-# Configuration for uv without pinning to a specific version to silence warnings in our GitHub workflows
+required-version = "0.6.14"


### PR DESCRIPTION
By pinning to the current release of `uv` this fixes warnings (not failures) `Could not find required-version under [tool.uv] in ./integration/pyproject.toml. Falling back to latest` in our workflow summary.

Fixed as seen in this run: https://github.com/posit-dev/connect-extensions/actions/runs/14412844483

<img width="1504" alt="image" src="https://github.com/user-attachments/assets/f5d1276d-b9d3-436e-8cda-5de075b02bd7" />
