### PR TITLE
Ensure the same uv version is being used everywhere for integration tests

### DIFF
--- a/integration/Makefile
+++ b/integration/Makefile
@@ -10,8 +10,8 @@ PROJECT_NAME := connect-extensions
 # Python settings
 PYTHON ?= $(shell command -v python || command -v python3)
 UV ?= uv
-# Read UV version from pyproject.toml
-UV_VERSION ?= $(shell grep -Po '(?<=required-version = ")[^"]+' pyproject.toml 2>/dev/null || echo "0.6.14")
+# Read UV version from pyproject.toml with more portable command
+UV_VERSION ?= $(shell grep 'required-version' pyproject.toml 2>/dev/null | sed -E 's/.*required-version = "([^"]+)".*/\1/' || echo "0.6.14")
 # uv defaults virtual environment to `$VIRTUAL_ENV` if set; otherwise .venv
 VIRTUAL_ENV ?= .venv
 UV_LOCK := uv.lock

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -10,6 +10,8 @@ PROJECT_NAME := connect-extensions
 # Python settings
 PYTHON ?= $(shell command -v python || command -v python3)
 UV ?= uv
+# Read UV version from pyproject.toml
+UV_VERSION ?= $(shell grep -Po '(?<=required-version = ")[^"]+' pyproject.toml 2>/dev/null || echo "0.6.14")
 # uv defaults virtual environment to `$VIRTUAL_ENV` if set; otherwise .venv
 VIRTUAL_ENV ?= .venv
 UV_LOCK := uv.lock
@@ -104,7 +106,7 @@ debug-env:
 # Ensure UV and virtualenv are available for Connect integration tests
 ensure-uv:
 	@if ! command -v $(UV) >/dev/null; then \
-		$(PYTHON) -m ensurepip && $(PYTHON) -m pip install "uv >= 0.4.27"; \
+		$(PYTHON) -m ensurepip && $(PYTHON) -m pip install "uv == $(UV_VERSION)"; \
 	fi
 	
 	echo "=== DEBUG before VENV creation ==="
@@ -130,7 +132,7 @@ ensure-uv:
 	@$(MAKE) debug-env
 	
 	echo "Installing UV in virtualenv"; \
-	$(UV) pip install "uv >= 0.4.27" --quiet; \
+	$(UV) pip install "uv == $(UV_VERSION)" --quiet; \
 
 
 # Install dependencies in Docker for Connect integration tests


### PR DESCRIPTION
This fixes our integration test makefile to ensure all environments are installing the exact same version of `uv` using the version specified in our `pyproject.toml` 

This fixes an issue experienced during integration tests where the `uv` versions differed and caused the setup to fail.

```
3.700 echo "Installing UV in virtualenv"; \
3.700 uv pip install "uv >= 0.4.27" --quiet; \
3.700 
3.701 Installing UV in virtualenv
3.706 error: Required uv version `==0.6.14` does not match the running version `0.6.16`
3.707 make: *** [Makefile:120: ensure-uv] Error 2
```