### PR TITLE
Removing `teardown_method`

### DIFF
--- a/integration/tests/posit/connect/test_deployments.py
+++ b/integration/tests/posit/connect/test_deployments.py
@@ -34,11 +34,6 @@ class TestExtensionDeployment:
         # Store initial content GUID for verification in teardown
         self.content_guid = self.content["guid"]
 
-    def teardown_method(self):
-        """Clean up any content created during the test."""
-        self.content.delete()
-        assert self.client.content.count() == 0, "Content not deleted after test"
-
     def test_extension_deploys(self):
         """Test that an Extension can be deployed and started successfully in Posit Connect."""
         # Get the bundle path using the container mount path


### PR DESCRIPTION
After doing some digging with @cgraham-rs, we discovered the `pins_tutorials` creates two pieces of content. One is the written instructions of how pins work in Connect and the other is an example of pins. The `teardown_method` uses the [delete](https://posit-dev.github.io/posit-sdk-py/reference/connect.content.html#posit.connect.content.ContentItem.delete) method to remove a piece of content. This `teardown_method` targets the actual tutorial, but the example generated by the tutorial remains. This fails the following assertion:
```
assert self.client.content.count() == 0, "Content not deleted after test"
```

We are temporarily removing this method, but we should reconsider if such a method could be added back, but be flexible enough to accept scenarios where pieces of content generate other content items.