### PR TITLE
Add vetiver-for-python

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -34,6 +34,7 @@ jobs:
             quarto-stock-report-python: extensions/quarto-stock-report-python/**
             portfolio-dashboard: extensions/portfolio-dashboard/**
             quarto-document: extensions/quarto-document/**
+            vetiver-for-python: extensions/vetiver-for-python/**
             stock-api-plumber: extensions/stock-api-plumber/**
             stock-api-flask: extensions/stock-api-flask/**
             landing-page: extensions/landing-page/**

--- a/extensions/vetiver-for-python/README.md
+++ b/extensions/vetiver-for-python/README.md
@@ -1,0 +1,17 @@
+# Deploy Model
+
+## About this example
+
+Using vetiver allows you to version and deploy your ML model as a production service that other tools and teams can use. APIs like those created with vetiver are a great way for software engineering teams to use your models without translating them into different languages.
+
+
+## Learn more
+
+* [MLOps with vetiver](https://vetiver.rstudio.com/)
+* [vetiver Python function reference](https://rstudio.github.io/vetiver-python/)
+* [Use vetiver on Connect](https://docs.posit.co/connect/user/vetiver/)
+
+## Requirements
+
+* Posit Connect license allows API publishing
+* Python version 3.8 or higher

--- a/extensions/vetiver-for-python/manifest.json
+++ b/extensions/vetiver-for-python/manifest.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "locale": "en_US.UTF-8",
+  "metadata": {
+    "appmode": "quarto-static"
+  },
+  "extension": {
+    "name": "vetiver-for-python",
+    "title": "Deploy Models with Vetiver for Python",
+    "description": "Using vetiver allows you to version and deploy your ML model as a production service that other tools and teams can use. APIs like those created with vetiver are a great way for software engineering teams to use your models without translating them into different languages.",
+    "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/vetiver-for-python",
+    "tags": ["Jump Start"],
+    "minimumConnectVersion": "2025.04.0",
+    "version": "1.0.0"
+  },
+  "environment": {
+    "python": {
+      "requires": "~=3.8"
+    },
+    "quarto": {
+      "requires": "~=1.4"
+    }
+  },
+  "quarto": {
+    "version": "1.4.557",
+    "engines": [
+      "jupyter"
+    ]
+  },
+  "python": {
+    "version": "3.11.7",
+    "package_manager": {
+      "name": "pip",
+      "version": "24.2",
+      "package_file": "requirements.txt"
+    }
+  },
+  "files": {
+    "requirements.txt": {
+      "checksum": "1130b244b7b45e6345d267a43d9f3b0e"
+    },
+    "vetiver.qmd": {
+      "checksum": "beb1cc1f8163cf999b52bcc82cb795d2"
+    }
+  }
+}

--- a/extensions/vetiver-for-python/requirements.txt
+++ b/extensions/vetiver-for-python/requirements.txt
@@ -1,0 +1,5 @@
+pins==0.8.4
+python-dotenv==1.0.1
+rsconnect-python==1.22.0
+scikit-learn==1.5.0
+vetiver==0.2.4

--- a/extensions/vetiver-for-python/vetiver.qmd
+++ b/extensions/vetiver-for-python/vetiver.qmd
@@ -1,0 +1,106 @@
+---
+title: "Version and deploy your model with vetiver"
+format:
+  html:
+    toc: true
+---
+
+# Outline
+
+This Jump Start example provides an example for you to follow along with to:
+
+- Version a trained model using [pins](https://docs.posit.co/connect/user/pins/)
+- Deploy the model as an API
+
+# Prework: Environment Variables
+
+Prior to beginning, environment variables must be set in your development environment for vetiver to work on Connect.
+
+1.  Create an API key for Posit Connect: [Learn How](https://docs.posit.co/connect/user/api-keys/)
+2.  Create a `.env` file in your working directory to store the API key and Posit Connect server address variables.
+
+Example `.env` file contents:
+
+```{verbatim}
+CONNECT_SERVER=<your-connect-server>
+CONNECT_API_KEY=<your-connect-api-key>
+```
+
+# Create a vetiver model
+
+For this example, let’s work with data on fuel efficiency for cars to predict miles per gallon.
+
+```{python}
+from vetiver.data import mtcars
+from sklearn import linear_model
+
+car_mod = linear_model.LinearRegression().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
+```
+
+This model uses the `LinearRegression()` model in scikit-learn, but you can use vetiver with [many kinds of models trained in Python](https://vetiver.rstudio.com/get-started/#installation).
+
+We can create a `VetiverModel()` in Python from the trained model; a vetiver model object collects the information needed to store, version, and deploy a trained model.
+
+```{python}
+from vetiver import VetiverModel
+v = VetiverModel(car_mod, model_name = "my.username/cars-mpg", 
+                prototype_data = mtcars.drop(columns="mpg"))
+v.description
+```
+
+Think of this vetiver model as a deployable model object.
+
+:::{.callout-note}
+Note that the model was stored as `my.username/cars-mpg`, where `my.username` is _your_ username on your Connect server.
+:::
+
+# Store and version your model
+
+You can store and version your model by using Connect as a pins "board". 
+
+:::{.callout-tip}
+For more on using pins for Python, see the [Connect pins docs](https://docs.posit.co/connect/user/python-pins/). 
+:::
+
+When we write the vetiver model to our board, the binary model object is stored on our board together with necessary metadata, like the packages needed to make a prediction and the model's input data prototype for checking new data at prediction time.
+
+```{python}
+import os
+from pins import board_connect
+from vetiver import vetiver_pin_write
+from dotenv import load_dotenv
+
+load_dotenv()
+
+rsc_server = os.getenv("CONNECT_SERVER")
+rsc_key = os.getenv("CONNECT_API_KEY")
+
+board = board_connect(api_key = rsc_key, server_url = rsc_server, allow_pickle_read = True)
+vetiver_pin_write(board, v)
+```
+
+If you train a different model (say, a different kind of model or with updated data) you can store the new model in the same pin; you will have access to both.
+
+# Deploy your model
+
+You can deploy your model with the function `deploy_rsconnect()`.
+
+:::{.callout-tip}
+*Before you run the next code chunk*: Update `my.username` to your own username on your Connect server.
+:::
+
+```{python}
+from rsconnect.api import RSConnectServer
+from vetiver import deploy_rsconnect
+
+connect_server = RSConnectServer(url = rsc_server, api_key = rsc_key)
+
+deploy_rsconnect(
+  connect_server = connect_server, 
+  board = board, 
+  pin_name = "my.username/cars-mpg"
+)
+```
+  
+Now you can interact with the visual documentation for your deployed model at its new URL on Connect, or [even get predictions from Python](https://docs.posit.co/connect/user/vetiver/#predict-from-your-model-endpoint).
+  


### PR DESCRIPTION
Currently errors with
```
tests-1    | E                       '2025/05/09 15:17:41.001011357 \x1b[31mPinsError\x1b[39m: You '
tests-1    | E                       'are connected as __bootstrap_admin__, but you are trying to '
tests-1    | E                       'create a new piece of content for another user '
tests-1    | E                       '(my.username/cars-mpg). They must create the content before you '
tests-1    | E                       'can write to it.',
```

The .qmd includes the following directions which indicate this may not be a good candidate for the Gallery.

```
Prior to beginning, environment variables must be set in your development environment for vetiver to work on Connect.

1.  Create an API key for Posit Connect: [Learn How](https://docs.posit.co/connect/user/api-keys/)
2.  Create a `.env` file in your working directory to store the API key and Posit Connect server address variables.
```