### PR TITLE
Add support for `minimumConnectVersion` specification

### DIFF
--- a/.github/actions/lint-extension/action.yml
+++ b/.github/actions/lint-extension/action.yml
@@ -30,6 +30,7 @@ runs:
           elif (.extension.title | type) != "string" then error("Missing extension.title")
           elif (.extension.description | type) != "string" then error("Missing extension.description")
           elif (.extension.homepage | type) != "string" then error("Missing extension.homepage")
+          elif (.extension.minimumConnectVersion | type) != "string" then error("Missing extension.minimumConnectVersion")
           elif (.extension.version | type) != "string" then error("Missing extension.version")
           else . end
         ' ./extensions/${{ inputs.extension-name }}/manifest.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ to the `manifest.json`:
     "description": "A lovely, detailed description of the content.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/my-content-name",
     "tags": [],
+    "minimumConnectVersion": "2025.04.0",
     "version": "0.0.0"
   }
 }
@@ -79,6 +80,18 @@ If you want to include a tag on content that is not already in the
 Pull requests can add new tags, but ensure that the tag follows the patterns
 of other tags and is not a duplicate. New tags should be added sparingly and
 reviewed carefully.
+
+#### Minimum Connect Version
+
+The `minimumConnectVersion` field in the `extension` section of the
+`manifest.json` is required to specify the minimum version of Posit Connect
+that the content can be installed and used on.
+
+Each time you release a version of your content the `minimumConnectVersion`
+is recorded for that specific release.
+
+A good Connect Version to start with is `"2025.04.0"` since it is the
+release that introduced the Connect Gallery.
 
 ### README.md
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,9 @@ a pull request with the changes.
 }
 ```
 
+If the new version of content requires a new minimum Connect version, then
+update the `minimumConnectVersion` as well.
+
 When that pull request is merged, GitHub Workflows will automatically create a
 new GitHub Release for the content changed, update the content list, and update
 Connect Gallery.

--- a/extensions.json
+++ b/extensions.json
@@ -9,13 +9,15 @@
       "latestVersion": {
         "version": "0.0.1",
         "released": "2025-04-11T21:32:23Z",
-        "url": "https://github.com/posit-dev/connect-extensions/releases/download/portfolio-dashboard%40v0.0.1/portfolio-dashboard.tar.gz"
+        "url": "https://github.com/posit-dev/connect-extensions/releases/download/portfolio-dashboard%40v0.0.1/portfolio-dashboard.tar.gz",
+        "minimumConnectVersion": "2025.04.0"
       },
       "versions": [
         {
           "version": "0.0.1",
           "released": "2025-04-11T21:32:23Z",
-          "url": "https://github.com/posit-dev/connect-extensions/releases/download/portfolio-dashboard%40v0.0.1/portfolio-dashboard.tar.gz"
+          "url": "https://github.com/posit-dev/connect-extensions/releases/download/portfolio-dashboard%40v0.0.1/portfolio-dashboard.tar.gz",
+          "minimumConnectVersion": "2025.04.0"
         }
       ]
     },
@@ -27,13 +29,15 @@
       "latestVersion": {
         "version": "0.0.1",
         "released": "2025-03-19T23:00:09Z",
-        "url": "https://github.com/posit-dev/connect-extensions/releases/download/publisher-command-center%40v0.0.1/publisher-command-center.tar.gz"
+        "url": "https://github.com/posit-dev/connect-extensions/releases/download/publisher-command-center%40v0.0.1/publisher-command-center.tar.gz",
+        "minimumConnectVersion": "2025.04.0"
       },
       "versions": [
         {
           "version": "0.0.1",
           "released": "2025-03-19T23:00:09Z",
-          "url": "https://github.com/posit-dev/connect-extensions/releases/download/publisher-command-center%40v0.0.1/publisher-command-center.tar.gz"
+          "url": "https://github.com/posit-dev/connect-extensions/releases/download/publisher-command-center%40v0.0.1/publisher-command-center.tar.gz",
+          "minimumConnectVersion": "2025.04.0"
         }
       ]
     },
@@ -45,13 +49,15 @@
       "latestVersion": {
         "version": "1.0.0",
         "released": "2025-04-14T20:05:36Z",
-        "url": "https://github.com/posit-dev/connect-extensions/releases/download/quarto-document%40v1.0.0/quarto-document.tar.gz"
+        "url": "https://github.com/posit-dev/connect-extensions/releases/download/quarto-document%40v1.0.0/quarto-document.tar.gz",
+        "minimumConnectVersion": "2025.04.0"
       },
       "versions": [
         {
           "version": "1.0.0",
           "released": "2025-04-14T20:05:36Z",
-          "url": "https://github.com/posit-dev/connect-extensions/releases/download/quarto-document%40v1.0.0/quarto-document.tar.gz"
+          "url": "https://github.com/posit-dev/connect-extensions/releases/download/quarto-document%40v1.0.0/quarto-document.tar.gz",
+          "minimumConnectVersion": "2025.04.0"
         }
       ]
     },
@@ -63,13 +69,15 @@
       "latestVersion": {
         "version": "1.0.0",
         "released": "2025-04-14T18:38:38Z",
-        "url": "https://github.com/posit-dev/connect-extensions/releases/download/quarto-stock-report-python%40v1.0.0/quarto-stock-report-python.tar.gz"
+        "url": "https://github.com/posit-dev/connect-extensions/releases/download/quarto-stock-report-python%40v1.0.0/quarto-stock-report-python.tar.gz",
+        "minimumConnectVersion": "2025.04.0"
       },
       "versions": [
         {
           "version": "1.0.0",
           "released": "2025-04-14T18:38:38Z",
-          "url": "https://github.com/posit-dev/connect-extensions/releases/download/quarto-stock-report-python%40v1.0.0/quarto-stock-report-python.tar.gz"
+          "url": "https://github.com/posit-dev/connect-extensions/releases/download/quarto-stock-report-python%40v1.0.0/quarto-stock-report-python.tar.gz",
+          "minimumConnectVersion": "2025.04.0"
         }
       ]
     },
@@ -81,18 +89,21 @@
       "latestVersion": {
         "version": "0.0.2",
         "released": "2025-04-16T22:32:48Z",
-        "url": "https://github.com/posit-dev/connect-extensions/releases/download/reaper%40v0.0.2/reaper.tar.gz"
+        "url": "https://github.com/posit-dev/connect-extensions/releases/download/reaper%40v0.0.2/reaper.tar.gz",
+        "minimumConnectVersion": "2025.04.0"
       },
       "versions": [
         {
           "version": "0.0.2",
           "released": "2025-04-16T22:32:48Z",
-          "url": "https://github.com/posit-dev/connect-extensions/releases/download/reaper%40v0.0.2/reaper.tar.gz"
+          "url": "https://github.com/posit-dev/connect-extensions/releases/download/reaper%40v0.0.2/reaper.tar.gz",
+          "minimumConnectVersion": "2025.04.0"
         },
         {
           "version": "0.0.1",
           "released": "2025-03-19T22:59:58Z",
-          "url": "https://github.com/posit-dev/connect-extensions/releases/download/reaper%40v0.0.1/reaper.tar.gz"
+          "url": "https://github.com/posit-dev/connect-extensions/releases/download/reaper%40v0.0.1/reaper.tar.gz",
+          "minimumConnectVersion": "2025.04.0"
         }
       ]
     }

--- a/extensions/audit-api/manifest.json
+++ b/extensions/audit-api/manifest.json
@@ -1440,6 +1440,7 @@
     "title": "Audit Log API",
     "description": "An API Publisher can call for audit logs.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/audit-api",
+    "minimumConnectVersion": "2025.04.0",
     "version": "0.0.0"
   }
 }

--- a/extensions/audit-reports/manifest.json
+++ b/extensions/audit-reports/manifest.json
@@ -45,6 +45,7 @@
     "title": "Audit Reports",
     "description": "A quarto site of audit reports.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/audit-reports",
+    "minimumConnectVersion": "2025.04.0",
     "version": "0.0.0"
   }
 }

--- a/extensions/datadog-prometheus-metrics/manifest.json
+++ b/extensions/datadog-prometheus-metrics/manifest.json
@@ -32,6 +32,7 @@
     "title": "Plotting Connect Prometheus Metrics from Datadog",
     "description": "Allows users to query Datadog for a selected Connect Prometheus metric over a given timeframe and view a plot of the results.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/datadog-prometheus-metrics",
+    "minimumConnectVersion": "2025.04.0",
     "version": "0.0.0"
   }
 }

--- a/extensions/integration-session-manager/manifest.json
+++ b/extensions/integration-session-manager/manifest.json
@@ -14,10 +14,10 @@
     }
   },
   "environment": {
-		"python": {
-			"requires": ">=3.8, <4"
-		}
-	},
+    "python": {
+      "requires": ">=3.8, <4"
+    }
+  },
   "files": {
     "requirements.txt": {
       "checksum": "ad96c76e9e6206cb681729471b4498cd"
@@ -40,6 +40,7 @@
     "title": "Connect OAuth Integration Session Manager",
     "description": "Allows Connect admins to view and manage OAuth integration sessions.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/integration-session-manager",
+    "minimumConnectVersion": "2025.04.0",
     "version": "0.0.0"
   }
 }

--- a/extensions/oauth-integration-debug/manifest.json
+++ b/extensions/oauth-integration-debug/manifest.json
@@ -32,6 +32,7 @@
     "title": "Connect OAuth Integration Debugger",
     "description": "Allows Connect content viewers to debug user session tokens and credential exchange.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/oauth-integration-debug",
+    "minimumConnectVersion": "2025.04.0",
     "version": "0.0.0"
   }
 }

--- a/extensions/oauth-integration-validator/manifest.json
+++ b/extensions/oauth-integration-validator/manifest.json
@@ -1397,6 +1397,7 @@
     "title": "Connect OAuth Integration Validator",
     "description": "Test an OAuth integration by performing a GET request to a specified endpoint using the access token obtained by Connect.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/oauth-integration-validator",
+    "minimumConnectVersion": "2025.04.0",
     "version": "0.0.0"
   }
 }

--- a/extensions/portfolio-dashboard/manifest.json
+++ b/extensions/portfolio-dashboard/manifest.json
@@ -7,6 +7,7 @@
     "title": "Portfolio Dashboard",
     "description": "A shiny application makes it easy to transform your analysis into an interactive dashboard using R so users can ask and answer questions in real-time, without having to touch any code.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/portfolio-dashboard",
+    "minimumConnectVersion": "2025.04.0",
     "version": "0.0.1"
   },
   "environment": {

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -63,6 +63,7 @@
 		"title": "Publisher Command Center",
 		"description": "A dashboard for publishers to help manage and track their content",
 		"homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/publisher-command-center",
+		"minimumConnectVersion": "2025.04.0",
 		"version": "0.0.1"
 	}
 }

--- a/extensions/quarto-document/manifest.json
+++ b/extensions/quarto-document/manifest.json
@@ -11,7 +11,9 @@
   },
   "quarto": {
     "version": "1.7.13",
-    "engines": ["markdown"]
+    "engines": [
+      "markdown"
+    ]
   },
   "packages": null,
   "files": {
@@ -28,6 +30,7 @@
     "title": "Quarto Document",
     "description": "This Quarto example shows how a basic document can present diagrams and interactivity.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-document",
+    "minimumConnectVersion": "2025.04.0",
     "version": "1.0.0"
   }
 }

--- a/extensions/quarto-stock-report-python/manifest.json
+++ b/extensions/quarto-stock-report-python/manifest.json
@@ -9,6 +9,7 @@
     "title": "Quarto Stock Report using Python",
     "description": "An example of how you might automate regular updates using a data source",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-stock-report-python",
+    "minimumConnectVersion": "2025.04.0",
     "version": "1.0.0"
   },
   "environment": {

--- a/extensions/reaper/manifest.json
+++ b/extensions/reaper/manifest.json
@@ -34,6 +34,7 @@
     "title": "Reaper",
     "description": "A view to a kill.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/reaper",
+    "minimumConnectVersion": "2025.04.0",
     "version": "0.0.2"
   }
 }

--- a/scripts/extension-list.ts
+++ b/scripts/extension-list.ts
@@ -42,7 +42,15 @@ class ExtensionList {
   }
 
   public addRelease(manifest: ExtensionManifest, githubRelease) {
-    const { name, title, description, homepage, version, tags } = manifest.extension;
+    const {
+      name,
+      title,
+      description,
+      homepage,
+      version,
+      tags,
+      minimumConnectVersion,
+    } = manifest.extension;
     const { assets, published_at } = githubRelease;
 
     const { browser_download_url } = assets.find(
@@ -53,6 +61,7 @@ class ExtensionList {
       version,
       released: published_at,
       url: browser_download_url,
+      minimumConnectVersion: minimumConnectVersion,
     };
 
     if (this.getExtension(name)) {

--- a/scripts/types/index.ts
+++ b/scripts/types/index.ts
@@ -5,6 +5,7 @@ export interface ExtensionManifest {
     description: string;
     homepage: string;
     version: string;
+    minimumConnectVersion: string;
     tags?: string[];
   };
 }
@@ -13,6 +14,7 @@ export interface ExtensionVersion {
   version: string;
   released: string;
   url: string;
+  minimumConnectVersion: string;
 }
 
 export interface Extension {


### PR DESCRIPTION
This PR adds a new item to the `extension` section of the `manifest.json` for content in the Gallery - `minimumConnectVersion`. As the name implies it is to set the minimum Connect version that is necessary for the content to work.

The field is required. The `lint` CI task has been updated to check if it is included. The contributing guide has also been updated with instructions for how to include it, recommending `2025.04.0` as a good place to start since _all_ content requires the Gallery feature.

As part of this PR I have updated all of the `manifest.extension` sections, the script that creates the extension list, and the extension list itself to add `minimumConnectVersion` to previous releases of content.