### PR TITLE
Publisher Command Center: Add link to access page in a collaborators section

### DIFF
--- a/extensions/publisher-command-center/src/components/Collaborators.js
+++ b/extensions/publisher-command-center/src/components/Collaborators.js
@@ -15,7 +15,7 @@ export default {
           m("small.text-body-secondary.align-items-center", [
             m(".fa-solid.fa-user-lock"),
             " ",
-            m("a", { href: accessUrl, target: "_blank" }, "Manage Access"),
+            m("a", { href: accessUrl, target: "_blank" }, "See Collaborators and Manage Access"),
           ])
         ),
       ]),

--- a/extensions/publisher-command-center/src/components/Collaborators.js
+++ b/extensions/publisher-command-center/src/components/Collaborators.js
@@ -1,0 +1,24 @@
+import m from "mithril";
+
+import Content from "../models/Content";
+
+export default {
+  view: function () {
+    const content = Content.data;
+    const accessUrl = content?.dashboard_url ? `${content.dashboard_url}/access` : "#";
+
+    return m(".pt-3.border-top", [
+      m(".", [
+        m("h5", "Collaborators"),
+        m(
+          "p",
+          m("small.text-body-secondary.align-items-center", [
+            m(".fa-solid.fa-user-lock"),
+            " ",
+            m("a", { href: accessUrl, target: "_blank" }, "Manage Access"),
+          ])
+        ),
+      ]),
+    ]);
+  },
+};

--- a/extensions/publisher-command-center/src/views/Edit.js
+++ b/extensions/publisher-command-center/src/views/Edit.js
@@ -5,7 +5,7 @@ import About from "../components/About";
 import Releases from "../components/Releases";
 import Processes from "../components/Processes";
 import Author from "../components/Author";
-
+import Collaborators from "../components/Collaborators";
 import Languages from "../components/Languages";
 
 const Edit = {
@@ -70,6 +70,9 @@ const Edit = {
             created: content?.created_time,
           }),
           m(Author, {
+            content_id: content?.guid,
+          }),
+          m(Collaborators, {
             content_id: content?.guid,
           }),
           m(Releases, {


### PR DESCRIPTION
This PR adds a new section to the Publisher Command Center's edit page. The right side now has a "Collaborators" section which links out to the access settings pane for the selected content.

<details>
  <summary>Preview</summary>
  
![CleanShot 2025-05-15 at 11 52 35@2x](https://github.com/user-attachments/assets/68586415-ec3d-45fd-ae27-5bdbc1c936f8)

</details> 

This was done since there isn't a public API to fetch the collaborators themselves so a link will suffice for now.

Fixes #123 