### PR TITLE
Improve integration test output for debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,33 +39,6 @@ create-extension:  ## [ext] Create extension folder
 # 	@[ -d dist ] && rm -r dist || true
 # 	uv build
 
-# Python dependencies for Connect integration tests
-$(UV_LOCK): dev
-	$(UV) lock
-
-dev: ensure-uv  ## [py] Install dependencies for Connect integration tests
-	$(UV) pip install --upgrade -e .
-
-$(VIRTUAL_ENV):  ## [py] Create virtualenv for Connect integration tests
-	$(UV) venv $(VIRTUAL_ENV)
-
-ensure-uv:  ## [py] Ensure UV and virtualenv are available for Connect integration tests
-	@if ! command -v $(UV) >/dev/null; then \
-		$(PYTHON) -m ensurepip && $(PYTHON) -m pip install "uv >= 0.4.27"; \
-	fi
-	@# Install virtual environment (before calling `uv pip install ...`)
-	@$(MAKE) $(VIRTUAL_ENV) 1>/dev/null
-	@# Be sure recent uv is installed
-	@$(UV) pip install "uv >= 0.4.27" --quiet
-
-docker-deps: ensure-uv  ## [py] Install dependencies in Docker for Connect integration tests
-	# Sync given the `uv.lock` file
-	# --frozen : assert that the lock file exists
-	# --no-install-project : do not install the project itself, but install its dependencies
-	# $(UV) sync --frozen --no-install-project
-	# Install dependencies from pyproject.toml directly
-	$(UV) pip install .
-
 help: FORCE  ## Show help messages for make targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; { \
 		printf "\033[32m%-18s\033[0m", $$1; \

--- a/integration/README.md
+++ b/integration/README.md
@@ -9,10 +9,11 @@ It is primarily designed to be run in CI, but can also be run locally.
 - Python
 
 ## Quick Start
-1. Use Makefile targets to set up and run tests
-2. For local testing:
-	- Copy the packaged extension (*.tar.gz) to `integration/bundles`
-	- Run: `make <connect-version> EXTENSION_NAME=<extension-name>`
+For local testing:
+- Install `uv` with a version matching that in `pyproject.toml`
+- Copy a valid Connect license file to `integration/license.lic`
+- Copy the packaged extension (*.tar.gz) to `integration/bundles`
+- Run: `make <connect-version> EXTENSION_NAME=<extension-name>`
 		- `<connect-version>` matches a valid version from CONNECT_VERSIONS in the Makefile 
 		- `<extension-name>` matches the base name of your .tar.gz file (without the .tar.gz extension)
 

--- a/integration/tests/posit/connect/test_deployments.py
+++ b/integration/tests/posit/connect/test_deployments.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 from posit import connect
 import requests
+import pprint
 
 # Configuration constants - could be moved to environment variables
 MAX_RETRIES = 6
@@ -55,9 +56,12 @@ class TestExtensionDeployment:
         deploy_time = time.time() - deploy_start
         print(f"Bundle deployment completed after {deploy_time:.1f}s")
 
+        # Format the task object so we can use it in our assertion messages for debugging
+        task_pp = pprint.pformat(task, indent=2)
+        
         # Verify deployment succeeded
-        assert task.is_finished is True, "Deployment task didn't finish"
-        assert task.error_code == 0, f"Deployment failed with code {task.error_code}: {task.error_message}"
+        assert task.is_finished is True, f"Deployment task didn't finish\nTask: {task_pp}"
+        assert task.error_code == 0, f"Deployment failed with code {task.error_code}\nTask:{task_pp}"
         
         # Refresh content after deployment
         self.content = self.client.content.get(self.content["guid"])


### PR DESCRIPTION
Changes:
- Improve integration test output when deploy fails to aid with debugging
- Improve integration test README to include more instructions for local testing
- Remove leftover integration test makefile targets from root makefile


Example of the improved output from a forced failure during local test.

