### PR TITLE
Remove `connect-extension.toml` file from Reaper

### DIFF
--- a/extensions/reaper/connect-extension.toml
+++ b/extensions/reaper/connect-extension.toml
@@ -1,4 +1,0 @@
-name = "reaper"
-title = "reaper"
-description = "a view to a kill."
-access_type = "logged_in"

--- a/extensions/reaper/manifest.json
+++ b/extensions/reaper/manifest.json
@@ -34,6 +34,6 @@
     "title": "Reaper",
     "description": "A view to a kill.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/reaper",
-    "version": "0.0.1"
+    "version": "0.0.2"
   }
 }


### PR DESCRIPTION
Since we have moved away from using `.toml` files in [extensions](https://github.com/posit-dev/connect/issues/30008), we should remove this one in the Reaper. This was also causing a flaky error in the `connect_gallery/home.cy.js` test because the `.toml` file was [included in the bundle](https://github.com/posit-dev/connect/blob/a4edb45bdfd6b7b2d1f35840ac865a76e42f0208/test/e2e/tests/connect_gallery/home.cy.js#L77) in the [PR](https://github.com/posit-dev/connect/pull/30998) from removing references to `.toml` files