### PR TITLE
Increase debug logging when application validation fails

### DIFF
--- a/integration/tests/posit/connect/test_deployments.py
+++ b/integration/tests/posit/connect/test_deployments.py
@@ -106,7 +106,7 @@ class TestExtensionDeployment:
     def _fetch_and_print_job_logs(self):
         """Helper to fetch and print job logs for debugging."""
         try:
-            # Get the most recent job
+            # Get all jobs which will include the environment restore and application logs
             jobs_response = requests.get(
                 f"{self.base_url}/__api__/v1/content/{self.content['guid']}/jobs",
                 headers={"Authorization": f"Key {self.api_key}"}
@@ -117,23 +117,29 @@ class TestExtensionDeployment:
                 print("No jobs found for content")
                 return
                 
-            job_key = jobs[0]["key"]
+            print(f"Found {len(jobs)} jobs for content")
             
-            # Get the job logs
-            log_response = requests.get(
-                f"{self.base_url}/__api__/v1/content/{self.content['guid']}/jobs/{job_key}/log",
-                headers={"Authorization": f"Key {self.api_key}"}
-            )
-            logs = log_response.json()
-            
-            print(f"Job logs for job {job_key}:")
-            if "entries" in logs and logs["entries"]:
-                for entry in logs["entries"]:
-                    timestamp = entry.get("timestamp", "")
-                    message = entry.get("data", "")
-                    print(f"    {timestamp} - {message}")
-            else:
-                print("No log entries found")
+            # Iterate through all jobs
+            for job in jobs:
+                job_key = job["key"]
+                
+                # Get the job logs
+                log_response = requests.get(
+                    f"{self.base_url}/__api__/v1/content/{self.content['guid']}/jobs/{job_key}/log",
+                    headers={"Authorization": f"Key {self.api_key}"}
+                )
+                logs = log_response.json()
+                
+                print(f"Job logs for job {job_key}:")
+                if "entries" in logs and logs["entries"]:
+                    for entry in logs["entries"]:
+                        timestamp = entry.get("timestamp", "")
+                        message = entry.get("data", "")
+                        print(f"    {timestamp} - {message}")
+                else:
+                    print(f"    No log entries found for job {job_key}")
+                
+                print("-" * 50)  # Separator between jobs
                 
         except Exception as e:
             print(f"Error fetching job logs: {e}")

--- a/integration/tests/posit/connect/test_deployments.py
+++ b/integration/tests/posit/connect/test_deployments.py
@@ -102,6 +102,8 @@ class TestExtensionDeployment:
             except requests.RequestException as e:
                 elapsed = time.time() - start_time
                 raise AssertionError(f"Failed to access content after {elapsed:.1f}s: {e}")
+
+
     
     def _fetch_and_print_job_logs(self):
         """Helper to fetch and print job logs for debugging."""
@@ -120,7 +122,8 @@ class TestExtensionDeployment:
             print(f"Found {len(jobs)} jobs for content")
             
             # Iterate through all jobs
-            for job in jobs:
+            # Iterate through jobs in reverse order (most recent first)
+            for job in reversed(jobs):
                 job_key = job["key"]
                 
                 # Get the job logs


### PR DESCRIPTION
This change ensures that when application verification fails that all logs for the application are available for debugging.

Currently we miss the environment restore logging. We could have opted to simply always log the task object, but that logging is visually different so logging it here ensures the logs have the same presentation.

Example by forcing logging during a passing test run locally.
```
tests-1    | Found 2 jobs for content
tests-1    | Job logs for job qkipO8Ndh26Ks8NG:
tests-1    |     2025-04-28T21:13:43.772379214Z - [rsc-session] Content GUID: 0275d07b-00c8-443f-9651-821938978027
tests-1    |     2025-04-28T21:13:43.772945755Z - [rsc-session] Content ID: 1
tests-1    |     2025-04-28T21:13:43.77294963Z - [rsc-session] Bundle ID: 1
tests-1    |     2025-04-28T21:13:43.772951422Z - [rsc-session] Job Key: qkipO8Ndh26Ks8NG
tests-1    |     2025-04-28T21:13:44.653581964Z - Running on host: 396b4d763e20
tests-1    |     2025-04-28T21:13:44.653601922Z - Process ID: 194
tests-1    |     2025-04-28T21:13:44.757416672Z - Linux distribution: Ubuntu 22.04.5 LTS (jammy)
tests-1    |     2025-04-28T21:13:44.787327339Z - Running as user: uid=999(rstudio-connect) gid=999(rstudio-connect) groups=999(rstudio-connect)
tests-1    |     2025-04-28T21:13:44.787366256Z - Connect version: 2025.03.0
tests-1    |     2025-04-28T21:13:44.787400422Z - LANG: en_US.UTF-8
tests-1    |     2025-04-28T21:13:44.787793797Z - Working directory: /opt/rstudio-connect/mnt/app
tests-1    |     2025-04-28T21:13:44.788225047Z - Using R 4.4.0
tests-1    |     2025-04-28T21:13:44.788230964Z - R.home(): /opt/R/4.4.0/lib/R
tests-1    |     2025-04-28T21:13:44.788948422Z - Using user agent string: 'RStudio R (4.4.0 x86_64-pc-linux-gnu x86_64 linux-gnu)' 
tests-1    |     2025-04-28T21:13:44.789165297Z - Configuring packrat to use available credentials for private repository access.
tests-1    |     2025-04-28T21:13:44.789472297Z - # Validating R library read / write permissions --------------------------------
tests-1    |     2025-04-28T21:13:44.791155464Z - Using R library for packrat bootstrap: /opt/rstudio-connect/mnt/R/4.4.0
tests-1    |     2025-04-28T21:13:44.791270631Z - # Validating managed packrat installation --------------------------------------
tests-1    |     2025-04-28T21:13:44.792139672Z - Vendored packrat archive: /opt/rstudio-connect/ext/R/packrat_0.9.2.9000_70625806c44bda42a7f3aeaa92ee65542cc590be.tar.gz
tests-1    |     2025-04-28T21:13:44.802133089Z - Vendored packrat SHA: 70625806c44bda42a7f3aeaa92ee65542cc590be
tests-1    |     2025-04-28T21:13:44.802180839Z - Managed packrat SHA:  
tests-1    |     2025-04-28T21:13:44.802259714Z - Managed packrat version: (none)
tests-1    |     2025-04-28T21:13:44.802497964Z - Installing packrat from /opt/rstudio-connect/ext/R/packrat_0.9.2.9000_70625806c44bda42a7f3aeaa92ee65542cc590be.tar.gz.
tests-1    |     2025-04-28T21:13:45.443327881Z - * installing *source* package ‘packrat’ ...
tests-1    |     2025-04-28T21:13:45.443569714Z - ** using staged installation
tests-1    |     2025-04-28T21:13:45.462406298Z - ** R
tests-1    |     2025-04-28T21:13:45.484905548Z - ** inst
tests-1    |     2025-04-28T21:13:45.486865714Z - ** byte-compile and prepare package for lazy loading
tests-1    |     2025-04-28T21:13:48.005980174Z - ** help
tests-1    |     2025-04-28T21:13:48.059677466Z - *** installing help indices
tests-1    |     2025-04-28T21:13:48.090588882Z - ** building package indices
tests-1    |     2025-04-28T21:13:48.598391258Z - ** testing if installed package can be loaded from temporary location
tests-1    |     2025-04-28T21:13:49.231992883Z - ** testing if installed package can be loaded from final location
tests-1    |     2025-04-28T21:13:49.958728341Z - ** testing if installed package keeps a record of temporary installation path
tests-1    |     2025-04-28T21:13:49.962044425Z - * DONE (packrat)
tests-1    |     2025-04-28T21:13:50.00250605Z - Managed packrat version: 0.9.2.9000
tests-1    |     2025-04-28T21:13:50.002879758Z - # Validating packrat cache read / write permissions ----------------------------
tests-1    |     2025-04-28T21:13:50.185883508Z - Using packrat cache directory: /opt/rstudio-connect/mnt/packrat/4.4.0
tests-1    |     2025-04-28T21:13:50.185897467Z - # Setting packrat options and preparing lockfile -------------------------------
tests-1    |     2025-04-28T21:13:50.249182508Z - Audited package hashes with local packrat installation.
tests-1    |     2025-04-28T21:13:50.250628633Z - # Resolving R package repositories ---------------------------------------------
tests-1    |     2025-04-28T21:13:50.260163258Z - Received repositories from Connect's configuration:
tests-1    |     2025-04-28T21:13:50.261347425Z - - CRAN = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"
tests-1    |     2025-04-28T21:13:50.261352758Z - - RSPM = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"
tests-1    |     2025-04-28T21:13:50.361309925Z - Received repositories from published content:
tests-1    |     2025-04-28T21:13:50.361491175Z - - CRAN = "https://cloud.r-project.org"
tests-1    |     2025-04-28T21:13:50.362367008Z - Combining repositories from configuration and content.
tests-1    |     2025-04-28T21:13:50.362425092Z - Packages will be installed using the following repositories:
tests-1    |     2025-04-28T21:13:50.362646925Z - - CRAN = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"
tests-1    |     2025-04-28T21:13:50.362652425Z - - RSPM = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"
tests-1    |     2025-04-28T21:13:50.362662842Z - - CRAN.1 = "https://cloud.r-project.org"
tests-1    |     2025-04-28T21:13:50.369372675Z - # Installing required R packages with `packrat::restore()` ---------------------
tests-1    |     2025-04-28T21:13:50.42143405Z - Installing FNN (1.1.4.1) ... 
tests-1    |     2025-04-28T21:13:50.937121259Z - curl: HTTP 200 https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/PACKAGES.rds
tests-1    |     2025-04-28T21:13:51.698742926Z - curl: HTTP 200 https://cloud.r-project.org/src/contrib/PACKAGES.rds
tests-1    |     2025-04-28T21:13:53.289517176Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/af122216c4ee9f785867b8573eb867f8b5b8b955987dc3a5b330473b387ef919.tar.gz
tests-1    |     2025-04-28T21:13:54.607499677Z - Caching FNN.
tests-1    |     2025-04-28T21:13:54.610073344Z - Using cached FNN.
tests-1    |     2025-04-28T21:13:54.610330969Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:13:54.610436219Z - Installing R6 (2.6.1) ... 
tests-1    |     2025-04-28T21:13:55.584352428Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/3ff12fe9f8a7fce0baf7d3f8ff8e6e16d8f5b8163cdefbf632041a6451fa81d5.tar.gz
tests-1    |     2025-04-28T21:13:56.859800053Z - Caching R6.
tests-1    |     2025-04-28T21:13:56.860977053Z - Using cached R6.
tests-1    |     2025-04-28T21:13:56.86121422Z -        OK (downloaded binary)
tests-1    |     2025-04-28T21:13:56.861292553Z - Installing Rcpp (1.0.14) ... 
tests-1    |     2025-04-28T21:13:57.874919595Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/d13c6291b664f2282c5a6bffcec9a05fef3e56376c9d2b07035c5872a2a85cb1.tar.gz
tests-1    |     2025-04-28T21:13:59.380136846Z - Caching Rcpp.
tests-1    |     2025-04-28T21:13:59.398500804Z - Using cached Rcpp.
tests-1    |     2025-04-28T21:13:59.402093429Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:13:59.402150263Z - Installing base64enc (0.1-3) ... 
tests-1    |     2025-04-28T21:14:00.383443721Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/4dfa7b8e9ab0823cbabf15bfb55ab7fa7503b23754d9c79853bc347be1094d1d.tar.gz
tests-1    |     2025-04-28T21:14:01.636290014Z - Caching base64enc.
tests-1    |     2025-04-28T21:14:01.637528014Z - Using cached base64enc.
tests-1    |     2025-04-28T21:14:01.637800722Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:01.66519868Z - Installing cli (3.6.4) ... 
tests-1    |     2025-04-28T21:14:02.057203875Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/ed311c8629c6724237bc76be5ad3dfec78fe747e1e0411cdfd43e7f5aa1076e2.tar.gz
tests-1    |     2025-04-28T21:14:03.430444334Z - Caching cli.
tests-1    |     2025-04-28T21:14:03.433907917Z - Using cached cli.
tests-1    |     2025-04-28T21:14:03.434523292Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:03.434662Z - Installing commonmark (1.9.5) ... 
tests-1    |     2025-04-28T21:14:04.413493667Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/ec08b1ec5873f442bbf495441592bb529b54bb2d9747744c4ee4abc3a8d64aba.tar.gz
tests-1    |     2025-04-28T21:14:05.647368835Z - Caching commonmark.
tests-1    |     2025-04-28T21:14:05.659909793Z - Using cached commonmark.
tests-1    |     2025-04-28T21:14:05.660145126Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:05.66021371Z - Installing crayon (1.5.3) ... 
tests-1    |     2025-04-28T21:14:06.66140046Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/f1c389c131fe91c82f919129d84bf243f7f7849afd9a27995db94758f8716ebf.tar.gz
tests-1    |     2025-04-28T21:14:07.931956419Z - Caching crayon.
tests-1    |     2025-04-28T21:14:07.933135127Z - Using cached crayon.
tests-1    |     2025-04-28T21:14:07.933374669Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:07.933449627Z - Installing curl (6.2.2) ... 
tests-1    |     2025-04-28T21:14:08.896171503Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/b7783cdb05d2f6034944014033ee6c070d9c1b81660c27b1341397badac600fb.tar.gz
tests-1    |     2025-04-28T21:14:10.187679212Z - Caching curl.
tests-1    |     2025-04-28T21:14:10.19000842Z - Using cached curl.
tests-1    |     2025-04-28T21:14:10.190371045Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:10.19045717Z - Installing digest (0.6.37) ... 
tests-1    |     2025-04-28T21:14:11.212064337Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/32b7981e68b57f42cbc79c47c14a13fd960cb6e152b7b3fb9d71829366ee34db.tar.gz
tests-1    |     2025-04-28T21:14:12.508888713Z - Caching digest.
tests-1    |     2025-04-28T21:14:12.51066088Z - Using cached digest.
tests-1    |     2025-04-28T21:14:12.510990755Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:12.511068421Z - Installing evaluate (1.0.3) ... 
tests-1    |     2025-04-28T21:14:13.514771547Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/4574c02ba1dbf610f550db09c403f9a6beb77938f04140be35233092bc395fce.tar.gz
tests-1    |     2025-04-28T21:14:14.940884964Z - Caching evaluate.
tests-1    |     2025-04-28T21:14:14.954694964Z - Using cached evaluate.
tests-1    |     2025-04-28T21:14:14.955140131Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:14.955339089Z - Installing fansi (1.0.6) ... 
tests-1    |     2025-04-28T21:14:15.942166715Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/0a369a4cec59109f683879da21ab07f78a765bbed3f452e5196bc6f9fa97c036.tar.gz
tests-1    |     2025-04-28T21:14:17.229373965Z - Caching fansi.
tests-1    |     2025-04-28T21:14:17.23083084Z - Using cached fansi.
tests-1    |     2025-04-28T21:14:17.231112257Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:17.231189257Z - Installing fastmap (1.2.0) ... 
tests-1    |     2025-04-28T21:14:18.205451632Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/8ce111cc307c67017d095e0d8bba184ae6585bad5ebb712e14312162ab54f2ed.tar.gz
tests-1    |     2025-04-28T21:14:19.4677573Z - Caching fastmap.
tests-1    |     2025-04-28T21:14:19.469058675Z - Using cached fastmap.
tests-1    |     2025-04-28T21:14:19.4693193Z -         OK (downloaded binary)
tests-1    |     2025-04-28T21:14:19.469414133Z - Installing generics (0.1.3) ... 
tests-1    |     2025-04-28T21:14:20.503912842Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/2f102b53e8103d5132f3092c83b82f4455d7335e4f81c61dd92bab29e215fd33.tar.gz
tests-1    |     2025-04-28T21:14:21.783903384Z - Caching generics.
tests-1    |     2025-04-28T21:14:21.785123176Z - Using cached generics.
tests-1    |     2025-04-28T21:14:21.785356384Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:21.785433259Z - Installing glue (1.8.0) ... 
tests-1    |     2025-04-28T21:14:22.809378343Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/dfecd93518dabccb49ceda67514c20c66d4ed3a90d10a007a745036cd040001b.tar.gz
tests-1    |     2025-04-28T21:14:24.132844385Z - Caching glue.
tests-1    |     2025-04-28T21:14:24.134628052Z - Using cached glue.
tests-1    |     2025-04-28T21:14:24.134938635Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:24.13502726Z - Installing jsonlite (2.0.0) ... 
tests-1    |     2025-04-28T21:14:25.128034761Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/5a7cabc04c24b14775d755b72d680969aab74e20b582a918a2d1db3566e887b2.tar.gz
tests-1    |     2025-04-28T21:14:26.523598845Z - Caching jsonlite.
tests-1    |     2025-04-28T21:14:26.526323553Z - Using cached jsonlite.
tests-1    |     2025-04-28T21:14:26.52676822Z -        OK (downloaded binary)
tests-1    |     2025-04-28T21:14:26.526863011Z - Installing lattice (0.22-6) ... 
tests-1    |     2025-04-28T21:14:26.907868595Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/ddd51872d2b9fd4e40091b82d618d1fc7258497d9aa85446bd494148847feb84.tar.gz
tests-1    |     2025-04-28T21:14:28.24090172Z - Caching lattice.
tests-1    |     2025-04-28T21:14:28.24350022Z - Using cached lattice.
tests-1    |     2025-04-28T21:14:28.24406597Z -        OK (downloaded binary)
tests-1    |     2025-04-28T21:14:28.24414422Z - Installing magrittr (2.0.3) ... 
tests-1    |     2025-04-28T21:14:29.210658554Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/a1075e913590c7bec5c1b6be7bda18961ca7953dd15676141b6c7306bc1ecb7b.tar.gz
tests-1    |     2025-04-28T21:14:30.476106888Z - Caching magrittr.
tests-1    |     2025-04-28T21:14:30.477934555Z - Using cached magrittr.
tests-1    |     2025-04-28T21:14:30.478283722Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:30.47837993Z - Installing mime (0.13) ... 
tests-1    |     2025-04-28T21:14:31.495102139Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/6f3cf40f4b1d8af2af6dd1594f914eef7a5f8b13867b572d204a20da6c87452b.tar.gz
tests-1    |     2025-04-28T21:14:32.781437917Z - Caching mime.
tests-1    |     2025-04-28T21:14:32.782620542Z - Using cached mime.
tests-1    |     2025-04-28T21:14:32.782843958Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:32.782917958Z - Installing pkgconfig (2.0.3) ... 
tests-1    |     2025-04-28T21:14:33.8111855Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/b2e807f4e9a49a2f9cb73bb74f8e2a7549140bae87baadad8802f5e405231ad2.tar.gz
tests-1    |     2025-04-28T21:14:35.078440293Z - Caching pkgconfig.
tests-1    |     2025-04-28T21:14:35.079606543Z - Using cached pkgconfig.
tests-1    |     2025-04-28T21:14:35.079876251Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:35.079955001Z - Installing renv (1.1.4) ... 
tests-1    |     2025-04-28T21:14:36.047792335Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/0b3179f19b5f4a7d7a17fb6ec341faa859285e7078b4c5948948299950305fc4.tar.gz
tests-1    |     2025-04-28T21:14:37.563512544Z - Caching renv.
tests-1    |     2025-04-28T21:14:37.567272002Z - Using cached renv.
tests-1    |     2025-04-28T21:14:37.567891669Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:37.567978127Z - Installing rlang (1.1.6) ... 
tests-1    |     2025-04-28T21:14:38.595947753Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/92c43a32d78a073a36e0f1b88b093a85b8a1e8031ac391631384b79ba80ac5a7.tar.gz
tests-1    |     2025-04-28T21:14:40.001841253Z - Caching rlang.
tests-1    |     2025-04-28T21:14:40.003917753Z - Using cached rlang.
tests-1    |     2025-04-28T21:14:40.004266128Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:40.004347003Z - Installing sodium (1.4.0) ... 
tests-1    |     2025-04-28T21:14:40.979217629Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/047e3bedcc6eb0505980ac794caafa5fcba41b7cd85b8042af54a02dcd3f53a1.tar.gz
tests-1    |     2025-04-28T21:14:42.266879671Z - Caching sodium.
tests-1    |     2025-04-28T21:14:42.268783046Z - Using cached sodium.
tests-1    |     2025-04-28T21:14:42.269122004Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:42.269202713Z - Installing stringi (1.8.7) ... 
tests-1    |     2025-04-28T21:14:43.326618297Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/c751327f49e86099cf5f86d8565ac1939a7564a2ab84783bd7ac97298e1435dc.tar.gz
tests-1    |     2025-04-28T21:14:44.770964214Z - Caching stringi.
tests-1    |     2025-04-28T21:14:44.774464089Z - Using cached stringi.
tests-1    |     2025-04-28T21:14:44.774987256Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:44.775064797Z - Installing swagger (5.17.14.1) ... 
tests-1    |     2025-04-28T21:14:45.786667673Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/d4432cc3e7e677ff59638fd371f0b263d8d34e1d9ea359dd4e3d9e3308d629bb.tar.gz
tests-1    |     2025-04-28T21:14:47.168957923Z - Caching swagger.
tests-1    |     2025-04-28T21:14:47.173147423Z - Using cached swagger.
tests-1    |     2025-04-28T21:14:47.173815298Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:47.173892257Z - Installing sys (3.4.3) ... 
tests-1    |     2025-04-28T21:14:48.185454341Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/a3561e03a5ee8fe4a602c2dea7f5927f32ef0e8dce2a8bc11426ee55abf4448f.tar.gz
tests-1    |     2025-04-28T21:14:49.498800425Z - Caching sys.
tests-1    |     2025-04-28T21:14:49.500265258Z - Using cached sys.
tests-1    |     2025-04-28T21:14:49.500526383Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:49.500605966Z - Installing utf8 (1.2.4) ... 
tests-1    |     2025-04-28T21:14:50.508474008Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/16d5f0f5fd3587bd848db24b3b452a9beeb84690a5a984967ce0955dab24f976.tar.gz
tests-1    |     2025-04-28T21:14:51.795246342Z - Caching utf8.
tests-1    |     2025-04-28T21:14:51.796626134Z - Using cached utf8.
tests-1    |     2025-04-28T21:14:51.796882051Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:51.796964384Z - Installing withr (3.0.2) ... 
tests-1    |     2025-04-28T21:14:52.763808593Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/b5fae07c47d6ad02b41cc60699ee8df88faf59e4bee0c12bc9d70b062066b05e.tar.gz
tests-1    |     2025-04-28T21:14:54.164018385Z - Caching withr.
tests-1    |     2025-04-28T21:14:54.165656635Z - Using cached withr.
tests-1    |     2025-04-28T21:14:54.165947052Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:54.166031135Z - Installing xfun (0.52) ... 
tests-1    |     2025-04-28T21:14:55.243475761Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/324c18217c6fed3b7c2f67223cf90042a545350ac91ebf1cc3903459ea4da7d6.tar.gz
tests-1    |     2025-04-28T21:14:56.533554011Z - Caching xfun.
tests-1    |     2025-04-28T21:14:56.535374178Z - Using cached xfun.
tests-1    |     2025-04-28T21:14:56.535714553Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:56.535799511Z - Installing yaml (2.3.10) ... 
tests-1    |     2025-04-28T21:14:57.51151297Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/2507c855fa4d0cd85378e33b4464470b4e39b0e87173b23fe4698716ad9a89dc.tar.gz
tests-1    |     2025-04-28T21:14:58.770530096Z - Caching yaml.
tests-1    |     2025-04-28T21:14:58.772028054Z - Using cached yaml.
tests-1    |     2025-04-28T21:14:58.772322179Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:14:58.772416637Z - Installing RcppEigen (0.3.4.0.2) ... 
tests-1    |     2025-04-28T21:14:59.815558388Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/f00f0dae38cb215fa6d1449d85f6327328d673486a8d247da2ed395d5901d1bb.tar.gz
tests-1    |     2025-04-28T21:15:01.295023764Z - Caching RcppEigen.
tests-1    |     2025-04-28T21:15:01.313914097Z - Using cached RcppEigen.
tests-1    |     2025-04-28T21:15:01.317422889Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:01.317510472Z - Installing triebeard (0.4.1) ... 
tests-1    |     2025-04-28T21:15:02.301006541Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/fa4730984e64b0391d695446f37a6395cfb7ba51c8f5cbfbf43380c250a1ee61.tar.gz
tests-1    |     2025-04-28T21:15:03.647677667Z - Caching triebeard.
tests-1    |     2025-04-28T21:15:03.649693542Z - Using cached triebeard.
tests-1    |     2025-04-28T21:15:03.650049625Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:03.650134584Z - Installing debugme (1.2.0) ... 
tests-1    |     2025-04-28T21:15:04.636889251Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/ba88f1d13ea93c61758b02833de7994cc9d8c432677b289085ac551ceda92488.tar.gz
tests-1    |     2025-04-28T21:15:05.917056293Z - Caching debugme.
tests-1    |     2025-04-28T21:15:05.918344335Z - Using cached debugme.
tests-1    |     2025-04-28T21:15:05.918555501Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:05.918645251Z - Installing webutils (1.2.2) ... 
tests-1    |     2025-04-28T21:15:06.903542794Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/cae4b72c0a0200048ea59fa087876d9600e8888c0cbfc79709863026933a5823.tar.gz
tests-1    |     2025-04-28T21:15:08.210930044Z - Caching webutils.
tests-1    |     2025-04-28T21:15:08.212262669Z - Using cached webutils.
tests-1    |     2025-04-28T21:15:08.212516044Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:08.212601086Z - Installing Matrix (1.7-0) ... 
tests-1    |     2025-04-28T21:15:08.651055628Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/6cb2450d3636fdfaee399670a96ed79a638224c9338c88a78dd8bf85521e83ec.tar.gz
tests-1    |     2025-04-28T21:15:10.65418817Z - Caching Matrix.
tests-1    |     2025-04-28T21:15:10.661807379Z - Using cached Matrix.
tests-1    |     2025-04-28T21:15:10.662995004Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:10.663069837Z - Installing htmltools (0.5.8.1) ... 
tests-1    |     2025-04-28T21:15:11.640140588Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/5b6115f38093f9bbc80c474f5ec79953073d90b5b6c629c068ac17b08751323c.tar.gz
tests-1    |     2025-04-28T21:15:13.020240338Z - Caching htmltools.
tests-1    |     2025-04-28T21:15:13.021826463Z - Using cached htmltools.
tests-1    |     2025-04-28T21:15:13.022110922Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:13.022210088Z - Installing later (1.4.2) ... 
tests-1    |     2025-04-28T21:15:14.035414297Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/69836b5cbac09a804de8ba5d030d250e580afad7bd34424d22618f37bc8e2d09.tar.gz
tests-1    |     2025-04-28T21:15:15.426429131Z - Caching later.
tests-1    |     2025-04-28T21:15:15.428045256Z - Using cached later.
tests-1    |     2025-04-28T21:15:15.428366964Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:15.428445298Z - Installing lifecycle (1.0.4) ... 
tests-1    |     2025-04-28T21:15:16.431390631Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/ce5a302512e1c971e9788fe5539b5ad4888c546f539477f6e656fd7b7d4c0134.tar.gz
tests-1    |     2025-04-28T21:15:17.809697924Z - Caching lifecycle.
tests-1    |     2025-04-28T21:15:17.811645215Z - Using cached lifecycle.
tests-1    |     2025-04-28T21:15:17.811970174Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:17.812046674Z - Installing askpass (1.2.1) ... 
tests-1    |     2025-04-28T21:15:18.770754674Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/01540b6be677be64e6cf4fb7256fbeb0b9b5642a9c2ce8d19bca870588589110.tar.gz
tests-1    |     2025-04-28T21:15:20.032659425Z - Caching askpass.
tests-1    |     2025-04-28T21:15:20.03402905Z - Using cached askpass.
tests-1    |     2025-04-28T21:15:20.034298258Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:20.034379258Z - Installing highr (0.11) ... 
tests-1    |     2025-04-28T21:15:21.000458884Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/f587062b3ef2b5a8eeebb3955877cee16b40517f7928458d6dcd18420da0b3f0.tar.gz
tests-1    |     2025-04-28T21:15:22.309151884Z - Caching highr.
tests-1    |     2025-04-28T21:15:22.322659093Z - Using cached highr.
tests-1    |     2025-04-28T21:15:22.323135968Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:22.323321968Z - Installing litedown (0.7) ... 
tests-1    |     2025-04-28T21:15:23.317634468Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/9dbe1e3889d8f5b1b7dec2429b32872a49e9da9f1a36235c59f0cd3daa81ac13.tar.gz
tests-1    |     2025-04-28T21:15:24.600686594Z - Caching litedown.
tests-1    |     2025-04-28T21:15:24.602513135Z - Using cached litedown.
tests-1    |     2025-04-28T21:15:24.60281176Z -        OK (downloaded binary)
tests-1    |     2025-04-28T21:15:24.602901885Z - Installing urltools (1.7.3) ... 
tests-1    |     2025-04-28T21:15:25.623341469Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/627bdf1e08fd51f7171520114e7d1db75a57d22aa94c1b82eb4c7e9c3f21ebfe.tar.gz
tests-1    |     2025-04-28T21:15:27.039227387Z - Caching urltools.
tests-1    |     2025-04-28T21:15:27.041095095Z - Using cached urltools.
tests-1    |     2025-04-28T21:15:27.041416303Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:27.041518595Z - Installing ranger (0.17.0) ... 
tests-1    |     2025-04-28T21:15:28.02705772Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/2bf1fe7598340356ec7e27a8f0712bb54070a5d40b1b9870bfbc96275a7ed95b.tar.gz
tests-1    |     2025-04-28T21:15:29.90359218Z - Caching ranger.
tests-1    |     2025-04-28T21:15:29.905222346Z - Using cached ranger.
tests-1    |     2025-04-28T21:15:29.905488263Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:29.905549305Z - Installing promises (1.3.2) ... 
connect-1  | 172.21.0.3 - - [28/Apr/2025:21:16:08 +0000] "GET /__api__/v1/content/0275d07b-00c8-443f-9651-821938978027/jobs/cMMiDwMCGwSrtazt/log HTTP/1.1" 200 4424
tests-1    |     2025-04-28T21:15:30.963637722Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/65349fe4d9f630d715d85dd2363699016749ec19db0f6bdeda444e6657e0e3ce.tar.gz
tests-1    |     2025-04-28T21:15:32.409921666Z - Caching promises.
tests-1    |     2025-04-28T21:15:32.412870125Z - Using cached promises.
tests-1    |     2025-04-28T21:15:32.413347458Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:32.413395375Z - Installing vctrs (0.6.5) ... 
tests-1    |     2025-04-28T21:15:33.470139084Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/b5d3ac2806b2c8b224f580c940b8d503c702cf0aa59d0065840a0858413af03d.tar.gz
tests-1    |     2025-04-28T21:15:34.880287543Z - Caching vctrs.
tests-1    |     2025-04-28T21:15:34.883170043Z - Using cached vctrs.
tests-1    |     2025-04-28T21:15:34.883626001Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:34.883701751Z - Installing openssl (2.3.2) ... 
tests-1    |     2025-04-28T21:15:35.85500371Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/6a3c8a0a867c80fb74ad6c8353a3269ef7b5dc8aa28a3c7558db1890c80a5943.tar.gz
tests-1    |     2025-04-28T21:15:37.192847044Z - Caching openssl.
tests-1    |     2025-04-28T21:15:37.195786627Z - Using cached openssl.
tests-1    |     2025-04-28T21:15:37.19634121Z -        OK (downloaded binary)
tests-1    |     2025-04-28T21:15:37.196443544Z - Installing knitr (1.50) ... 
tests-1    |     2025-04-28T21:15:38.243169586Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/90fa213e443a7e7612b2efd155cbe4d339c927006f9306c981fc8ff05c5f620f.tar.gz
tests-1    |     2025-04-28T21:15:39.593625087Z - Caching knitr.
tests-1    |     2025-04-28T21:15:39.598894503Z - Using cached knitr.
tests-1    |     2025-04-28T21:15:39.599833962Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:39.599920253Z - Installing markdown (2.0) ... 
tests-1    |     2025-04-28T21:15:40.561107129Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/f5954151c313c7ff42a23a567aaa6e047e3c2854a6474ba9561627b9099eceda.tar.gz
tests-1    |     2025-04-28T21:15:41.880315254Z - Caching markdown.
tests-1    |     2025-04-28T21:15:41.881947713Z - Using cached markdown.
tests-1    |     2025-04-28T21:15:41.882258546Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:41.882385129Z - Installing missRanger (2.6.1) ... 
tests-1    |     2025-04-28T21:15:42.841107838Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/eb261e50a969ccdd12339d2a1853ef1ed0ee4dbcc0207e0981669ceb2acc61d2.tar.gz
tests-1    |     2025-04-28T21:15:44.147874297Z - Caching missRanger.
tests-1    |     2025-04-28T21:15:44.14942438Z - Using cached missRanger.
tests-1    |     2025-04-28T21:15:44.149702297Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:44.149777172Z - Installing httpuv (1.6.16) ... 
tests-1    |     2025-04-28T21:15:45.123176339Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/197037e056b72851d4dc7eeb24e8df27d5153c3cc7621225dfc87b83d47459dc.tar.gz
tests-1    |     2025-04-28T21:15:46.599435007Z - Caching httpuv.
tests-1    |     2025-04-28T21:15:46.601353923Z - Using cached httpuv.
tests-1    |     2025-04-28T21:15:46.601689965Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:46.601801298Z - Installing pillar (1.10.2) ... 
tests-1    |     2025-04-28T21:15:47.61298659Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/b0ea1423761ca5aa81007825200c47a3084acd5b201d08b8e26279d622f5a4de.tar.gz
tests-1    |     2025-04-28T21:15:49.083414966Z - Caching pillar.
tests-1    |     2025-04-28T21:15:49.085918133Z - Using cached pillar.
tests-1    |     2025-04-28T21:15:49.086333799Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:49.086428549Z - Installing tidyselect (1.2.1) ... 
tests-1    |     2025-04-28T21:15:50.100325175Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/425ca596cf79ef06c6025575f49f1e9fa02a73e13cbe47dc890045b9563e7923.tar.gz
tests-1    |     2025-04-28T21:15:51.531134301Z - Caching tidyselect.
tests-1    |     2025-04-28T21:15:51.533405592Z - Using cached tidyselect.
tests-1    |     2025-04-28T21:15:51.533744426Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:51.533857342Z - Installing httr (1.4.7) ... 
tests-1    |     2025-04-28T21:15:52.549446468Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/f55cde798b74dbd10e9d9ae7db860261d3af39f9fc269e8c50be0e664d05f86a.tar.gz
tests-1    |     2025-04-28T21:15:53.847315677Z - Caching httr.
tests-1    |     2025-04-28T21:15:53.849514927Z - Using cached httr.
tests-1    |     2025-04-28T21:15:53.849863177Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:53.84995751Z - Installing outForest (1.0.1) ... 
tests-1    |     2025-04-28T21:15:54.82553501Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/52fd8be5d52cf5c3b9e8642171cd3cd2694038fb48e9de98d17bb60378cc9eb5.tar.gz
tests-1    |     2025-04-28T21:15:56.139628928Z - Caching outForest.
tests-1    |     2025-04-28T21:15:56.141387219Z - Using cached outForest.
tests-1    |     2025-04-28T21:15:56.141675761Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:56.141783969Z - Installing plumber (1.3.0) ... 
tests-1    |     2025-04-28T21:15:57.24065522Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/43c53e1c46b7a52bce03d9f1d92f7fa32bf56496ec5f2a1d45b11cc6e1148fed.tar.gz
tests-1    |     2025-04-28T21:15:58.732419012Z - Caching plumber.
tests-1    |     2025-04-28T21:15:58.735794471Z - Using cached plumber.
tests-1    |     2025-04-28T21:15:58.736427721Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:15:58.736476846Z - Installing tibble (3.2.1) ... 
tests-1    |     2025-04-28T21:15:59.745056513Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/4b348536db92dacf1ec58afb3fbb68bcd82eb98c4fedb3a38d947be421027dfc.tar.gz
tests-1    |     2025-04-28T21:16:01.290912389Z - Caching tibble.
tests-1    |     2025-04-28T21:16:01.29373768Z - Using cached tibble.
tests-1    |     2025-04-28T21:16:01.294233639Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:16:01.294361847Z - Installing plumbertableau (0.1.1) ... 
tests-1    |     2025-04-28T21:16:02.310359375Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/18e3bb940a89274fc7f120c4924dc0e1d5d2657fddd1029cebce84ce677841b5.tar.gz
tests-1    |     2025-04-28T21:16:03.810389584Z - Caching plumbertableau.
tests-1    |     2025-04-28T21:16:03.813459084Z - Using cached plumbertableau.
tests-1    |     2025-04-28T21:16:03.813967709Z -       OK (downloaded binary)
tests-1    |     2025-04-28T21:16:03.814055875Z - Installing dplyr (1.1.4) ... 
tests-1    |     2025-04-28T21:16:04.804304959Z - curl: HTTP 200 https://rspm-sync.rstudio.com/bin/4.4-jammy/43d09f17d20c75b1b72e8576cb8a2753e0430bc8fff6a7a831872448e5d0c35c.tar.gz
tests-1    |     2025-04-28T21:16:06.380393335Z - Caching dplyr.
tests-1    |     2025-04-28T21:16:06.383611418Z - Using cached dplyr.
tests-1    |     2025-04-28T21:16:06.384154835Z -       OK (downloaded binary)
tests-1    | --------------------------------------------------
tests-1    | Job logs for job cMMiDwMCGwSrtazt:
tests-1    |     2025-04-28T21:16:06.844677294Z - [rsc-session] Content GUID: 0275d07b-00c8-443f-9651-821938978027
tests-1    |     2025-04-28T21:16:06.845289294Z - [rsc-session] Content ID: 1
tests-1    |     2025-04-28T21:16:06.845292294Z - [rsc-session] Bundle ID: 1
tests-1    |     2025-04-28T21:16:06.845294002Z - [rsc-session] Job Key: cMMiDwMCGwSrtazt
tests-1    |     2025-04-28T21:16:07.33540371Z - Running on host: 396b4d763e20
tests-1    |     2025-04-28T21:16:07.33542196Z - Process ID: 4172
tests-1    |     2025-04-28T21:16:07.441878544Z - Linux distribution: Ubuntu 22.04.5 LTS (jammy)
tests-1    |     2025-04-28T21:16:07.473695461Z - Running as user: uid=999(rstudio-connect) gid=999(rstudio-connect) groups=999(rstudio-connect)
tests-1    |     2025-04-28T21:16:07.473715127Z - Connect version: 2025.03.0
tests-1    |     2025-04-28T21:16:07.473768002Z - LANG: en_US.UTF-8
tests-1    |     2025-04-28T21:16:07.474237419Z - Working directory: /opt/rstudio-connect/mnt/app
tests-1    |     2025-04-28T21:16:07.474640586Z - Using R 4.4.0
tests-1    |     2025-04-28T21:16:07.474647211Z - R.home(): /opt/R/4.4.0/lib/R
tests-1    |     2025-04-28T21:16:07.475115377Z - Content will use associated Packrat library
tests-1    |     2025-04-28T21:16:07.476926752Z - Adding Packrat library to R_LIBS and .libPaths: /opt/rstudio-connect/mnt/app/packrat/lib/x86_64-pc-linux-gnu/4.4.0
tests-1    |     2025-04-28T21:16:07.477055586Z - R_LIBS: /opt/rstudio-connect/mnt/app/packrat/lib/x86_64-pc-linux-gnu/4.4.0
tests-1    |     2025-04-28T21:16:07.477060294Z - .libPaths(): /opt/rstudio-connect/mnt/app/packrat/lib/x86_64-pc-linux-gnu/4.4.0, /opt/R/4.4.0/lib/R/library
tests-1    |     2025-04-28T21:16:07.483451377Z - plumber version: 1.3.0
tests-1    |     2025-04-28T21:16:07.483464044Z - jsonlite version: 2.0.0
tests-1    |     2025-04-28T21:16:07.483496961Z - httpuv version: 1.6.16
tests-1    |     2025-04-28T21:16:07.483497711Z - rmarkdown version: (none)
tests-1    |     2025-04-28T21:16:07.483501336Z - reticulate version: (none)
tests-1    |     2025-04-28T21:16:07.483629419Z - Using pandoc: /opt/rstudio-connect/ext/pandoc/2.16
tests-1    |     2025-04-28T21:16:07.700112836Z - Plumber API starting ...
tests-1    |     2025-04-28T21:16:07.960559544Z - 
tests-1    |     2025-04-28T21:16:07.960573711Z - Attaching package: ‘dplyr’
tests-1    |     2025-04-28T21:16:07.960614961Z - 
tests-1    |     2025-04-28T21:16:07.962013336Z - The following objects are masked from ‘package:stats’:
tests-1    |     2025-04-28T21:16:07.962020294Z - 
tests-1    |     2025-04-28T21:16:07.962042211Z -     filter, lag
tests-1    |     2025-04-28T21:16:07.962043211Z - 
tests-1    |     2025-04-28T21:16:07.962185211Z - The following objects are masked from ‘package:base’:
tests-1    |     2025-04-28T21:16:07.962194711Z - 
tests-1    |     2025-04-28T21:16:07.962205794Z -     intersect, setdiff, setequal, union
tests-1    |     2025-04-28T21:16:07.962206377Z - 
tests-1    |     2025-04-28T21:16:07.966802919Z - Verbose logging is off. To enable it please set the environment variable `DEBUGME` to include `plumbertableau`.
tests-1    |     2025-04-28T21:16:07.966807961Z - 
tests-1    |     2025-04-28T21:16:07.966818419Z - 
tests-1    |     2025-04-28T21:16:08.016713336Z - Running plumber API at http://127.0.0.1:44009
tests-1    |     2025-04-28T21:16:08.179637961Z - Running swagger Docs at http://127.0.0.1:44009/__docs__/
tests-1    | --------------------------------------------------
```