### PR TITLE
Publisher Command Center: Allow publishers to publish

### DIFF
--- a/extensions/publisher-command-center/app.py
+++ b/extensions/publisher-command-center/app.py
@@ -47,14 +47,9 @@ def get_visitor_client(token: str | None) -> connect.Client:
 async def contents(posit_connect_user_session_token: str = Header(None)):
     visitor = get_visitor_client(posit_connect_user_session_token)
 
-    response = client.get("metrics/procs")
-    processes = response.json()
-
     contents = visitor.me.content.find()
     for content in contents:
-        content["processes"] = [
-            process for process in processes if content["guid"] == process["app_guid"]
-        ]
+        content["active_jobs"] = [job for job in content.jobs if job["status"] == 0]
 
     return contents
 
@@ -74,12 +69,10 @@ async def get_content_processes(
     visitor = get_visitor_client(posit_connect_user_session_token)
 
     # Assert the viewer has access to the content
-    assert visitor.content.get(content_id)
-
-    response = client.get("metrics/procs")
-    processes = response.json()
-
-    return [process for process in processes if process.get("app_guid") == content_id]
+    content = visitor.content.get(content_id)
+    # make a list of the iterable:
+    active_jobs = [job for job in content.jobs if job["status"] == 0]
+    return active_jobs
 
 
 @app.delete("/api/contents/{content_id}/processes/{process_id}")

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -68,6 +68,6 @@
 			"API Publishing",
 			"OAuth Integrations"
 		],
-		"version": "0.0.2"
+		"version": "0.0.3"
 	}
 }

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -22,7 +22,7 @@
       "checksum": "a162a98758867a701ce693948ffdfa67"
     },
     "app.py": {
-      "checksum": "0e5df52143323d9ae49cf77c51298cde"
+      "checksum": "92709c50369eca0216b8e121cd87c94c"
     },
     "dist/assets/fa-brands-400.808443ae.ttf": {
       "checksum": "15d54d142da2f2d6f2e90ed1d55121af"
@@ -51,11 +51,11 @@
     "dist/assets/index.0c2ac2eb.css": {
       "checksum": "96fb5a8d93644a29ece62d52354fbc73"
     },
-    "dist/assets/index.835b2c40.js": {
-      "checksum": "52e8175304138c1ef6d18c808dcb4b04"
+    "dist/assets/index.3b47d0e1.js": {
+      "checksum": "b7a54352e0a5437ef97c8d3202983dac"
     },
     "dist/index.html": {
-      "checksum": "a3cf0e03275e2436d932280af100438c"
+      "checksum": "a64aa56406944bd2184562c18bfc3b4e"
     }
 	},
 	"extension": {

--- a/extensions/publisher-command-center/src/components/ContentsComponent.js
+++ b/extensions/publisher-command-center/src/components/ContentsComponent.js
@@ -72,7 +72,7 @@ const ContentsComponent = {
                 "td",
                 m(Languages, content)
               ),
-              m("td", content?.processes.length),
+              m("td", content?.active_jobs?.length),
               m("td", format(content["last_deployed_time"], "MMM do, yyyy")),
               m("td", format(content["created_time"], "MMM do, yyyy")),
               m(

--- a/extensions/publisher-command-center/src/components/Processes.js
+++ b/extensions/publisher-command-center/src/components/Processes.js
@@ -103,8 +103,6 @@ export default {
             m("th", { scope: "col" }, ""),
             m("th", { scope: "col" }, "Id"),
             m("th", { scope: "col" }, "Started"),
-            m("th", { scope: "col" }, "CPUs"),
-            m("th", { scope: "col" }, "Memory"),
             m("th", { scope: "col" }, "Hostname"),
           ]),
         ),
@@ -116,7 +114,7 @@ export default {
                 "td.text-center.py-2",
                 m(StopButton, {
                   content_id: vnode.attrs.id,
-                  process_id: process?.job_key,
+                  process_id: process?.key,
                 }),
               ),
               m("td", process?.pid),
@@ -124,8 +122,6 @@ export default {
                 "td",
                 formatDistanceToNow(process?.start_time, { addSuffix: true }),
               ),
-              m("td", Number(process?.cpu_current).toFixed(2)),
-              m("td", filesize(process?.ram)),
               m("td", process?.hostname),
             ]);
           }),


### PR DESCRIPTION
Fixes #127 

The Publisher Command Center could not be published by a Publisher because it called the unversioned, admin-only `metrics/procs` endpoint. It used this to display CPU and memory usage for processes.

I removed those calls and removed their display from the UI, so now the content will run successfully with a Publisher API key.

I deployed the content to my local dev Connect environment and confirmed that it could run from a Publisher account, kill processes, etc.

I bumped the version so that it releases to the gallery. @fizzboop this might affect your open PR on the same piece of content — we can coordinate on that if we need to!

Screenshots attached showing before and after:

<img width="1492" alt="Screen Shot 2025-05-19 at 04 31 26 PM@2x" src="https://github.com/user-attachments/assets/e29fda99-090c-46ac-b05d-f75708b71d34" />
<img width="1497" alt="Screen Shot 2025-05-19 at 05 13 11 PM@2x" src="https://github.com/user-attachments/assets/b30792b5-3991-4203-bdb4-be1845d0708a" />
