### PR TITLE
Configure Connect to log email to console

### DIFF
--- a/integration/rstudio-connect.gcfg
+++ b/integration/rstudio-connect.gcfg
@@ -6,7 +6,8 @@
 ; email. The system will not be able to send administrative email until this
 ; setting is configured.
 ;
-; SenderEmail = account@company.com
+SenderEmail = no-reply@example.com
+EmailProvider = none
 
 ; The persistent data directory mounted into our container.
 DataDir = /data


### PR DESCRIPTION
Enable Connect to log email to the console.

This should fix the issue where content rendering errors cause Connect to try to email error reports and then that action generates a failure which causes confusion when debugging as the email failure masks the real error with the content.

```
tests-1    | E                       '2025/04/23 19:26:21.396666230 2/3 [unnamed-chunk-1]',
tests-1    | E                       '2025/04/23 19:26:21.622144953 Error in `formatter()`:',
tests-1    | E                       '2025/04/23 19:26:21.622157486 ! could not find function '
tests-1    | E                       '"formatter"',
tests-1    | E                       '2025/04/23 19:26:21.623544788 ',
tests-1    | E                       '2025/04/23 19:26:21.623553725 Quitting from '
tests-1    | E                       'portfolio-report-email.Rmd:10-25 [unnamed-chunk-1]',
tests-1    | E                       '2025/04/23 19:26:21.624587797 Execution halted',
tests-1    | E                       'Unable to render the deployed content: Rendering exited '
tests-1    | E                       'abnormally: exit status 1',
tests-1    | E                       'Failure emailing the error: The system has not been configured '
tests-1    | E                       'to send email',
tests-1    | E                       'Stopped session pings to http://127.0.0.1:45353/'],
tests-1    | E           'result': { 'data': 'An error occurred while attempting to launch the '
tests-1    | E                               'content after deployment',
tests-1    | E                       'type': 'launch-error'}}
tests-1    | E       assert 1 == 0
tests-1    | E        +  where 1 = {'id': 'Q583XJJ00Ws8Gtu1', 'output': ['Building R Markdown document...', 'Bundle created with R version 4.4.3 (>=4.0) ...ype': 'launch-error'}, 'finished': True, 'code': 1, 'error': 'Rendering exited abnormally: exit status 1', 'last': 556}.error_code
tests-1    | 
tests-1    | tests/posit/connect/test_deployments.py:64: AssertionError
tests-1    | - generated xml file: /connect-extensions/integration/reports/connect-preview.xml -
tests-1    | =========================== short test summary info ============================
tests-1    | FAILED tests/posit/connect/test_deployments.py::TestExtensionDeployment::test_extension_deploys
tests-1    | ======================== 1 failed in 147.71s (0:02:27) =========================
tests-1    | make: *** [Makefile:288: test] Error 1
```