### PR TITLE
Add `category` support for Gallery extensions

### DIFF
--- a/.github/actions/lint-extension/action.yml
+++ b/.github/actions/lint-extension/action.yml
@@ -65,6 +65,35 @@ runs:
         fi
       shell: bash
 
+    # Ensures that the manifest.json category is valid
+    - name: Check category
+      run: |
+        # Read in valid category titles from extensions.json
+        VALID_CATEGORY_TITLES=$(jq -c '[.categories[] | .title]' ./extensions.json)
+
+        # Read in category from the extension's manifest.json
+        EXTENSION_CATEGORY=$(jq -r '.extension.category // ""' ./extensions/${{ inputs.extension-name }}/manifest.json)
+
+        # If the extension's category is empty, skip validation
+        if [ -z "$EXTENSION_CATEGORY" ]; then
+          echo "No category specified in manifest.json"
+          exit 0
+        fi
+
+        # Check if extension category is in the valid categories title list
+        CATEGORY_VALID=$(jq -n --argjson global "$VALID_CATEGORY_TITLES" --arg category "$EXTENSION_CATEGORY" '
+          $global | index($category) != null
+        ')
+
+        # Check if the category is valid
+        if [ "$CATEGORY_VALID" != "true" ]; then
+          echo "Error: The category '$EXTENSION_CATEGORY' in manifest.json is not defined in extensions.json"
+          echo "Valid categories are: $(jq -r 'join(", ")' <<< "$VALID_CATEGORY_TITLES")"
+          echo "Please use one of the valid category titles or add a new category to the 'categories' array in extensions.json."
+          exit 1
+        fi
+      shell: bash
+
     # Ensures that the manifest.json has only valid tags
     - name: Check tags
       run: |

--- a/.github/actions/lint-extension/action.yml
+++ b/.github/actions/lint-extension/action.yml
@@ -68,8 +68,8 @@ runs:
     # Ensures that the manifest.json category is valid
     - name: Check category
       run: |
-        # Read in valid category titles from extensions.json
-        VALID_CATEGORY_TITLES=$(jq -c '[.categories[] | .title]' ./extensions.json)
+        # Read in valid category IDs from extensions.json
+        VALID_CATEGORY_IDS=$(jq -c '[.categories[] | .id]' ./extensions.json)
 
         # Read in category from the extension's manifest.json
         EXTENSION_CATEGORY=$(jq -r '.extension.category // ""' ./extensions/${{ inputs.extension-name }}/manifest.json)
@@ -80,16 +80,16 @@ runs:
           exit 0
         fi
 
-        # Check if extension category is in the valid categories title list
-        CATEGORY_VALID=$(jq -n --argjson global "$VALID_CATEGORY_TITLES" --arg category "$EXTENSION_CATEGORY" '
+        # Check if extension category is in the valid categories ID list
+        CATEGORY_VALID=$(jq -n --argjson global "$VALID_CATEGORY_IDS" --arg category "$EXTENSION_CATEGORY" '
           $global | index($category) != null
         ')
 
         # Check if the category is valid
         if [ "$CATEGORY_VALID" != "true" ]; then
           echo "Error: The category '$EXTENSION_CATEGORY' in manifest.json is not defined in extensions.json"
-          echo "Valid categories are: $(jq -r 'join(", ")' <<< "$VALID_CATEGORY_TITLES")"
-          echo "Please use one of the valid category titles or add a new category to the 'categories' array in extensions.json."
+          echo "Valid categories are: $(jq -r 'join(", ")' <<< "$VALID_CATEGORY_IDS")"
+          echo "Please use one of the valid category IDs or add a new category to the 'categories' array in extensions.json."
           exit 1
         fi
       shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ to the `manifest.json`:
     "title": "My Content Name",
     "description": "A lovely, detailed description of the content.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/my-content-name",
+    "category": "Extensions",
     "tags": [],
     "minimumConnectVersion": "2025.04.0",
     "version": "0.0.0"
@@ -50,6 +51,15 @@ to the `manifest.json`:
 It is recommended to begin with `"version": "0.0.0"` to avoid triggering a
 release during development of your content. When you are ready to release to
 the gallery check the [Adding content to the Connect Gallery](#adding-content-to-the-connect-gallery) section.
+
+#### Category
+
+The `category` field in the `extension` section of the `manifest.json` is
+required to group content in the Gallery.
+
+Available categories are listed in the [`extensions.json`](./extensions.json)
+file. The category should match the `title`, and automations in the repository
+will check that the category is valid.
 
 #### Tags
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ to the `manifest.json`:
     "title": "My Content Name",
     "description": "A lovely, detailed description of the content.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/my-content-name",
-    "category": "Extensions",
+    "category": "",
     "tags": [],
     "minimumConnectVersion": "2025.04.0",
     "version": "0.0.0"
@@ -57,8 +57,20 @@ the gallery check the [Adding content to the Connect Gallery](#adding-content-to
 The `category` field in the `extension` section of the `manifest.json` is
 required to group content in the Gallery.
 
+```json
+// manifest.json
+
+{
+  ...
+  "extension": {
+    "category": "extension,
+    ...
+  }
+}
+```
+
 Available categories are listed in the [`extensions.json`](./extensions.json)
-file. The category should match the `title`, and automations in the repository
+file. The category should match the `id`, and automations in the repository
 will check that the category is valid.
 
 #### Tags

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,9 @@ Available categories are listed in the [`extensions.json`](./extensions.json)
 file. The category should match the `id`, and automations in the repository
 will check that the category is valid.
 
+The order of the categories determines the order in which they are displayed
+in the Connect Gallery.
+
 #### Tags
 
 The `tags` array in the `extension` section of the `manifest.json` is optional,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,8 +73,8 @@ Available categories are listed in the [`extensions.json`](./extensions.json)
 file. The category should match the `id`, and automations in the repository
 will check that the category is valid.
 
-The order of the categories determines the order in which they are displayed
-in the Connect Gallery.
+The order of the categories in [`extensions.json`](./extensions.json) determines
+the order in which they are displayed in the Connect Gallery.
 
 #### Tags
 

--- a/extensions.json
+++ b/extensions.json
@@ -2,12 +2,12 @@
   "categories": [
     {
       "id": "extension",
-      "title": "Extensions",
+      "title": "extensions",
       "description": "Useful tools that utilize the Posit Connect API to extend the functionality of Connect."
     },
     {
       "id": "example",
-      "title": "Examples",
+      "title": "examples",
       "description": "Pre-built content to illustrate the types of content publishable on Posit Connect."
     }
   ],

--- a/extensions.json
+++ b/extensions.json
@@ -1,10 +1,12 @@
 {
   "categories": [
     {
+      "id": "example",
       "title": "Examples",
       "description": "Examples are pre-built content to illustrate the types of content publishable on Posit Connect."
     },
     {
+      "id": "extension",
       "title": "Extensions",
       "description": "Extensions are useful tools that utilize the Posit Connect API to extend the functionality of Posit Connect."
     }

--- a/extensions.json
+++ b/extensions.json
@@ -3,12 +3,12 @@
     {
       "id": "example",
       "title": "Examples",
-      "description": "Examples are pre-built content to illustrate the types of content publishable on Posit Connect."
+      "description": "Pre-built content to illustrate the types of content publishable on Posit Connect."
     },
     {
       "id": "extension",
       "title": "Extensions",
-      "description": "Extensions are useful tools that utilize the Posit Connect API to extend the functionality of Posit Connect."
+      "description": "Useful tools that utilize the Posit Connect API to extend the functionality of Connect."
     }
   ],
   "tags": [],

--- a/extensions.json
+++ b/extensions.json
@@ -1,7 +1,15 @@
 {
-  "tags": [
-    "Jump Start"
+  "categories": [
+    {
+      "title": "Examples",
+      "description": "Examples are pre-built content that you can use to get started with Posit Connect."
+    },
+    {
+      "title": "Extensions",
+      "description": "Extensions are useful tools that utilize the Posit Connect API to extend the functionality of Posit Connect."
+    }
   ],
+  "tags": [],
   "requiredFeatures": [
     "API Publishing",
     "OAuth Integrations",

--- a/extensions.json
+++ b/extensions.json
@@ -9,7 +9,9 @@
       "description": "Extensions are useful tools that utilize the Posit Connect API to extend the functionality of Posit Connect."
     }
   ],
-  "tags": [],
+  "tags": [
+    "Jump Start"
+  ],
   "requiredFeatures": [
     "API Publishing",
     "OAuth Integrations",

--- a/extensions.json
+++ b/extensions.json
@@ -217,6 +217,7 @@
       "title": "Publisher Command Center",
       "description": "An app that helps publishers view and manage details about apps and dashboards deployed to Connect: View app metadata and history for all of the apps you are collaborating on as well as see and managing running process for individual apps.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/publisher-command-center",
+      "category": "extension",
       "latestVersion": {
         "version": "0.0.2",
         "released": "2025-05-08T19:26:11Z",
@@ -588,6 +589,7 @@
       "title": "Usage Metrics Dashboard",
       "description": "Understand usage patterns across your work on Connect. Browse an overview of usage across everything you've published, and dive into detailed breakdowns of data for an individual deployment, down to the level of individual visits.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/usage-metrics-dashboard",
+      "category": "extension",
       "latestVersion": {
         "version": "1.0.0",
         "released": "2025-05-07T20:38:49Z",

--- a/extensions.json
+++ b/extensions.json
@@ -1,14 +1,14 @@
 {
   "categories": [
     {
-      "id": "example",
-      "title": "Examples",
-      "description": "Pre-built content to illustrate the types of content publishable on Posit Connect."
-    },
-    {
       "id": "extension",
       "title": "Extensions",
       "description": "Useful tools that utilize the Posit Connect API to extend the functionality of Connect."
+    },
+    {
+      "id": "example",
+      "title": "Examples",
+      "description": "Pre-built content to illustrate the types of content publishable on Posit Connect."
     }
   ],
   "tags": [],

--- a/extensions.json
+++ b/extensions.json
@@ -2,7 +2,7 @@
   "categories": [
     {
       "title": "Examples",
-      "description": "Examples are pre-built content that you can use to get started with Posit Connect."
+      "description": "Examples are pre-built content to illustrate the types of content publishable on Posit Connect."
     },
     {
       "title": "Extensions",

--- a/extensions.json
+++ b/extensions.json
@@ -11,9 +11,7 @@
       "description": "Extensions are useful tools that utilize the Posit Connect API to extend the functionality of Posit Connect."
     }
   ],
-  "tags": [
-    "Jump Start"
-  ],
+  "tags": [],
   "requiredFeatures": [
     "API Publishing",
     "OAuth Integrations",
@@ -25,6 +23,7 @@
       "title": "Connect Widgets Example",
       "description": "connectwidgets is an R package that can be used to query for a subset of your existing content items, then organize them within htmlwidget components in an R Markdown document or Shiny application.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/connectwidgets-example",
+      "category": "example",
       "latestVersion": {
         "version": "0.0.1",
         "released": "2025-04-24T19:17:16Z",
@@ -49,15 +48,14 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "fastapitableau-example",
       "title": "Tableau Python Extension",
       "description": "fastapitableau is a Python package that enables Python developers to build FastAPI APIs that function as Tableau Analytics Extensions. These extensions can be leveraged from Tableau workbooks to allow real time requests from Tableau to Python. This extension builds on top of Tableau's example Superstore dataset.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/fastapitableau-example",
+      "category": "example",
       "latestVersion": {
         "version": "1.0.0",
         "released": "2025-04-24T19:38:18Z",
@@ -88,15 +86,14 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "landing-page",
       "title": "Static HTML landing page",
       "description": "A simple static HTML web page that can be served from Connect",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/landing-page",
+      "category": "example",
       "latestVersion": {
         "version": "1.0.0",
         "released": "2025-04-24T19:04:23Z",
@@ -111,15 +108,14 @@
           "minimumConnectVersion": "2025.04.0"
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "plumbertableau-example",
       "title": "plumbertableau example",
       "description": "plumbertableau is an R package that enables R developers to build Plumber APIs that function as Tableau Analytics Extensions. These extensions can be leveraged from Tableau workbooks to allow real time requests from Tableau to R. This extension builds on top of Tableau's example Superstore dataset.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/plumbertableau-example",
+      "category": "example",
       "latestVersion": {
         "version": "1.0.0",
         "released": "2025-04-29T18:05:16Z",
@@ -150,15 +146,14 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "portfolio-dashboard",
       "title": "Portfolio Dashboard",
       "description": "A shiny application makes it easy to transform your analysis into an interactive dashboard using R so users can ask and answer questions in real-time, without having to touch any code.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/portfolio-dashboard",
+      "category": "example",
       "latestVersion": {
         "version": "0.0.1",
         "released": "2025-04-11T21:32:23Z",
@@ -183,15 +178,14 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "portfolio-report",
       "title": "Portfolio Report",
       "description": "This R Markdown document includes parameters, making it easier for stakeholders to customize the report's assumptions and create their own version. The main document serves as a standard base template, containing your core code and analysis, so you don't have to copy, paste, and republish.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/portfolio-report",
+      "category": "example",
       "latestVersion": {
         "version": "0.0.1",
         "released": "2025-05-01T18:23:36Z",
@@ -216,9 +210,7 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "publisher-command-center",
@@ -279,6 +271,7 @@
       "title": "Quarto Document",
       "description": "This Quarto example shows how a basic document can present diagrams and interactivity.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-document",
+      "category": "example",
       "latestVersion": {
         "version": "1.0.1",
         "released": "2025-05-08T19:48:06Z",
@@ -314,15 +307,14 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "quarto-script-r",
       "title": "Run an R Script using Quarto",
       "description": "This example demonstrates running a simple R script on Connect as a Quarto project. It is an example of how you might automate regular imports and transformations from a data source. JSON and CSV files are exported and made available for download. The script also generates a custom email, with the generated CSV files as attachments.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-script-r",
+      "category": "example",
       "latestVersion": {
         "version": "1.0.0",
         "released": "2025-05-14T13:17:52Z",
@@ -353,15 +345,14 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "quarto-stock-report-python",
       "title": "Quarto Stock Report using Python",
       "description": "An example of how you might automate regular updates using a data source",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-stock-report-python",
+      "category": "example",
       "latestVersion": {
         "version": "1.0.1",
         "released": "2025-05-08T19:48:11Z",
@@ -406,15 +397,14 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "quarto-website",
       "title": "Quarto Website",
       "description": "This Quarto website uses the Posit Connect Server API together with Python to construct a dashboard that presents published content. Views showing featured and all content are included. Set the `FEATURED_TAGS` environment variable and feature content having a particular tag name.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-website",
+      "category": "example",
       "latestVersion": {
         "version": "1.0.0",
         "released": "2025-05-14T12:56:14Z",
@@ -445,15 +435,14 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "stock-api-fastapi",
       "title": "FastAPI Stock Pricing Service",
       "description": "APIs are a great way for software engineering teams to use your models without translating them into different languages",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-fastapi",
+      "category": "example",
       "latestVersion": {
         "version": "1.0.0",
         "released": "2025-04-24T18:56:34Z",
@@ -484,15 +473,14 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "stock-api-flask",
       "title": "Flask Stock Pricing Service",
       "description": "APIs are a great way for software engineering teams to use your models without translating them into different languages",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-flask",
+      "category": "example",
       "latestVersion": {
         "version": "1.0.0",
         "released": "2025-04-24T19:12:11Z",
@@ -523,15 +511,14 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "stock-api-plumber",
       "title": "Stock Pricing Service with Plumber API",
       "description": "An API allows you to turn your models into production services that other tools and teams can use. APIs are a great way for software engineering teams to use your models without translating them into different languages.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-plumber",
+      "category": "example",
       "latestVersion": {
         "version": "1.0.0",
         "released": "2025-04-25T18:11:56Z",
@@ -562,15 +549,14 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "stock-dashboard-python",
       "title": "Stock Pricing Dashboard using Python Dash",
       "description": "A Dash application makes it easy to transform your analysis into an interactive dashboard using Python so users can ask and answer questions in real-time, without having to touch any code.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-dashboard-python",
+      "category": "example",
       "latestVersion": {
         "version": "1.0.0",
         "released": "2025-05-14T12:53:16Z",
@@ -595,9 +581,7 @@
           }
         }
       ],
-      "tags": [
-        "Jump Start"
-      ]
+      "tags": []
     },
     {
       "name": "usage-metrics-dashboard",

--- a/extensions/connectwidgets-example/manifest.json
+++ b/extensions/connectwidgets-example/manifest.json
@@ -16,7 +16,7 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/connectwidgets-example",
     "version": "0.0.1",
     "minimumConnectVersion": "2025.04.0",
-    "tags": ["Jump Start"]
+    "category": "example"
   },
   "environment": {
     "r": {

--- a/extensions/fastapitableau-example/manifest.json
+++ b/extensions/fastapitableau-example/manifest.json
@@ -15,7 +15,7 @@
       "API Publishing"
     ],
     "version": "1.0.0",
-    "tags": ["Jump Start"]
+    "category": "example"
   },
   "environment": {
     "python": {

--- a/extensions/landing-page/manifest.json
+++ b/extensions/landing-page/manifest.json
@@ -14,7 +14,7 @@
     "title": "Static HTML landing page",
     "description": "A simple static HTML web page that can be served from Connect",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/landing-page",
-    "tags": ["Jump Start"],
+    "category": "example",
     "minimumConnectVersion": "2025.04.0",
     "version": "1.0.0"
   },

--- a/extensions/plumbertableau-example/manifest.json
+++ b/extensions/plumbertableau-example/manifest.json
@@ -14,7 +14,7 @@
     "title": "plumbertableau example",
     "description": "plumbertableau is an R package that enables R developers to build Plumber APIs that function as Tableau Analytics Extensions. These extensions can be leveraged from Tableau workbooks to allow real time requests from Tableau to R. This extension builds on top of Tableau's example Superstore dataset.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/plumbertableau-example",
-    "tags": ["Jump Start"],
+    "category": "example",
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": [
       "API Publishing"

--- a/extensions/portfolio-dashboard/manifest.json
+++ b/extensions/portfolio-dashboard/manifest.json
@@ -9,7 +9,7 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/portfolio-dashboard",
     "minimumConnectVersion": "2025.04.0",
     "version": "0.0.1",
-    "tags": ["Jump Start"]
+    "category": "example"
   },
   "environment": {
     "r": {

--- a/extensions/portfolio-report/manifest.json
+++ b/extensions/portfolio-report/manifest.json
@@ -16,7 +16,7 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/portfolio-report",
     "version": "0.0.1",
     "minimumConnectVersion": "2025.04.0",
-    "tags": ["Jump Start"]
+    "category": "example"
   },
   "environment": {
     "r": {

--- a/extensions/quarto-document/manifest.json
+++ b/extensions/quarto-document/manifest.json
@@ -31,12 +31,12 @@
     "description": "This Quarto example shows how a basic document can present diagrams and interactivity.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-document",
     "minimumConnectVersion": "2025.04.0",
+    "category": "example",
     "version": "1.0.1"
   },
   "environment": {
     "quarto": {
       "requires": "~=1.0"
     }
-  },
-  "tags": ["Jump Start"]
+  }
 }

--- a/extensions/quarto-script-r/manifest.json
+++ b/extensions/quarto-script-r/manifest.json
@@ -14,7 +14,7 @@
     "title": "Run an R Script using Quarto",
     "description": "This example demonstrates running a simple R script on Connect as a Quarto project. It is an example of how you might automate regular imports and transformations from a data source. JSON and CSV files are exported and made available for download. The script also generates a custom email, with the generated CSV files as attachments.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-script-r",
-    "tags": ["Jump Start"],
+    "category": "example",
     "minimumConnectVersion": "2025.04.0",
     "version": "1.0.0"
   },
@@ -28,7 +28,9 @@
   },
   "quarto": {
     "version": "1.4.557",
-    "engines": ["knitr"]
+    "engines": [
+      "knitr"
+    ]
   },
   "packages": {
     "R6": {

--- a/extensions/quarto-stock-report-python/manifest.json
+++ b/extensions/quarto-stock-report-python/manifest.json
@@ -10,8 +10,8 @@
     "description": "An example of how you might automate regular updates using a data source",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-stock-report-python",
     "minimumConnectVersion": "2025.04.0",
-    "version": "1.0.1",
-    "tags": ["Jump Start"]
+    "category": "example",
+    "version": "1.0.1"
   },
   "environment": {
     "python": {

--- a/extensions/quarto-website/manifest.json
+++ b/extensions/quarto-website/manifest.json
@@ -10,7 +10,7 @@
     "title": "Quarto Website",
     "description": "This Quarto website uses the Posit Connect Server API together with Python to construct a dashboard that presents published content. Views showing featured and all content are included. Set the `FEATURED_TAGS` environment variable and feature content having a particular tag name.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-website",
-    "tags": ["Jump Start"],
+    "category": "example",
     "minimumConnectVersion": "2025.04.0",
     "version": "1.0.0"
   },

--- a/extensions/stock-api-fastapi/manifest.json
+++ b/extensions/stock-api-fastapi/manifest.json
@@ -10,6 +10,8 @@
     "title": "FastAPI Stock Pricing Service",
     "description": "APIs are a great way for software engineering teams to use your models without translating them into different languages",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-fastapi",
+    "category": "Examples",
+    "tags": [],
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": [
       "API Publishing"

--- a/extensions/stock-api-fastapi/manifest.json
+++ b/extensions/stock-api-fastapi/manifest.json
@@ -10,7 +10,7 @@
     "title": "FastAPI Stock Pricing Service",
     "description": "APIs are a great way for software engineering teams to use your models without translating them into different languages",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-fastapi",
-    "category": "Examples",
+    "category": "example",
     "tags": [],
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": [

--- a/extensions/stock-api-fastapi/manifest.json
+++ b/extensions/stock-api-fastapi/manifest.json
@@ -10,7 +10,7 @@
     "title": "FastAPI Stock Pricing Service",
     "description": "APIs are a great way for software engineering teams to use your models without translating them into different languages",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-fastapi",
-    "category": "Invalid",
+    "category": "Examples",
     "tags": [
       "Jump Start"
     ],

--- a/extensions/stock-api-fastapi/manifest.json
+++ b/extensions/stock-api-fastapi/manifest.json
@@ -10,7 +10,10 @@
     "title": "FastAPI Stock Pricing Service",
     "description": "APIs are a great way for software engineering teams to use your models without translating them into different languages",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-fastapi",
-    "tags": ["Jump Start"],
+    "category": "",
+    "tags": [
+      "Jump Start"
+    ],
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": [
       "API Publishing"

--- a/extensions/stock-api-fastapi/manifest.json
+++ b/extensions/stock-api-fastapi/manifest.json
@@ -10,7 +10,7 @@
     "title": "FastAPI Stock Pricing Service",
     "description": "APIs are a great way for software engineering teams to use your models without translating them into different languages",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-fastapi",
-    "category": "",
+    "category": "Invalid",
     "tags": [
       "Jump Start"
     ],

--- a/extensions/stock-api-fastapi/manifest.json
+++ b/extensions/stock-api-fastapi/manifest.json
@@ -10,10 +10,6 @@
     "title": "FastAPI Stock Pricing Service",
     "description": "APIs are a great way for software engineering teams to use your models without translating them into different languages",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-fastapi",
-    "category": "Examples",
-    "tags": [
-      "Jump Start"
-    ],
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": [
       "API Publishing"

--- a/extensions/stock-api-flask/manifest.json
+++ b/extensions/stock-api-flask/manifest.json
@@ -10,7 +10,7 @@
     "title": "Flask Stock Pricing Service",
     "description": "APIs are a great way for software engineering teams to use your models without translating them into different languages",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-api-flask",
-    "tags": ["Jump Start"],
+    "category": "example",
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": [
       "API Publishing"

--- a/extensions/stock-api-plumber/manifest.json
+++ b/extensions/stock-api-plumber/manifest.json
@@ -19,7 +19,7 @@
     "requiredFeatures": [
       "API Publishing"
     ],
-    "tags": ["Jump Start"]
+    "category": "example"
   },
   "environment": {
     "r": {

--- a/extensions/stock-dashboard-python/manifest.json
+++ b/extensions/stock-dashboard-python/manifest.json
@@ -10,7 +10,7 @@
     "title": "Stock Pricing Dashboard using Python Dash",
     "description": "A Dash application makes it easy to transform your analysis into an interactive dashboard using Python so users can ask and answer questions in real-time, without having to touch any code.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-dashboard-python",
-    "tags": ["Jump Start"],
+    "category": "example",
     "minimumConnectVersion": "2025.04.0",
     "version": "1.0.0"
   },

--- a/scripts/types/index.ts
+++ b/scripts/types/index.ts
@@ -1,3 +1,8 @@
+export interface Category {
+  title: string;
+  description: string;
+}
+
 export interface LanguageRequirement {
   requires: string;
 }
@@ -17,6 +22,7 @@ export interface ExtensionManifest {
     version: string;
     minimumConnectVersion: string;
     requiredFeatures?: RequiredFeature[];
+    category?: Category['title'];
     tags?: string[];
   };
   environment?: ExtensionEnvironment;
@@ -45,4 +51,5 @@ export interface Extension {
   latestVersion: ExtensionVersion;
   versions: ExtensionVersion[];
   tags: string[];
+  category?: string;
 }

--- a/scripts/types/index.ts
+++ b/scripts/types/index.ts
@@ -1,4 +1,5 @@
 export interface Category {
+  id: string;
   title: string;
   description: string;
 }
@@ -22,7 +23,7 @@ export interface ExtensionManifest {
     version: string;
     minimumConnectVersion: string;
     requiredFeatures?: RequiredFeature[];
-    category?: Category['title'];
+    category?: Category['id'];
     tags?: string[];
   };
   environment?: ExtensionEnvironment;
@@ -51,5 +52,5 @@ export interface Extension {
   latestVersion: ExtensionVersion;
   versions: ExtensionVersion[];
   tags: string[];
-  category?: Category['title'];
+  category?: Category['id'];
 }

--- a/scripts/types/index.ts
+++ b/scripts/types/index.ts
@@ -51,5 +51,5 @@ export interface Extension {
   latestVersion: ExtensionVersion;
   versions: ExtensionVersion[];
   tags: string[];
-  category?: string;
+  category?: Category['title'];
 }


### PR DESCRIPTION
This PR introduces a new `category` property for the `extension` section of the `manifest.json`. The `category` can be an `id` of one of the `categories` in the `extensions.json`.

The categories are used to group the content in the Connect UI.

Items tagged Jump Starts are being migrated over to `category: "example"` since we want one of the distinct categories in the Gallery to be Examples - containing the jump start examples. The other category is "extension" which contains the useful tools/dashboards we want to share.

The changes here include:
- linting to make sure the `category` is valid (similar to how the tag linting works)
- updates to the `extension-list` script to write new `category` values to extensions in the list
- documentation in the `CONTRIBUTING` guide describing the `category` property
- updates to the manifest and extension list to use the new categories
  - this is entirely metadata so no need for new releases (similar to tags)

---

Some example GitHub workflows to test the new linting:
- [An empty `category: ""`](https://github.com/posit-dev/connect-extensions/actions/runs/15074499637/job/42378659398?pr=132)
- [An invalid `category`](https://github.com/posit-dev/connect-extensions/actions/runs/15074576409/job/42378916043?pr=132)
- [A valid `category`](https://github.com/posit-dev/connect-extensions/actions/runs/15074590881/job/42378969579?pr=132)
- [No `category`](https://github.com/posit-dev/connect-extensions/actions/runs/15074608297/job/42379022737?pr=132)