### PR TITLE
Add support for `requiredFeatures` specification

### DIFF
--- a/.github/actions/lint-extension/action.yml
+++ b/.github/actions/lint-extension/action.yml
@@ -36,6 +36,35 @@ runs:
         ' ./extensions/${{ inputs.extension-name }}/manifest.json
       shell: bash
 
+    # Ensures that the manifest.json has only valid requiredFeatures
+    - name: Check required features
+      run: |
+        # Read in valid requiredFeatures from extensions.json
+        VALID_FEATURES=$(jq -c '.requiredFeatures' ./extensions.json)
+        
+        # Read in requiredFeatures from the extension's manifest.json
+        EXTENSION_REQUIRED_FEATURES=$(jq -c '.extension.requiredFeatures // []' ./extensions/${{ inputs.extension-name }}/manifest.json)
+
+        # Check if the extension's requiredFeatures is an array
+        if [ "$(jq -r 'type' <<< "$EXTENSION_REQUIRED_FEATURES")" != "array" ]; then
+          echo "Error: The requiredFeatures in manifest.json must be an array."
+          exit 1
+        fi
+        
+        # Check if any extension requiredFeatures are not in the valid requiredFeatures list
+        INVALID_FEATURES=$(jq -n -c --argjson global "$VALID_FEATURES" --argjson extension "$EXTENSION_REQUIRED_FEATURES" '
+          $extension | map(. as $feature | if ($global | index($feature) | not) then $feature else empty end)
+        ')
+        
+        # Check if there are any invalid requiredFeatures
+        if [ "$INVALID_FEATURES" != "[]" ]; then
+          echo "Error: The following `requiredFeatures` in manifest.json are not defined in extensions.json:"
+          echo "$INVALID_FEATURES"
+          echo "Please add these features to the 'requiredFeatures' array in extensions.json or remove them from the manifest."
+          exit 1
+        fi
+      shell: bash
+
     # Ensures that the manifest.json has only valid tags
     - name: Check tags
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,27 @@ is recorded for that specific release.
 A good Connect Version to start with is `"2025.04.0"` since it is the
 release that introduced the Connect Gallery.
 
+#### Required Connect Features
+
+The `requiredFeatures` field in the `extension` section of the `manifest.json`
+is optional, but if your content requires enhanced features of Posit Connect to
+function correctly it should be included.
+
+For example, if your content requires the API Publishing feature your 
+`manifest.json` should include the following:
+
+```json
+// manifest.json
+
+{
+  ...
+  "extension": {
+    "requiredFeatures": ["API Publishing"],
+    ...
+  }
+}
+```
+
 ### README.md
 
 In the above extension section there is a `homepage` link that we provide in the

--- a/extensions.json
+++ b/extensions.json
@@ -1,5 +1,9 @@
 {
   "tags": [],
+  "requiredFeatures": [
+    "API Publishing",
+    "OAuth Integrations"
+  ],
   "extensions": [
     {
       "name": "connectwidgets-example",

--- a/extensions.json
+++ b/extensions.json
@@ -2,7 +2,8 @@
   "tags": [],
   "requiredFeatures": [
     "API Publishing",
-    "OAuth Integrations"
+    "OAuth Integrations",
+    "Current User Execution"
   ],
   "extensions": [
     {

--- a/extensions/stock-api-fastapi/manifest.json
+++ b/extensions/stock-api-fastapi/manifest.json
@@ -12,6 +12,9 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-fastapi",
     "tags": [],
     "minimumConnectVersion": "2025.04.0",
+    "requiredFeatures": [
+      "API Publishing"
+    ],
     "version": "1.0.0"
   },
   "environment": {

--- a/scripts/types/index.ts
+++ b/scripts/types/index.ts
@@ -6,8 +6,14 @@ export interface ExtensionManifest {
     homepage: string;
     version: string;
     minimumConnectVersion: string;
+    requiredFeatures?: RequiredFeature[];
     tags?: string[];
   };
+}
+
+export enum RequiredFeature {
+  API_PUBLISHING = 'API Publishing',
+  OAUTH_INTEGRATIONS = 'OAuth Integrations',
 }
 
 export interface ExtensionVersion {
@@ -15,6 +21,7 @@ export interface ExtensionVersion {
   released: string;
   url: string;
   minimumConnectVersion: string;
+  requiredFeatures?: RequiredFeature[];
 }
 
 export interface Extension {

--- a/scripts/types/index.ts
+++ b/scripts/types/index.ts
@@ -14,6 +14,7 @@ export interface ExtensionManifest {
 export enum RequiredFeature {
   API_PUBLISHING = 'API Publishing',
   OAUTH_INTEGRATIONS = 'OAuth Integrations',
+  CURRENT_USER_EXECUTION = 'Current User Execution',
 }
 
 export interface ExtensionVersion {


### PR DESCRIPTION
Since Connect licenses have product tiers some items in the Gallery need a way to specify that they require features from Connect that may not be on all instances.

Those include
- [API Publishing](https://docs.posit.co/connect/user/fastapi/index.html)
- [OAuth Integrations](https://docs.posit.co/connect/admin/integrations/oauth-integrations/index.html)
- [Current User Execution](https://docs.posit.co/connect/admin/process-management/index.html#runas-current)

This PR adds support in the form of linting, writing to the extension list, and specifying the required features in the `manifest.json` similar to the `minimumConnectVersion`.

This will help users know if a Gallery item will work on their specific instance.