### PR TITLE
add quarto-document jump start example to gallery

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -32,6 +32,7 @@ jobs:
             reaper: extensions/reaper/**
             integration-session-manager: extensions/integration-session-manager/**
             portfolio-dashboard: extensions/portfolio-dashboard/**
+            quarto-document: extensions/quarto-document/**
 
   # Runs for each extension that has changed from `simple-extension-changes`
   # Lints and packages in preparation for tests and and release.
@@ -107,7 +108,7 @@ jobs:
             '$arr | split(",")' -c)
           echo "Successful extensions: $SUCCESSFUL_EXTENSIONS"
           echo "successful_extensions=$SUCCESSFUL_EXTENSIONS" >> "$GITHUB_OUTPUT"
-  
+
 
   # Runs Connect integration tests for each extension that were successfully linted and packaged
   simple-extension-connect-integration-tests:
@@ -123,9 +124,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [simple-extension-connect-integration-tests]
     # Only run if connect integration tests actually ran and produced valid output
-    if: ${{ 
-      always() && 
-      needs.simple-extension-connect-integration-tests.result != 'skipped' && 
+    if: ${{
+      always() &&
+      needs.simple-extension-connect-integration-tests.result != 'skipped' &&
       needs.simple-extension-connect-integration-tests.result != 'canceled' &&
       needs.simple-extension-connect-integration-tests.outputs.successful_extensions != '[]'
       }}

--- a/extensions/quarto-document/README.md
+++ b/extensions/quarto-document/README.md
@@ -1,0 +1,10 @@
+# Quarto Document
+
+## About this example
+
+This Quarto example shows how a basic document can present diagrams and
+interactivity.
+
+## Learn more
+
+* [Quarto](https://quarto.org)

--- a/extensions/quarto-document/_quarto.yml
+++ b/extensions/quarto-document/_quarto.yml
@@ -1,0 +1,2 @@
+project:
+  title: Quarto Document

--- a/extensions/quarto-document/connect-extension.qmd
+++ b/extensions/quarto-document/connect-extension.qmd
@@ -1,0 +1,8 @@
+---
+title: Quarto Document
+categories:
+    - quarto
+---
+
+This Quarto example shows how a basic document can present diagrams and
+interactivity.

--- a/extensions/quarto-document/index.qmd
+++ b/extensions/quarto-document/index.qmd
@@ -1,0 +1,102 @@
+---
+title: Quarto Document
+format:
+  html:
+    echo: false
+---
+
+Quarto enables you to weave together content and executable code into a
+finished document. To learn more about Quarto see <https://quarto.org>.
+
+## Workflow diagram
+
+This diagram depicts a simple workflow showing the
+[tidying](https://vita.had.co.nz/papers/tidy-data.html) and analysis of a data
+set with written findings reviewed by your peers.
+
+```{mermaid}
+stateDiagram-v2
+  direction LR
+
+  [*] --> tidy
+  tidy --> analyze
+  analyze --> tidy
+  analyze --> write
+  write --> review
+  review --> write: feedback
+  review --> accepted
+  accepted --> [*]
+```
+
+Your personal workflow may be more complicated than this example, but
+thankfully, Quarto lets you include
+[diagrams](https://quarto.org/docs/authoring/diagrams.html) to help you
+communicate how you work!
+
+## Penguins
+
+Quarto documents can incorporate interactive data exploration and analysis.
+One way of including these dynamic capabilities is by using [Observable
+JS](https://quarto.org/docs/interactive/ojs/) (OJS).
+
+This is a simple example based on Allison Horst's [Palmer
+Penguins](https://allisonhorst.github.io/palmerpenguins/) dataset. Here we
+look at how penguin body mass varies across both sex and species (use the
+provided inputs to filter the dataset by bill length and island):
+
+```{ojs}
+// https://observablehq.com/@observablehq/sample-datasets
+// https://allisonhorst.github.io/palmerpenguins/
+filtered = penguins.filter(function(penguin) {
+  return bill_length_min < penguin.culmen_length_mm &&
+         islands.includes(penguin.island);
+})
+```
+
+```{ojs}
+//| panel: input
+
+viewof bill_length_min = Inputs.range(
+  [32, 50], 
+  {value: 35, step: 1, label: "Bill length (min):"}
+)
+viewof islands = Inputs.checkbox(
+  ["Torgersen", "Biscoe", "Dream"], 
+  { value: ["Torgersen", "Biscoe"], 
+    label: "Islands:"
+  }
+)
+```
+
+::: {.panel-tabset}
+
+
+## Plot
+
+```{ojs}
+Plot.rectY(filtered, 
+  Plot.binX(
+    {y: "count"}, 
+    {x: "body_mass_g", fill: "species", thresholds: 20}
+  ))
+  .plot({
+    facet: {
+      data: filtered,
+      x: "sex",
+      y: "species",
+      marginRight: 80
+    },
+    marks: [
+      Plot.frame(),
+    ]
+  }
+)
+```
+
+## Data
+
+```{ojs}
+Inputs.table(filtered)
+```
+
+:::

--- a/extensions/quarto-document/manifest.json
+++ b/extensions/quarto-document/manifest.json
@@ -20,9 +20,6 @@
     },
     "index.qmd": {
       "checksum": "52f82c15783f37b2de073e22e1b5a648"
-    },
-    "thumbnail.jpg": {
-      "checksum": "3691931bc6c8ff0b84317140edbd4b8b"
     }
   },
   "users": null,

--- a/extensions/quarto-document/manifest.json
+++ b/extensions/quarto-document/manifest.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "locale": "en_US",
+  "platform": "4.4.1",
+  "metadata": {
+    "appmode": "quarto-static",
+    "primary_rmd": "index.qmd",
+    "primary_html": null,
+    "content_category": null,
+    "has_parameters": false
+  },
+  "quarto": {
+    "version": "1.7.13",
+    "engines": ["markdown"]
+  },
+  "packages": null,
+  "files": {
+    "_quarto.yml": {
+      "checksum": "e498dcc5956dba39a6df10ac9568fcb9"
+    },
+    "index.qmd": {
+      "checksum": "52f82c15783f37b2de073e22e1b5a648"
+    },
+    "thumbnail.jpg": {
+      "checksum": "3691931bc6c8ff0b84317140edbd4b8b"
+    }
+  },
+  "users": null,
+  "extension": {
+    "name": "quarto-document",
+    "title": "Quarto Document",
+    "description": "This Quarto example shows how a basic document can present diagrams and interactivity.",
+    "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-document",
+    "version": "1.0.0"
+  }
+}


### PR DESCRIPTION
Add the `quarto-document` jump start example to the Gallery.

I'm unsure if the version constraint syntax applies to the `quarto` field of `manifest.json`. I don't _think_ it does — I think it's just the `environment` field — but the baseline Quarto version matching is probably fine, as it defaults to "nearest" and this particular document is extremely simple.