### PR TITLE
Add `requiredEnvironment` to extension list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,14 +143,21 @@ Here is an example of what needs to be included in a `manifest.json`:
   ...
   "environment": {
     "python": {
-      "requires": ">=3.8, <4"
+      "requires": "~=3.8"
     },
     "r": {
-      "requires": ">=4.2, <5"
+      "requires": "~=4.2"
     }
   }
 }
 ```
+
+It is recommended to use the `~=` operator to specify the version of the
+language(s) that the content requires for concise display in the Connect Gallery
+UI.
+
+`~=` is the "Compatible release" operator. `~=4.2` means "any version greater
+than or equal to 4.2 but less than 5.0".
 
 ## Adding content to the Connect Gallery
 

--- a/extensions.json
+++ b/extensions.json
@@ -159,14 +159,24 @@
         "version": "0.0.1",
         "released": "2025-05-01T18:23:36Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/portfolio-report%40v0.0.1/portfolio-report.tar.gz",
-        "minimumConnectVersion": "2025.04.0"
+        "minimumConnectVersion": "2025.04.0",
+        "requiredEnvironment": {
+          "r": {
+            "requires": "~=4.4"
+          }
+        }
       },
       "versions": [
         {
           "version": "0.0.1",
           "released": "2025-05-01T18:23:36Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/portfolio-report%40v0.0.1/portfolio-report.tar.gz",
-          "minimumConnectVersion": "2025.04.0"
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "r": {
+              "requires": "~=4.4"
+            }
+          }
         }
       ],
       "tags": []

--- a/extensions.json
+++ b/extensions.json
@@ -15,14 +15,24 @@
         "version": "0.0.1",
         "released": "2025-04-24T19:17:16Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/connectwidgets-example%40v0.0.1/connectwidgets-example.tar.gz",
-        "minimumConnectVersion": "2025.04.0"
+        "minimumConnectVersion": "2025.04.0",
+        "requiredEnvironment": {
+          "r": {
+            "requires": "~=4.0"
+          }
+        }
       },
       "versions": [
         {
           "version": "0.0.1",
           "released": "2025-04-24T19:17:16Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/connectwidgets-example%40v0.0.1/connectwidgets-example.tar.gz",
-          "minimumConnectVersion": "2025.04.0"
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "r": {
+              "requires": "~=4.0"
+            }
+          }
         }
       ],
       "tags": []
@@ -36,14 +46,24 @@
         "version": "1.0.0",
         "released": "2025-04-24T19:38:18Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/fastapitableau-example%40v1.0.0/fastapitableau-example.tar.gz",
-        "minimumConnectVersion": "2025.04.0"
+        "minimumConnectVersion": "2025.04.0",
+        "requiredEnvironment": {
+          "python": {
+            "requires": "~=3.9"
+          }
+        }
       },
       "versions": [
         {
           "version": "1.0.0",
           "released": "2025-04-24T19:38:18Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/fastapitableau-example%40v1.0.0/fastapitableau-example.tar.gz",
-          "minimumConnectVersion": "2025.04.0"
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "python": {
+              "requires": "~=3.9"
+            }
+          }
         }
       ],
       "tags": []
@@ -78,14 +98,24 @@
         "version": "1.0.0",
         "released": "2025-04-29T18:05:16Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/plumbertableau-example%40v1.0.0/plumbertableau-example.tar.gz",
-        "minimumConnectVersion": "2025.04.0"
+        "minimumConnectVersion": "2025.04.0",
+        "requiredEnvironment": {
+          "r": {
+            "requires": "~=4.4"
+          }
+        }
       },
       "versions": [
         {
           "version": "1.0.0",
           "released": "2025-04-29T18:05:16Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/plumbertableau-example%40v1.0.0/plumbertableau-example.tar.gz",
-          "minimumConnectVersion": "2025.04.0"
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "r": {
+              "requires": "~=4.4"
+            }
+          }
         }
       ],
       "tags": []
@@ -99,14 +129,24 @@
         "version": "0.0.1",
         "released": "2025-04-11T21:32:23Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/portfolio-dashboard%40v0.0.1/portfolio-dashboard.tar.gz",
-        "minimumConnectVersion": "2025.04.0"
+        "minimumConnectVersion": "2025.04.0",
+        "requiredEnvironment": {
+          "r": {
+            "requires": "~=4.4"
+          }
+        }
       },
       "versions": [
         {
           "version": "0.0.1",
           "released": "2025-04-11T21:32:23Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/portfolio-dashboard%40v0.0.1/portfolio-dashboard.tar.gz",
-          "minimumConnectVersion": "2025.04.0"
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "r": {
+              "requires": "~=4.4"
+            }
+          }
         }
       ]
     },
@@ -140,14 +180,24 @@
         "version": "0.0.1",
         "released": "2025-03-19T23:00:09Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/publisher-command-center%40v0.0.1/publisher-command-center.tar.gz",
-        "minimumConnectVersion": "2025.04.0"
+        "minimumConnectVersion": "2025.04.0",
+        "requiredEnvironment": {
+          "python": {
+            "requires": "~=3.8"
+          }
+        }
       },
       "versions": [
         {
           "version": "0.0.1",
           "released": "2025-03-19T23:00:09Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/publisher-command-center%40v0.0.1/publisher-command-center.tar.gz",
-          "minimumConnectVersion": "2025.04.0"
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "python": {
+              "requires": "~=3.8"
+            }
+          }
         }
       ]
     },
@@ -180,14 +230,24 @@
         "version": "1.0.0",
         "released": "2025-04-14T18:38:38Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/quarto-stock-report-python%40v1.0.0/quarto-stock-report-python.tar.gz",
-        "minimumConnectVersion": "2025.04.0"
+        "minimumConnectVersion": "2025.04.0",
+        "requiredEnvironment": {
+          "python": {
+            "requires": "~=3.9"
+          }
+        }
       },
       "versions": [
         {
           "version": "1.0.0",
           "released": "2025-04-14T18:38:38Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/quarto-stock-report-python%40v1.0.0/quarto-stock-report-python.tar.gz",
-          "minimumConnectVersion": "2025.04.0"
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "python": {
+              "requires": "~=3.9"
+            }
+          }
         }
       ]
     },
@@ -200,20 +260,35 @@
         "version": "0.0.2",
         "released": "2025-04-16T22:32:48Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/reaper%40v0.0.2/reaper.tar.gz",
-        "minimumConnectVersion": "2025.04.0"
+        "minimumConnectVersion": "2025.04.0",
+        "requiredEnvironment": {
+          "python": {
+            "requires": "~=3.8"
+          }
+        }
       },
       "versions": [
         {
           "version": "0.0.2",
           "released": "2025-04-16T22:32:48Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/reaper%40v0.0.2/reaper.tar.gz",
-          "minimumConnectVersion": "2025.04.0"
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "python": {
+              "requires": "~=3.8"
+            }
+          }
         },
         {
           "version": "0.0.1",
           "released": "2025-03-19T22:59:58Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/reaper%40v0.0.1/reaper.tar.gz",
-          "minimumConnectVersion": "2025.04.0"
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "python": {
+              "requires": "~=3.8"
+            }
+          }
         }
       ]
     },
@@ -226,14 +301,24 @@
         "version": "1.0.0",
         "released": "2025-04-24T18:56:34Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/stock-api-fastapi%40v1.0.0/stock-api-fastapi.tar.gz",
-        "minimumConnectVersion": "2025.04.0"
+        "minimumConnectVersion": "2025.04.0",
+        "requiredEnvironment": {
+          "python": {
+            "requires": "~=3.11"
+          }
+        }
       },
       "versions": [
         {
           "version": "1.0.0",
           "released": "2025-04-24T18:56:34Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/stock-api-fastapi%40v1.0.0/stock-api-fastapi.tar.gz",
-          "minimumConnectVersion": "2025.04.0"
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "python": {
+              "requires": "~=3.11"
+            }
+          }
         }
       ],
       "tags": []
@@ -247,14 +332,24 @@
         "version": "1.0.0",
         "released": "2025-04-24T19:12:11Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/stock-api-flask%40v1.0.0/stock-api-flask.tar.gz",
-        "minimumConnectVersion": "2025.04.0"
+        "minimumConnectVersion": "2025.04.0",
+        "requiredEnvironment": {
+          "python": {
+            "requires": "~=3.10"
+          }
+        }
       },
       "versions": [
         {
           "version": "1.0.0",
           "released": "2025-04-24T19:12:11Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/stock-api-flask%40v1.0.0/stock-api-flask.tar.gz",
-          "minimumConnectVersion": "2025.04.0"
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "python": {
+              "requires": "~=3.10"
+            }
+          }
         }
       ],
       "tags": []
@@ -268,14 +363,24 @@
         "version": "1.0.0",
         "released": "2025-04-25T18:11:56Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/stock-api-plumber%40v1.0.0/stock-api-plumber.tar.gz",
-        "minimumConnectVersion": "2025.04.0"
+        "minimumConnectVersion": "2025.04.0",
+        "requiredEnvironment": {
+          "r": {
+            "requires": "~=4.4"
+          }
+        }
       },
       "versions": [
         {
           "version": "1.0.0",
           "released": "2025-04-25T18:11:56Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/stock-api-plumber%40v1.0.0/stock-api-plumber.tar.gz",
-          "minimumConnectVersion": "2025.04.0"
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "r": {
+              "requires": "~=4.4"
+            }
+          }
         }
       ],
       "tags": []

--- a/extensions/connectwidgets-example/manifest.json
+++ b/extensions/connectwidgets-example/manifest.json
@@ -19,7 +19,7 @@
   },
   "environment": {
     "r": {
-      "requires": ">=4.0"
+      "requires": "~=4.0"
     }
   },
   "packages": {

--- a/extensions/fastapitableau-example/manifest.json
+++ b/extensions/fastapitableau-example/manifest.json
@@ -15,7 +15,7 @@
   },
   "environment": {
     "python": {
-      "requires": ">=3.9, <4"
+      "requires": "~=3.9"
     }
   },
   "python": {

--- a/extensions/plumbertableau-example/manifest.json
+++ b/extensions/plumbertableau-example/manifest.json
@@ -20,7 +20,7 @@
   },
   "environment": {
     "r": {
-      "requires": ">=4.4.0, <5"
+      "requires": "~=4.4.0"
     }
   },
   "packages": {

--- a/extensions/portfolio-dashboard/manifest.json
+++ b/extensions/portfolio-dashboard/manifest.json
@@ -12,7 +12,7 @@
   },
   "environment": {
     "r": {
-      "requires": ">=4.4"
+      "requires": "~=4.4"
     }
   },
   "metadata": {

--- a/extensions/portfolio-report/manifest.json
+++ b/extensions/portfolio-report/manifest.json
@@ -19,7 +19,7 @@
   },
   "environment": {
     "r": {
-      "requires": ">=4.4.0"
+      "requires": "~=4.4"
     }
   },
   "packages": {

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -13,7 +13,7 @@
 	},
 	"environment": {
 		"python": {
-			"requires": ">=3.8, <4"
+			"requires": "~=3.8"
 		}
 	},
 	"packages": {},

--- a/extensions/quarto-stock-report-python/manifest.json
+++ b/extensions/quarto-stock-report-python/manifest.json
@@ -14,7 +14,7 @@
   },
   "environment": {
     "python": {
-      "requires": ">=3.9, <4"
+      "requires": "~=3.9"
     }
   },
   "quarto": {

--- a/extensions/reaper/manifest.json
+++ b/extensions/reaper/manifest.json
@@ -15,7 +15,7 @@
   },
   "environment": {
     "python": {
-      "requires": ">=3.8, <4"
+      "requires": "~=3.8"
     }
   },
   "files": {

--- a/extensions/stock-api-fastapi/manifest.json
+++ b/extensions/stock-api-fastapi/manifest.json
@@ -19,7 +19,7 @@
   },
   "environment": {
     "python": {
-      "requires": ">=3.11, <4"
+      "requires": "~=3.11"
     }
   },
   "python": {

--- a/extensions/stock-api-flask/manifest.json
+++ b/extensions/stock-api-flask/manifest.json
@@ -16,7 +16,7 @@
   },
   "environment": {
     "python": {
-      "requires": ">=3.10, <4"
+      "requires": "~=3.10"
     }
   },
   "python": {

--- a/extensions/stock-api-plumber/manifest.json
+++ b/extensions/stock-api-plumber/manifest.json
@@ -19,7 +19,7 @@
   },
   "environment": {
     "r": {
-      "requires": ">=4.4.0, <5"
+      "requires": "~=4.4"
     }
   },
   "packages": {

--- a/scripts/extension-list.ts
+++ b/scripts/extension-list.ts
@@ -74,7 +74,7 @@ class ExtensionList {
       url: browser_download_url,
       minimumConnectVersion: minimumConnectVersion,
       ...(requiredFeatures ? { requiredFeatures } : {}),
-      requiredEnvironment: manifest.environment,
+      ...(manifest.environment ? { requiredEnvironment: manifest.environment } : {}),
     };
 
     if (this.getExtension(name)) {

--- a/scripts/extension-list.ts
+++ b/scripts/extension-list.ts
@@ -74,6 +74,7 @@ class ExtensionList {
       url: browser_download_url,
       minimumConnectVersion: minimumConnectVersion,
       ...(requiredFeatures ? { requiredFeatures } : {}),
+      requiredEnvironment: manifest.environment,
     };
 
     if (this.getExtension(name)) {

--- a/scripts/types/index.ts
+++ b/scripts/types/index.ts
@@ -1,3 +1,13 @@
+export interface LanguageRequirement {
+  requires: string;
+}
+
+export interface ExtensionEnvironment {
+  python?: LanguageRequirement;
+  r?: LanguageRequirement;
+  quarto?: LanguageRequirement;
+}
+
 export interface ExtensionManifest {
   extension: {
     name: string;
@@ -9,6 +19,7 @@ export interface ExtensionManifest {
     requiredFeatures?: RequiredFeature[];
     tags?: string[];
   };
+  environment?: ExtensionEnvironment;
 }
 
 export enum RequiredFeature {
@@ -23,6 +34,7 @@ export interface ExtensionVersion {
   url: string;
   minimumConnectVersion: string;
   requiredFeatures?: RequiredFeature[];
+  requiredEnvironment?: ExtensionEnvironment;
 }
 
 export interface Extension {


### PR DESCRIPTION
This PR includes a new field in the extension list (`extensions.json`) called `requiredEnvironment`. It sits inside of each content version (similar to `minimumConnectVersion`) and uses the `manifest.json`'s `environment` language version constraints specification to fill it. They use the same syntax.

This will enable the Connect UI to display and eventually behave differently based on the required language versions for each content item.

Each of the released items in the extension list have had the new field back-ported by manually adding it.

The CONTRIBUTING guide has been updated to recommend concise version constraints for better display in the Gallery, and `manifest.json` files have been adjusted to follow that guideline.