```
tests-1    | F
tests-1    | 
tests-1    | =================================== FAILURES ===================================
tests-1    | ________________ TestExtensionDeployment.test_extension_deploys ________________
tests-1    | 
tests-1    | self = <test_deployments.TestExtensionDeployment object at 0x7ffffd7de0d0>
tests-1    | 
tests-1    |     def test_extension_deploys(self):
tests-1    |         """Test that an Extension can be deployed and started successfully in Posit Connect."""
tests-1    |         # Get the bundle path using the container mount path
tests-1    |         bundle_path = Path(BUNDLE_BASE_PATH) / f"{self.extension_name}.tar.gz"
tests-1    |         if not bundle_path.exists():
tests-1    |             raise FileNotFoundError(f"Extension bundle not found at {bundle_path}")
tests-1    |     
tests-1    |         # Create bundle and deploy
tests-1    |         bundle = self.content.bundles.create(str(bundle_path))
tests-1    |     
tests-1    |         # Deploy bundle and track timing
tests-1    |         deploy_start = time.time()
tests-1    |         task = bundle.deploy()
tests-1    |         task.wait_for()
tests-1    |         deploy_time = time.time() - deploy_start
tests-1    |         print(f"Bundle deployment completed after {deploy_time:.1f}s")
tests-1    |     
tests-1    |         # Format the task object so we can use it in our assertion messages for debugging
tests-1    |         task_pp = pprint.pformat(task, indent=2)
tests-1    |     
tests-1    |         # Verify deployment succeeded
tests-1    |         assert task.is_finished is True, f"Deployment task didn't finish\nTask: {task_pp}"
tests-1    | >       assert task.error_code == 99, f"Deployment failed with code {task.error_code}\nTask:{task_pp}"
tests-1    | E       AssertionError: Deployment failed with code 0
tests-1    | E         Task:{ 'code': 0,
tests-1    | E           'error': '',
tests-1    | E           'finished': True,
tests-1    | E           'id': 'UYfhL9A4bfPNQOdc',
tests-1    | E           'last': 119,
tests-1    | E           'output': [ 'Building FastAPI application...',
tests-1    | E                       'Bundle created with Python version 3.12.3 (>=3.8, <4) is '
tests-1    | E                       'compatible with environment Local with Python version 3.12.1 '
tests-1    | E                       'from /opt/python/3.12.1/bin/python3.12 ',
tests-1    | E                       'Bundle requested Python version 3.12.3 (>=3.8, <4); using '
tests-1    | E                       '/opt/python/3.12.1/bin/python3.12 from Local which has version '
tests-1    | E                       '3.12.1',
tests-1    | E                       '2025/04/15 22:19:04.751771752 [rsc-session] Content GUID: '
tests-1    | E                       'b9471236-b857-4235-bcb3-12e8193849ed',
tests-1    | E                       '2025/04/15 22:19:04.752359835 [rsc-session] Content ID: 1',
tests-1    | E                       '2025/04/15 22:19:04.752363252 [rsc-session] Bundle ID: 1',
tests-1    | E                       '2025/04/15 22:19:04.752364627 [rsc-session] Job Key: '
tests-1    | E                       'EnkP9vEpDEU0DX9e',
tests-1    | E                       'Determining session server location ...',
tests-1    | E                       'Connecting to session server http://127.0.0.1:34891 ...',
tests-1    | E                       'Connected to session server http://127.0.0.1:34891',
tests-1    | E                       '2025/04/15 22:19:04.980273085 Running on host: 160074980adc',
tests-1    | E                       '2025/04/15 22:19:04.980294919 Process ID: 195',
tests-1    | E                       '2025/04/15 22:19:05.070485669 Linux distribution: Ubuntu '
tests-1    | E                       '22.04.5 LTS (jammy)',
tests-1    | E                       '2025/04/15 22:19:05.087781210 Running as user: '
tests-1    | E                       'uid=999(rstudio-connect) gid=999(rstudio-connect) '
tests-1    | E                       'groups=999(rstudio-connect)',
tests-1    | E                       '2025/04/15 22:19:05.087791794 Connect version: 2025.03.0',
tests-1    | E                       '2025/04/15 22:19:05.087827960 LANG: en_US.UTF-8',
tests-1    | E                       '2025/04/15 22:19:05.088005377 Working directory: '
tests-1    | E                       '/opt/rstudio-connect/mnt/app',
tests-1    | E                       '2025/04/15 22:19:05.088276252 Building environment using Python '
tests-1    | E                       '3.12.1 (main, Feb 25 2025, 22:25:40) [GCC 11.4.0] at '
tests-1    | E                       '/opt/python/3.12.1/bin/python3.12',
tests-1    | E                       '2025/04/15 22:19:05.088972669 Requested packages: '
tests-1    | E                       'cachetools==5.5.1, fastapi==0.115.6, posit_sdk @ '
tests-1    | E                       'git+https://github.com/posit-dev/posit-sdk-py.git@main',
tests-1    | E                       '2025/04/15 22:19:05.092869544 Creating environment: '
tests-1    | E                       'rqOHNaSBl0CUZDFb-Cr3zw',
tests-1    | E                       '2025/04/15 22:19:05.654524044 Requirement already satisfied: '
tests-1    | E                       'pip in /opt/python/3.12.1/lib/python3.12/site-packages (25.0.1)',
tests-1    | E                       '2025/04/15 22:19:05.753236752 Requirement already satisfied: '
tests-1    | E                       'setuptools in /opt/python/3.12.1/lib/python3.12/site-packages '
tests-1    | E                       '(78.1.0)',
tests-1    | E                       '2025/04/15 22:19:05.902501752 Collecting wheel',
tests-1    | E                       '2025/04/15 22:19:05.937447544   Downloading '
tests-1    | E                       'wheel-0.45.1-py3-none-any.whl.metadata (2.3 kB)',
tests-1    | E                       '2025/04/15 22:19:05.958702836 Downloading '
tests-1    | E                       'wheel-0.45.1-py3-none-any.whl (72 kB)',
tests-1    | E                       '2025/04/15 22:19:05.981096211 Installing collected packages: '
tests-1    | E                       'wheel',
tests-1    | E                       '2025/04/15 22:19:06.026910919 Successfully installed '
tests-1    | E                       'wheel-0.45.1',
tests-1    | E                       '2025/04/15 22:19:06.720964086 Collecting posit_sdk@ '
tests-1    | E                       'git+https://github.com/posit-dev/posit-sdk-py.git@main (from -r '
tests-1    | E                       'python/requirements.txt (line 3))',
tests-1    | E                       '2025/04/15 22:19:06.721466836   Cloning '
tests-1    | E                       'https://github.com/posit-dev/posit-sdk-py.git (to revision '
tests-1    | E                       'main) to '
tests-1    | E                       '/opt/rstudio-connect/mnt/tmp/pip-install-ab561x0b/posit-sdk_964f3b130f7c469ea8caaa3906ccfdc5',
tests-1    | E                       '2025/04/15 22:19:06.738142836   Running command git clone '
tests-1    | E                       '--filter=blob:none --quiet '
tests-1    | E                       'https://github.com/posit-dev/posit-sdk-py.git '
tests-1    | E                       '/opt/rstudio-connect/mnt/tmp/pip-install-ab561x0b/posit-sdk_964f3b130f7c469ea8caaa3906ccfdc5',
tests-1    | E                       '2025/04/15 22:19:07.739238337   Resolved '
tests-1    | E                       'https://github.com/posit-dev/posit-sdk-py.git to commit '
tests-1    | E                       'b61e2db365bb3ce92fe7fc276d98a5257cf2e531',
tests-1    | E                       '2025/04/15 22:19:07.764323337   Installing build dependencies: '
tests-1    | E                       'started',
tests-1    | E                       '2025/04/15 22:19:09.547915879   Installing build dependencies: '
tests-1    | E                       "finished with status 'done'",
tests-1    | E                       '2025/04/15 22:19:09.548908962   Getting requirements to build '
tests-1    | E                       'wheel: started',
tests-1    | E                       '2025/04/15 22:19:10.109152754   Getting requirements to build '
tests-1    | E                       "wheel: finished with status 'done'",
tests-1    | E                       '2025/04/15 22:19:10.111159671   Preparing metadata '
tests-1    | E                       '(pyproject.toml): started',
tests-1    | E                       '2025/04/15 22:19:10.689294921   Preparing metadata '
tests-1    | E                       "(pyproject.toml): finished with status 'done'",
tests-1    | E                       '2025/04/15 22:19:12.589407381 Collecting cachetools==5.5.1 '
tests-1    | E                       '(from -r python/requirements.txt (line 1))',
tests-1    | E                       '2025/04/15 22:19:12.631727964   Downloading '
tests-1    | E                       'cachetools-5.5.1-py3-none-any.whl.metadata (5.4 kB)',
tests-1    | E                       '2025/04/15 22:19:12.700930131 Collecting fastapi==0.115.6 (from '
tests-1    | E                       '-r python/requirements.txt (line 2))',
tests-1    | E                       '2025/04/15 22:19:12.712844631   Downloading '
tests-1    | E                       'fastapi-0.115.6-py3-none-any.whl.metadata (27 kB)',
tests-1    | E                       '2025/04/15 22:19:12.753646464 Collecting uvicorn (from -r '
tests-1    | E                       'python/requirements.txt (line 4))',
tests-1    | E                       '2025/04/15 22:19:12.764400214   Downloading '
tests-1    | E                       'uvicorn-0.34.1-py3-none-any.whl.metadata (6.5 kB)',
tests-1    | E                       '2025/04/15 22:19:12.860400881 Collecting websockets (from -r '
tests-1    | E                       'python/requirements.txt (line 5))',
tests-1    | E                       '2025/04/15 22:19:12.871562256   Downloading '
tests-1    | E                       'websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata '
tests-1    | E                       '(6.8 kB)',
tests-1    | E                       '2025/04/15 22:19:12.891426672 Collecting aiofiles (from -r '
tests-1    | E                       'python/requirements.txt (line 6))',
tests-1    | E                       '2025/04/15 22:19:12.902732214   Downloading '
tests-1    | E                       'aiofiles-24.1.0-py3-none-any.whl.metadata (10 kB)',
tests-1    | E                       '2025/04/15 22:19:12.936922506 Collecting starlette (from -r '
tests-1    | E                       'python/requirements.txt (line 7))',
tests-1    | E                       '2025/04/15 22:19:12.947812881   Downloading '
tests-1    | E                       'starlette-0.46.2-py3-none-any.whl.metadata (6.2 kB)',
tests-1    | E                       '2025/04/15 22:19:12.986937381 Collecting wsproto (from -r '
tests-1    | E                       'python/requirements.txt (line 8))',
tests-1    | E                       '2025/04/15 22:19:13.003223381   Downloading '
tests-1    | E                       'wsproto-1.2.0-py3-none-any.whl.metadata (5.6 kB)',
tests-1    | E                       '2025/04/15 22:19:13.024944464 Collecting starlette (from -r '
tests-1    | E                       'python/requirements.txt (line 7))',
tests-1    | E                       '2025/04/15 22:19:13.039824881   Downloading '
tests-1    | E                       'starlette-0.41.3-py3-none-any.whl.metadata (6.0 kB)',
tests-1    | E                       '2025/04/15 22:19:13.162432131 Collecting '
tests-1    | E                       'pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4 '
tests-1    | E                       '(from fastapi==0.115.6->-r python/requirements.txt (line 2))',
tests-1    | E                       '2025/04/15 22:19:13.173405422   Downloading '
tests-1    | E                       'pydantic-2.11.3-py3-none-any.whl.metadata (65 kB)',
tests-1    | E                       '2025/04/15 22:19:13.207947006 Collecting '
tests-1    | E                       'typing-extensions>=4.8.0 (from fastapi==0.115.6->-r '
tests-1    | E                       'python/requirements.txt (line 2))',
tests-1    | E                       '2025/04/15 22:19:13.218282798   Downloading '
tests-1    | E                       'typing_extensions-4.13.2-py3-none-any.whl.metadata (3.0 kB)',
tests-1    | E                       '2025/04/15 22:19:13.261509881 Collecting requests<3,>=2.31.0 '
tests-1    | E                       '(from posit_sdk@ '
tests-1    | E                       'git+https://github.com/posit-dev/posit-sdk-py.git@main->-r '
tests-1    | E                       'python/requirements.txt (line 3))',
tests-1    | E                       '2025/04/15 22:19:13.272362173   Downloading '
tests-1    | E                       'requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)',
tests-1    | E                       '2025/04/15 22:19:13.299690714 Collecting packaging (from '
tests-1    | E                       'posit_sdk@ '
tests-1    | E                       'git+https://github.com/posit-dev/posit-sdk-py.git@main->-r '
tests-1    | E                       'python/requirements.txt (line 3))',
tests-1    | E                       '2025/04/15 22:19:13.310316381   Downloading '
tests-1    | E                       'packaging-24.2-py3-none-any.whl.metadata (3.2 kB)',
tests-1    | E                       '2025/04/15 22:19:13.337735048 Collecting click>=7.0 (from '
tests-1    | E                       'uvicorn->-r python/requirements.txt (line 4))',
tests-1    | E                       '2025/04/15 22:19:13.348479006   Downloading '
tests-1    | E                       'click-8.1.8-py3-none-any.whl.metadata (2.3 kB)',
tests-1    | E                       '2025/04/15 22:19:13.366551089 Collecting h11>=0.8 (from '
tests-1    | E                       'uvicorn->-r python/requirements.txt (line 4))',
tests-1    | E                       '2025/04/15 22:19:13.377401673   Downloading '
tests-1    | E                       'h11-0.14.0-py3-none-any.whl.metadata (8.2 kB)',
tests-1    | E                       '2025/04/15 22:19:13.406059839 Collecting anyio<5,>=3.4.0 (from '
tests-1    | E                       'starlette->-r python/requirements.txt (line 7))',
tests-1    | E                       '2025/04/15 22:19:13.416385298   Downloading '
tests-1    | E                       'anyio-4.9.0-py3-none-any.whl.metadata (4.7 kB)',
tests-1    | E                       '2025/04/15 22:19:13.443203048 Collecting idna>=2.8 (from '
tests-1    | E                       'anyio<5,>=3.4.0->starlette->-r python/requirements.txt (line '
tests-1    | E                       '7))',
tests-1    | E                       '2025/04/15 22:19:13.453317839   Downloading '
tests-1    | E                       'idna-3.10-py3-none-any.whl.metadata (10 kB)',
tests-1    | E                       '2025/04/15 22:19:13.472254381 Collecting sniffio>=1.1 (from '
tests-1    | E                       'anyio<5,>=3.4.0->starlette->-r python/requirements.txt (line '
tests-1    | E                       '7))',
tests-1    | E                       '2025/04/15 22:19:13.482480298   Downloading '
tests-1    | E                       'sniffio-1.3.1-py3-none-any.whl.metadata (3.9 kB)',
tests-1    | E                       '2025/04/15 22:19:13.507321256 Collecting annotated-types>=0.6.0 '
tests-1    | E                       '(from '
tests-1    | E                       'pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4->fastapi==0.115.6->-r '
tests-1    | E                       'python/requirements.txt (line 2))',
tests-1    | E                       '2025/04/15 22:19:13.517685589   Downloading '
tests-1    | E                       'annotated_types-0.7.0-py3-none-any.whl.metadata (15 kB)',
tests-1    | E                       '2025/04/15 22:19:13.968866173 Collecting pydantic-core==2.33.1 '
tests-1    | E                       '(from '
tests-1    | E                       'pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4->fastapi==0.115.6->-r '
tests-1    | E                       'python/requirements.txt (line 2))',
tests-1    | E                       '2025/04/15 22:19:13.979441590   Downloading '
tests-1    | E                       'pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata '
tests-1    | E                       '(6.8 kB)',
tests-1    | E                       '2025/04/15 22:19:14.001897840 Collecting '
tests-1    | E                       'typing-inspection>=0.4.0 (from '
tests-1    | E                       'pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4->fastapi==0.115.6->-r '
tests-1    | E                       'python/requirements.txt (line 2))',
tests-1    | E                       '2025/04/15 22:19:14.013097423   Downloading '
tests-1    | E                       'typing_inspection-0.4.0-py3-none-any.whl.metadata (2.6 kB)',
tests-1    | E                       '2025/04/15 22:19:14.084760506 Collecting '
tests-1    | E                       'charset-normalizer<4,>=2 (from requests<3,>=2.31.0->posit_sdk@ '
tests-1    | E                       'git+https://github.com/posit-dev/posit-sdk-py.git@main->-r '
tests-1    | E                       'python/requirements.txt (line 3))',
tests-1    | E                       '2025/04/15 22:19:14.095161381   Downloading '
tests-1    | E                       'charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata '
tests-1    | E                       '(35 kB)',
tests-1    | E                       '2025/04/15 22:19:14.157552923 Collecting urllib3<3,>=1.21.1 '
tests-1    | E                       '(from requests<3,>=2.31.0->posit_sdk@ '
tests-1    | E                       'git+https://github.com/posit-dev/posit-sdk-py.git@main->-r '
tests-1    | E                       'python/requirements.txt (line 3))',
tests-1    | E                       '2025/04/15 22:19:14.168633090   Downloading '
tests-1    | E                       'urllib3-2.4.0-py3-none-any.whl.metadata (6.5 kB)',
tests-1    | E                       '2025/04/15 22:19:14.195583923 Collecting certifi>=2017.4.17 '
tests-1    | E                       '(from requests<3,>=2.31.0->posit_sdk@ '
tests-1    | E                       'git+https://github.com/posit-dev/posit-sdk-py.git@main->-r '
tests-1    | E                       'python/requirements.txt (line 3))',
tests-1    | E                       '2025/04/15 22:19:14.206642590   Downloading '
tests-1    | E                       'certifi-2025.1.31-py3-none-any.whl.metadata (2.5 kB)',
tests-1    | E                       '2025/04/15 22:19:14.234805090 Downloading '
tests-1    | E                       'cachetools-5.5.1-py3-none-any.whl (9.5 kB)',
tests-1    | E                       '2025/04/15 22:19:14.247865173 Downloading '
tests-1    | E                       'fastapi-0.115.6-py3-none-any.whl (94 kB)',
tests-1    | E                       '2025/04/15 22:19:14.263691381 Downloading '
tests-1    | E                       'uvicorn-0.34.1-py3-none-any.whl (62 kB)',
tests-1    | E                       '2025/04/15 22:19:14.277177090 Downloading '
tests-1    | E                       'websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl '
tests-1    | E                       '(182 kB)',
tests-1    | E                       '2025/04/15 22:19:14.292368173 Downloading '
tests-1    | E                       'aiofiles-24.1.0-py3-none-any.whl (15 kB)',
tests-1    | E                       '2025/04/15 22:19:14.304402548 Downloading '
tests-1    | E                       'starlette-0.41.3-py3-none-any.whl (73 kB)',
tests-1    | E                       '2025/04/15 22:19:14.317663006 Downloading '
tests-1    | E                       'wsproto-1.2.0-py3-none-any.whl (24 kB)',
tests-1    | E                       '2025/04/15 22:19:14.330287131 Downloading '
tests-1    | E                       'anyio-4.9.0-py3-none-any.whl (100 kB)',
tests-1    | E                       '2025/04/15 22:19:14.344639006 Downloading '
tests-1    | E                       'click-8.1.8-py3-none-any.whl (98 kB)',
tests-1    | E                       '2025/04/15 22:19:14.357889465 Downloading '
tests-1    | E                       'h11-0.14.0-py3-none-any.whl (58 kB)',
tests-1    | E                       '2025/04/15 22:19:14.372725631 Downloading '
tests-1    | E                       'pydantic-2.11.3-py3-none-any.whl (443 kB)',
tests-1    | E                       '2025/04/15 22:19:14.395647006 Downloading '
tests-1    | E                       'pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl '
tests-1    | E                       '(2.0 MB)',
tests-1    | E                       '2025/04/15 22:19:14.420974048    '
tests-1    | E                       '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.0/2.0 MB 91.6 MB/s '
tests-1    | E                       'eta 0:00:00',
tests-1    | E                       '2025/04/15 22:19:14.431276173 Downloading '
tests-1    | E                       'requests-2.32.3-py3-none-any.whl (64 kB)',
tests-1    | E                       '2025/04/15 22:19:14.444080048 Downloading '
tests-1    | E                       'typing_extensions-4.13.2-py3-none-any.whl (45 kB)',
tests-1    | E                       '2025/04/15 22:19:14.456879423 Downloading '
tests-1    | E                       'packaging-24.2-py3-none-any.whl (65 kB)',
tests-1    | E                       '2025/04/15 22:19:14.469410798 Downloading '
tests-1    | E                       'annotated_types-0.7.0-py3-none-any.whl (13 kB)',
tests-1    | E                       '2025/04/15 22:19:14.482522131 Downloading '
tests-1    | E                       'certifi-2025.1.31-py3-none-any.whl (166 kB)',
tests-1    | E                       '2025/04/15 22:19:14.497364256 Downloading '
tests-1    | E                       'charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl '
tests-1    | E                       '(145 kB)',
tests-1    | E                       '2025/04/15 22:19:14.510483048 Downloading '
tests-1    | E                       'idna-3.10-py3-none-any.whl (70 kB)',
tests-1    | E                       '2025/04/15 22:19:14.524049006 Downloading '
tests-1    | E                       'sniffio-1.3.1-py3-none-any.whl (10 kB)',
tests-1    | E                       '2025/04/15 22:19:14.538295631 Downloading '
tests-1    | E                       'typing_inspection-0.4.0-py3-none-any.whl (14 kB)',
tests-1    | E                       '2025/04/15 22:19:14.553182173 Downloading '
tests-1    | E                       'urllib3-2.4.0-py3-none-any.whl (128 kB)',
tests-1    | E                       '2025/04/15 22:19:14.584271340 Building wheels for collected '
tests-1    | E                       'packages: posit_sdk',
tests-1    | E                       '2025/04/15 22:19:14.610834215   Building wheel for posit_sdk '
tests-1    | E                       '(pyproject.toml): started',
tests-1    | E                       '2025/04/15 22:19:15.220541132   Building wheel for posit_sdk '
tests-1    | E                       "(pyproject.toml): finished with status 'done'",
tests-1    | E                       '2025/04/15 22:19:15.221411048   Created wheel for posit_sdk: '
tests-1    | E                       'filename=posit_sdk-0.9.0-py3-none-any.whl size=72601 '
tests-1    | E                       'sha256=ae18aa9b6436e5b324df4b69c9066f7fb0c1ce1169900adfe08c196e7dd92df3',
tests-1    | E                       '2025/04/15 22:19:15.221584882   Stored in directory: '
tests-1    | E                       '/opt/rstudio-connect/mnt/tmp/pip-ephem-wheel-cache-7kj3dp2x/wheels/6b/c7/f9/dd4dc59b2f51af53f5c58d97fe19db1ae64df2b42d319d8aae',
tests-1    | E                       '2025/04/15 22:19:15.223947257 Successfully built posit_sdk',
tests-1    | E                       '2025/04/15 22:19:15.263679673 Installing collected packages: '
tests-1    | E                       'websockets, urllib3, typing-extensions, sniffio, packaging, '
tests-1    | E                       'idna, h11, click, charset-normalizer, certifi, cachetools, '
tests-1    | E                       'annotated-types, aiofiles, wsproto, uvicorn, typing-inspection, '
tests-1    | E                       'requests, pydantic-core, anyio, starlette, pydantic, posit_sdk, '
tests-1    | E                       'fastapi',
tests-1    | E                       '2025/04/15 22:19:16.282634924 Successfully installed '
tests-1    | E                       'aiofiles-24.1.0 annotated-types-0.7.0 anyio-4.9.0 '
tests-1    | E                       'cachetools-5.5.1 certifi-2025.1.31 charset-normalizer-3.4.1 '
tests-1    | E                       'click-8.1.8 fastapi-0.115.6 h11-0.14.0 idna-3.10 packaging-24.2 '
tests-1    | E                       'posit_sdk-0.9.0 pydantic-2.11.3 pydantic-core-2.33.1 '
tests-1    | E                       'requests-2.32.3 sniffio-1.3.1 starlette-0.41.3 '
tests-1    | E                       'typing-extensions-4.13.2 typing-inspection-0.4.0 urllib3-2.4.0 '
tests-1    | E                       'uvicorn-0.34.1 websockets-15.0.1 wsproto-1.2.0',
tests-1    | E                       '2025/04/15 22:19:16.662473424 Packages in the environment: '
tests-1    | E                       'aiofiles==24.1.0, annotated-types==0.7.0, anyio==4.9.0, '
tests-1    | E                       'cachetools==5.5.1, certifi==2025.1.31, '
tests-1    | E                       'charset-normalizer==3.4.1, click==8.1.8, fastapi==0.115.6, '
tests-1    | E                       'h11==0.14.0, idna==3.10, packaging==24.2, pip==25.0.1, '
tests-1    | E                       'posit-sdk @ '
tests-1    | E                       'git+https://github.com/posit-dev/posit-sdk-py.git@b61e2db365bb3ce92fe7fc276d98a5257cf2e531, '
tests-1    | E                       'pydantic==2.11.3, pydantic_core==2.33.1, requests==2.32.3, '
tests-1    | E                       'setuptools==78.1.0, sniffio==1.3.1, starlette==0.41.3, '
tests-1    | E                       'typing-inspection==0.4.0, typing_extensions==4.13.2, '
tests-1    | E                       'urllib3==2.4.0, uvicorn==0.34.1, virtualenv==16.7.12, '
tests-1    | E                       'websockets==15.0.1, wheel==0.45.1, wsproto==1.2.0, ',
tests-1    | E                       '2025/04/15 22:19:16.662723466 Creating lockfile: '
tests-1    | E                       'python/requirements.txt.lock',
tests-1    | E                       'Completed Python build using Local against Python version: '
tests-1    | E                       "'3.12.1'",
tests-1    | E                       'Stopped session pings to http://127.0.0.1:34891',
tests-1    | E                       'Launching FastAPI application...'],
tests-1    | E           'result': None}
tests-1    | E       assert 0 == 99
tests-1    | E        +  where 0 = {'id': 'UYfhL9A4bfPNQOdc', 'output': ['Building FastAPI application...', 'Bundle created with Python version 3.12.3 (>...0.1:34891', 'Launching FastAPI application...'], 'result': None, 'finished': True, 'code': 0, 'error': '', 'last': 119}.error_code
tests-1    | 
tests-1    | tests/posit/connect/test_deployments.py:64: AssertionError
tests-1    | -- generated xml file: /connect-extensions/integration/reports/2025.03.0.xml ---
tests-1    | =========================== short test summary info ============================
tests-1    | FAILED tests/posit/connect/test_deployments.py::TestExtensionDeployment::test_extension_deploys
tests-1    | ============================== 1 failed in 12.95s ==============================
tests-1    | make: *** [Makefile:286: test] Error 1
```