### PR TITLE
Add more exclusions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,17 @@
-/.quarto/
-_site/
+# RStudio
 .Rproj.user
+**/renv/
 
+# Quarto
+.quarto/
+_site/
+index.quarto_ipynb
+**/libs/
+README.html
+extensions/*/connect-extension_files
+
+# Mac
+.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
Exclude the following:

- renv
- Files generated by quarto preview
- Mac store files