### PR TITLE
Add support for content tags

### DIFF
--- a/.github/actions/lint-extension/action.yml
+++ b/.github/actions/lint-extension/action.yml
@@ -35,6 +35,29 @@ runs:
         ' ./extensions/${{ inputs.extension-name }}/manifest.json
       shell: bash
 
+    # Ensures that the manifest.json has only valid tags
+    - name: Check tags
+      run: |
+        # Read in valid tags from extensions.json
+        VALID_TAGS=$(jq -c '.tags' ./extensions.json)
+        
+        # Read in tags from the extension's manifest.json
+        EXTENSION_TAGS=$(jq -c '.extension.tags // []' ./extensions/${{ inputs.extension-name }}/manifest.json)
+        
+        # Check if any extension tag is not in the valid tags list
+        INVALID_TAGS=$(jq -n -c --argjson global "$VALID_TAGS" --argjson extension "$EXTENSION_TAGS" '
+          $extension | map(. as $tag | if ($global | index($tag) | not) then $tag else empty end)
+        ')
+        
+        # Check if there are any invalid tags
+        if [ "$INVALID_TAGS" != "[]" ]; then
+          echo "Error: The following tags in manifest.json are not defined in extensions.json:"
+          echo "$INVALID_TAGS"
+          echo "Please add these tags to the 'tags' array in extensions.json or remove them from the manifest."
+          exit 1
+        fi
+      shell: bash
+       
     - uses: actions/setup-node@v4
 
     - run: npm install -g semver

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ to the `manifest.json`:
     "title": "My Content Name",
     "description": "A lovely, detailed description of the content.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/my-content-name",
+    "tags": [],
     "version": "0.0.0"
   }
 }
@@ -48,6 +49,27 @@ to the `manifest.json`:
 It is recommended to begin with `"version": "0.0.0"` to avoid triggering a
 release during development of your content. When you are ready to release to
 the gallery check the [Adding content to the Connect Gallery](#adding-content-to-the-connect-gallery) section.
+
+#### Tags
+
+The `tags` array in the `extension` section of the `manifest.json` is optional,
+but it helps users filter content in the Gallery. A good start is to include the
+languages and tools used:
+
+```json
+// manifest.json
+
+{
+  ...
+  "extension": {
+    "tags": ["python", "quarto"],
+    ...
+  }
+}
+```
+
+Available tags are listed in the [extensions.json](./extensions.json) and the
+automations in the repository will check that any included tags are valid.
 
 ### README.md
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,17 @@ languages and tools used:
 }
 ```
 
-Available tags are listed in the [extensions.json](./extensions.json) and the
+Available tags are listed in the [`extensions.json`](./extensions.json) and the
 automations in the repository will check that any included tags are valid.
+
+##### Adding a new tag to the gallery
+
+If you want to include a tag on content that is not already in the
+[`extensions.json`](./extensions.json) file, it can be added.
+
+Pull requests can add new tags, but ensure that the tag follows the patterns
+of other tags and is not a duplicate. New tags should be added sparingly and
+reviewed carefully.
 
 ### README.md
 

--- a/extensions.json
+++ b/extensions.json
@@ -1,4 +1,5 @@
 {
+  "tags": [],
   "extensions": [
     {
       "name": "portfolio-dashboard",

--- a/scripts/extension-list.ts
+++ b/scripts/extension-list.ts
@@ -31,17 +31,18 @@ function sortExtensionVersions(extension: Extension) {
 }
 
 class ExtensionList {
-  constructor(public extensions: Extension[]) {
+  constructor(public tags: string[], public extensions: Extension[]) {
+    this.tags = tags;
     this.extensions = extensions;
   }
 
   static fromFile(path: string) {
-    const extensions = JSON.parse(fs.readFileSync(path, "utf8")).extensions;
-    return new ExtensionList(extensions);
+    const file = JSON.parse(fs.readFileSync(path, "utf8"));
+    return new ExtensionList(file.tags, file.extensions);
   }
 
   public addRelease(manifest: ExtensionManifest, githubRelease) {
-    const { name, title, description, homepage, version } = manifest.extension;
+    const { name, title, description, homepage, version, tags } = manifest.extension;
     const { assets, published_at } = githubRelease;
 
     const { browser_download_url } = assets.find(
@@ -55,10 +56,10 @@ class ExtensionList {
     };
 
     if (this.getExtension(name)) {
-      this.updateExtensionDetails(name, title, description, homepage);
+      this.updateExtensionDetails(name, title, description, homepage, tags);
       this.addExtensionVersion(name, newVersion);
     } else {
-      this.addNewExtension(name, title, description, homepage, newVersion);
+      this.addNewExtension(name, title, description, homepage, newVersion, tags);
     }
   }
 
@@ -70,13 +71,15 @@ class ExtensionList {
     name: string,
     title: string,
     description: string,
-    homepage: string
+    homepage: string,
+    tags: string[] = []
   ) {
     this.updateExtension(name, {
       ...this.getExtension(name),
       title,
       description,
       homepage,
+      tags,
     });
   }
 
@@ -109,7 +112,8 @@ class ExtensionList {
     title: string,
     description: string,
     homepage: string,
-    initialVersion: ExtensionVersion
+    initialVersion: ExtensionVersion,
+    tags: string[] = []
   ) {
     if (this.getExtension(name) !== undefined) {
       throw new Error(`Extension ${name} already exists in the list`);
@@ -121,6 +125,7 @@ class ExtensionList {
       homepage,
       latestVersion: initialVersion,
       versions: [initialVersion],
+      tags,
     });
     this.sortExtensions();
   }
@@ -134,7 +139,11 @@ class ExtensionList {
   }
 
   public stringify() {
-    return JSON.stringify({ extensions: this.extensions }, null, 2);
+    const output = {
+      tags: this.tags,
+      extensions: this.extensions
+    }
+    return JSON.stringify(output, null, 2);
   }
 
   private sortExtensions() {

--- a/scripts/types/index.ts
+++ b/scripts/types/index.ts
@@ -5,6 +5,7 @@ export interface ExtensionManifest {
     description: string;
     homepage: string;
     version: string;
+    tags?: string[];
   };
 }
 
@@ -21,4 +22,5 @@ export interface Extension {
   homepage: string;
   latestVersion: ExtensionVersion;
   versions: ExtensionVersion[];
+  tags: string[];
 }


### PR DESCRIPTION
This adds tag support to the extension list allowing content to set tags from the list in the `extensions.json` file.

The linting CI step checks that any tags supplied in the content's `manifest.json` (in `extension.tags`) are in the `extensions.json` `tags` array. This maintains a list of valid tags to avoid duplication or very similar tags.

This PR doesn't add any tags to content or the `extensions.json`, I plan to follow-up with that so we can focus on reviewing the implementation here.

The `extension-list.ts` script has been updated to handle the new `tags` section of `extensions.json`.

### Test Workflows

- https://github.com/posit-dev/connect-extensions/actions/runs/14498752928 is a run where the linting passed
- https://github.com/posit-dev/connect-extensions/actions/runs/14498303579 shows a linting failure when a tag is included that isn't in `extensions.json`