### PR TITLE
Backport `requiredFeatures` in extension list and manifests

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -47,6 +47,9 @@
         "released": "2025-04-24T19:38:18Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/fastapitableau-example%40v1.0.0/fastapitableau-example.tar.gz",
         "minimumConnectVersion": "2025.04.0",
+        "requiredFeatures": [
+          "API Publishing"
+        ],
         "requiredEnvironment": {
           "python": {
             "requires": "~=3.9"
@@ -59,6 +62,9 @@
           "released": "2025-04-24T19:38:18Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/fastapitableau-example%40v1.0.0/fastapitableau-example.tar.gz",
           "minimumConnectVersion": "2025.04.0",
+          "requiredFeatures": [
+            "API Publishing"
+          ],
           "requiredEnvironment": {
             "python": {
               "requires": "~=3.9"
@@ -99,6 +105,9 @@
         "released": "2025-04-29T18:05:16Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/plumbertableau-example%40v1.0.0/plumbertableau-example.tar.gz",
         "minimumConnectVersion": "2025.04.0",
+        "requiredFeatures": [
+          "API Publishing"
+        ],
         "requiredEnvironment": {
           "r": {
             "requires": "~=4.4"
@@ -111,6 +120,9 @@
           "released": "2025-04-29T18:05:16Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/plumbertableau-example%40v1.0.0/plumbertableau-example.tar.gz",
           "minimumConnectVersion": "2025.04.0",
+          "requiredFeatures": [
+            "API Publishing"
+          ],
           "requiredEnvironment": {
             "r": {
               "requires": "~=4.4"
@@ -191,6 +203,10 @@
         "released": "2025-03-19T23:00:09Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/publisher-command-center%40v0.0.1/publisher-command-center.tar.gz",
         "minimumConnectVersion": "2025.04.0",
+        "requiredFeatures": [
+          "API Publishing",
+          "OAuth Integrations"
+        ],
         "requiredEnvironment": {
           "python": {
             "requires": "~=3.8"
@@ -203,6 +219,10 @@
           "released": "2025-03-19T23:00:09Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/publisher-command-center%40v0.0.1/publisher-command-center.tar.gz",
           "minimumConnectVersion": "2025.04.0",
+          "requiredFeatures": [
+            "API Publishing",
+            "OAuth Integrations"
+          ],
           "requiredEnvironment": {
             "python": {
               "requires": "~=3.8"
@@ -312,6 +332,9 @@
         "released": "2025-04-24T18:56:34Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/stock-api-fastapi%40v1.0.0/stock-api-fastapi.tar.gz",
         "minimumConnectVersion": "2025.04.0",
+        "requiredFeatures": [
+          "API Publishing"
+        ],
         "requiredEnvironment": {
           "python": {
             "requires": "~=3.11"
@@ -324,6 +347,9 @@
           "released": "2025-04-24T18:56:34Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/stock-api-fastapi%40v1.0.0/stock-api-fastapi.tar.gz",
           "minimumConnectVersion": "2025.04.0",
+          "requiredFeatures": [
+            "API Publishing"
+          ],
           "requiredEnvironment": {
             "python": {
               "requires": "~=3.11"
@@ -343,6 +369,9 @@
         "released": "2025-04-24T19:12:11Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/stock-api-flask%40v1.0.0/stock-api-flask.tar.gz",
         "minimumConnectVersion": "2025.04.0",
+        "requiredFeatures": [
+          "API Publishing"
+        ],
         "requiredEnvironment": {
           "python": {
             "requires": "~=3.10"
@@ -355,6 +384,9 @@
           "released": "2025-04-24T19:12:11Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/stock-api-flask%40v1.0.0/stock-api-flask.tar.gz",
           "minimumConnectVersion": "2025.04.0",
+          "requiredFeatures": [
+            "API Publishing"
+          ],
           "requiredEnvironment": {
             "python": {
               "requires": "~=3.10"
@@ -374,6 +406,9 @@
         "released": "2025-04-25T18:11:56Z",
         "url": "https://github.com/posit-dev/connect-extensions/releases/download/stock-api-plumber%40v1.0.0/stock-api-plumber.tar.gz",
         "minimumConnectVersion": "2025.04.0",
+        "requiredFeatures": [
+          "API Publishing"
+        ],
         "requiredEnvironment": {
           "r": {
             "requires": "~=4.4"
@@ -386,6 +421,9 @@
           "released": "2025-04-25T18:11:56Z",
           "url": "https://github.com/posit-dev/connect-extensions/releases/download/stock-api-plumber%40v1.0.0/stock-api-plumber.tar.gz",
           "minimumConnectVersion": "2025.04.0",
+          "requiredFeatures": [
+            "API Publishing"
+          ],
           "requiredEnvironment": {
             "r": {
               "requires": "~=4.4"

--- a/extensions/fastapitableau-example/manifest.json
+++ b/extensions/fastapitableau-example/manifest.json
@@ -11,6 +11,9 @@
     "description": "fastapitableau is a Python package that enables Python developers to build FastAPI APIs that function as Tableau Analytics Extensions. These extensions can be leveraged from Tableau workbooks to allow real time requests from Tableau to Python. This extension builds on top of Tableau's example Superstore dataset.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/fastapitableau-example",
     "minimumConnectVersion": "2025.04.0",
+    "requiredFeatures": [
+      "API Publishing"
+    ],
     "version": "1.0.0"
   },
   "environment": {

--- a/extensions/plumbertableau-example/manifest.json
+++ b/extensions/plumbertableau-example/manifest.json
@@ -16,6 +16,9 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/plumbertableau-example",
     "tags": [],
     "minimumConnectVersion": "2025.04.0",
+    "requiredFeatures": [
+      "API Publishing"
+    ],
     "version": "1.0.0"
   },
   "environment": {

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -64,6 +64,10 @@
 		"description": "A dashboard for publishers to help manage and track their content",
 		"homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/publisher-command-center",
 		"minimumConnectVersion": "2025.04.0",
+		"requiredFeatures": [
+			"API Publishing",
+			"OAuth Integrations"
+		],
 		"version": "0.0.1"
 	}
 }

--- a/extensions/stock-api-flask/manifest.json
+++ b/extensions/stock-api-flask/manifest.json
@@ -12,6 +12,9 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-flask",
     "tags": [],
     "minimumConnectVersion": "2025.04.0",
+    "requiredFeatures": [
+      "API Publishing"
+    ],
     "version": "1.0.0"
   },
   "environment": {

--- a/extensions/stock-api-plumber/manifest.json
+++ b/extensions/stock-api-plumber/manifest.json
@@ -15,7 +15,10 @@
     "description": "An API allows you to turn your models into production services that other tools and teams can use. APIs are a great way for software engineering teams to use your models without translating them into different languages.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-plumber",
     "version": "1.0.0",
-    "minimumConnectVersion": "2025.04.0"
+    "minimumConnectVersion": "2025.04.0",
+    "requiredFeatures": [
+      "API Publishing"
+    ]
   },
   "environment": {
     "r": {


### PR DESCRIPTION
This PR follows up with #84 to backport the `requiredFeatures` into the manifests and extension list for added content that requires features.

Most are API Publishing requirements, the one exception is Publisher Command Center which requires OAuth Integration setup to function.