### PR TITLE
feat: add "content scope" control to megadashboard

### DIFF
--- a/extensions/who-is-visiting-this-content/app.R
+++ b/extensions/who-is-visiting-this-content/app.R
@@ -333,6 +333,16 @@ server <- function(input, output, session) {
     )
   })
 
+  # "Clear filter x" link ----
+
+  observeEvent(input$clear_selection, {
+    updateSelectizeInput(
+      session,
+      "selected_users",
+      selected = NA
+    )
+  })
+
   # Cache invalidation button ----
 
   cache <- cachem::cache_disk("./app_cache/cache/")
@@ -422,17 +432,12 @@ server <- function(input, output, session) {
   scope_choices <- switch(active_user_role,
     "administrator" = list(
       "All Content" = "all",
-      "Content I Can See" = "view",
       "Content I Can Edit" = "edit",
       "Content I Own" = "own"
     ),
     "publisher" = list(
-      "Content I Can See" = "view",
       "Content I Can Edit" = "edit",
       "Content I Own" = "own"
-    ),
-    "viewer" = list(
-      "Content I Can See" = "view"
     ),
     NULL
   )

--- a/extensions/who-is-visiting-this-content/app.R
+++ b/extensions/who-is-visiting-this-content/app.R
@@ -435,11 +435,10 @@ server <- function(input, output, session) {
       "Owned + Collaborating" = "edit",
       "Owned" = "own"
     ),
-    "publisher" = list(
+    list(
       "Owned + Collaborating" = "edit",
       "Owned" = "own"
-    ),
-    NULL
+    )
   )
 
   observe({

--- a/extensions/who-is-visiting-this-content/app.R
+++ b/extensions/who-is-visiting-this-content/app.R
@@ -121,7 +121,7 @@ ui <- function(request) {
         "input.content_guid == null",
         selectizeInput(
           "content_scope",
-          "Content Scope",
+          "Included Content",
           choices = NULL
         ),
         selectizeInput(
@@ -432,12 +432,12 @@ server <- function(input, output, session) {
   scope_choices <- switch(active_user_role,
     "administrator" = list(
       "All Content" = "all",
-      "Content I Can Edit" = "edit",
-      "Content I Own" = "own"
+      "Owned + Collaborating" = "edit",
+      "Owned" = "own"
     ),
     "publisher" = list(
-      "Content I Can Edit" = "edit",
-      "Content I Own" = "own"
+      "Owned + Collaborating" = "edit",
+      "Owned" = "own"
     ),
     NULL
   )

--- a/extensions/who-is-visiting-this-content/app.R
+++ b/extensions/who-is-visiting-this-content/app.R
@@ -442,18 +442,20 @@ server <- function(input, output, session) {
     updateSelectizeInput(session, "content_scope", choices = scope_choices, selected = scope_choices[1])
   })
 
+  content_unscoped <- reactive({
+    get_content(client)
+  }) |> bindCache(active_user_guid)
+
   content <- reactive({
     req(input$content_scope)
 
-    all_content <- get_content(client)
-
     switch(input$content_scope,
-      "all" = all_content,
-      "view" = all_content |> filter(app_role != "none"),
-      "edit" = all_content |> filter(app_role %in% c("owner", "editor")),
-      "own" = all_content |> filter(app_role == "owner")
+      "all" = content_unscoped(),
+      "view" = content_unscoped() |> filter(app_role != "none"),
+      "edit" = content_unscoped() |> filter(app_role %in% c("owner", "editor")),
+      "own" = content_unscoped() |> filter(app_role == "owner")
     )
-  }) |> bindCache(active_user_guid, input$content_scope)
+  })
 
   date_range <- reactive({
     switch(input$date_range_choice,


### PR DESCRIPTION
## Overview

This PR adds a dropdown menu to the sidebar allowing users to select the set of content they see.

Different account roles on Connect get different options:

- Administrators see "All Content", "Owned + Collaborating", and "Owned"
- Publishers see "Owned + Collaborating" and "Owned"
- Viewers still see the Publisher choices in the dropdown (i.e. the Publisher choices are the fallback), but since they don't own or collaborate on any content, they can't see its usage metrics).

These correspond to the following. I don't love the language on these — I've gone back and forth on many different options and would love feedback):

- "All Content" just gets… all content.
- "Owned + Collaborating": content where `user_role` is `owner` or `editor` — for publishers, this includes both their owned content and content they collaborate on.
- "Owned": content where `user_role` is `owner`

When a Viewer account loads the app, they see a message stating that Viewers can't see usage data. When a Publisher or Admin loads the account, but their filters lead there to be no usage data, a different message is displayed.

![Screen Shot 2025-05-01 at 12 49 42 PM](https://github.com/user-attachments/assets/5e51509e-3ec6-446b-932c-9d9a2abd5d59)
![Screen Shot 2025-05-01 at 11 48 42 AM@2x](https://github.com/user-attachments/assets/f0222401-806f-40c9-aef1-bdf4eceae20c)

### Test Deployments

It's deployed to Dogfood and connect.posit.it. Note that the draft deployment on connect.posit.it now displays a narrow set of content. Before, it displayed metrics for all content you had permission to _view_ — now it shows only content that you that is owned by you or that you are collaborating on.

- https://connect.posit.it/megadashboard/
- https://dogfood.team.pct.posit.it/megadashboard/

---

We will want to check this on a live server with different user account roles (e.g. a Publisher and a Viewer account) and app roles (i.e. a Publisher who is be a collaborator on a content item).

---

Earlier, I had planned a broader set of scopes, but the firehose only lets you retrieve metrics for content you own or collaborate on unless you're an Administrator.

> - Administrators see "All Content", "Content I Can See", "Content I Can Edit", and "Content I Own"
> - Publishers see "Content I Can See", "Content I Can Edit", and "Content I Own"
> - Viewers see "Content I Can See"
> 
> These correspond to the following:
> 
> - "All Content" just gets… all content.
> - "Content I Can See": content where `user_role` is not `none` — this is different for admins than "all content on the server" and the most inclusive set for other users.
> - "Content I Can Edit": content where `user_role` is `owner` or `editor` — for publishers, this includes both their owned content and content they collaborate on.
> - "Content I Own": content where `user_role` is `owner` — self-explanatory.