### PR TITLE
Add lock and rename content functionality to Publisher Command Center

### DIFF
--- a/extensions/publisher-command-center/app.py
+++ b/extensions/publisher-command-center/app.py
@@ -1,6 +1,6 @@
 from http import client
 import asyncio
-from fastapi import FastAPI, Header
+from fastapi import FastAPI, Header, Body
 from fastapi.staticfiles import StaticFiles
 from posit import connect
 from posit.connect.errors import ClientError
@@ -76,13 +76,13 @@ async def lock_content(
 @app.patch("/api/content/{content_id}/rename")
 async def rename_content(
     content_id: str,
-    new_name: str = "",
+    title: str = Body(..., embed = True),
     posit_connect_user_session_token: str = Header(None),
 ):
     visitor = get_visitor_client(posit_connect_user_session_token)
     content = visitor.content.get(content_id)
 
-    content.update(title = new_name)
+    content.update(title = title)
     return content
 
 @app.get("/api/contents/{content_id}/processes")

--- a/extensions/publisher-command-center/app.py
+++ b/extensions/publisher-command-center/app.py
@@ -61,6 +61,29 @@ async def content(
     visitor = get_visitor_client(posit_connect_user_session_token)
     return visitor.content.get(content_id)
 
+@app.patch("/api/content/{content_id}/lock")
+async def lock_content(
+    content_id: str,
+    posit_connect_user_session_token: str = Header(None),
+):
+    visitor = get_visitor_client(posit_connect_user_session_token)
+    content = visitor.content.get(content_id)
+    is_locked = content.locked
+
+    content.update(locked=not is_locked)
+    return content
+
+@app.patch("/api/content/{content_id}/rename")
+async def rename_content(
+    content_id: str,
+    new_name: str = "",
+    posit_connect_user_session_token: str = Header(None),
+):
+    visitor = get_visitor_client(posit_connect_user_session_token)
+    content = visitor.content.get(content_id)
+
+    content.update(title = new_name)
+    return content
 
 @app.get("/api/contents/{content_id}/processes")
 async def get_content_processes(

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -20,21 +20,21 @@
   "extension": {
   "name": "publisher-command-center",
   "title": "Publisher Command Center",
-  "description": "An app that helps publishers view and manage details about apps and dashboards deployed to Connect: View app metadata and history for all of the apps you are collaborating on as well as see and managing running process for individual apps.",
+  "description": "An app that helps publishers view and manage details about apps and dashboards deployed to Connect. View app metadata and history for all of the apps you are collaborating on as well as see and managing running process for individual apps.",
   "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/publisher-command-center",
   "minimumConnectVersion": "2025.04.0",
   "requiredFeatures": [
     "API Publishing",
     "OAuth Integrations"
   ],
-  "version": "0.0.4"
+  "version": "0.0.5"
   },
   "files": {
     "requirements.txt": {
       "checksum": "a162a98758867a701ce693948ffdfa67"
     },
     "app.py": {
-      "checksum": "55729c283443e02bcfc4233ccf0c2b3d"
+      "checksum": "b56cfcda18d0d11dee415ccdf81a757e"
     },
     "dist/assets/fa-brands-400.808443ae.ttf": {
       "checksum": "15d54d142da2f2d6f2e90ed1d55121af"
@@ -60,14 +60,14 @@
     "dist/assets/fa-v4compatibility.30f6abf6.ttf": {
       "checksum": "4ed293ceaca9b5b2d9cd74a477963fae"
     },
+    "dist/assets/index.3a9c08bc.js": {
+      "checksum": "190b4f6c18d188527b1bfbf2bef1ede6"
+    },
     "dist/assets/index.eba02280.css": {
       "checksum": "cb5a34d5ea88d4969288161bd3123ee4"
     },
-    "dist/assets/index.f987f996.js": {
-      "checksum": "f8a777db2d3d8e211a31f70bbca57234"
-    },
     "dist/index.html": {
-      "checksum": "c61715903d067cc4ece8190fbdddb516"
+      "checksum": "1cbc14166f5e5bcf06fbe9c6c35d55aa"
     }
   }
 }

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -20,7 +20,7 @@
   "extension": {
   "name": "publisher-command-center",
   "title": "Publisher Command Center",
-  "description": "An app that helps publishers view and manage details about apps and dashboards deployed to Connect. View app metadata and history for all of the apps you are collaborating on as well as see and managing running process for individual apps.",
+  "description": "An app that helps publishers view and manage details about apps and dashboards deployed to Connect: View app metadata and history for all of the apps you are collaborating on as well as see and managing running process for individual apps.",
   "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/publisher-command-center",
   "minimumConnectVersion": "2025.04.0",
   "requiredFeatures": [
@@ -34,7 +34,7 @@
       "checksum": "a162a98758867a701ce693948ffdfa67"
     },
     "app.py": {
-      "checksum": "b56cfcda18d0d11dee415ccdf81a757e"
+      "checksum": "55729c283443e02bcfc4233ccf0c2b3d"
     },
     "dist/assets/fa-brands-400.808443ae.ttf": {
       "checksum": "15d54d142da2f2d6f2e90ed1d55121af"
@@ -60,16 +60,6 @@
     "dist/assets/fa-v4compatibility.30f6abf6.ttf": {
       "checksum": "4ed293ceaca9b5b2d9cd74a477963fae"
     },
-<<<<<<< HEAD
-    "dist/assets/index.043e0ce3.css": {
-      "checksum": "0e41eeba30bce2f8e92873acb12462f7"
-    },
-    "dist/assets/index.7d457dc3.js": {
-      "checksum": "5cbfee09ee6b22913005c1adbaff39f7"
-    },
-    "dist/index.html": {
-      "checksum": "ae6f4b40d27ac5c0586b85fd13806c72"
-=======
     "dist/assets/index.90f1ae46.js": {
       "checksum": "8b85382a2fd0bb7f106cf03488e3bd72"
     },
@@ -78,7 +68,6 @@
     },
     "dist/index.html": {
       "checksum": "af4c52e366ba6e5be8f9776014856862"
->>>>>>> main
     }
   }
 }

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -27,7 +27,7 @@
     "API Publishing",
     "OAuth Integrations"
   ],
-  "version": "0.0.5"
+  "version": "0.0.4"
   },
   "files": {
     "requirements.txt": {
@@ -60,14 +60,14 @@
     "dist/assets/fa-v4compatibility.30f6abf6.ttf": {
       "checksum": "4ed293ceaca9b5b2d9cd74a477963fae"
     },
-    "dist/assets/index.3a9c08bc.js": {
-      "checksum": "190b4f6c18d188527b1bfbf2bef1ede6"
+    "dist/assets/index.043e0ce3.css": {
+      "checksum": "0e41eeba30bce2f8e92873acb12462f7"
     },
-    "dist/assets/index.eba02280.css": {
-      "checksum": "cb5a34d5ea88d4969288161bd3123ee4"
+    "dist/assets/index.7d457dc3.js": {
+      "checksum": "5cbfee09ee6b22913005c1adbaff39f7"
     },
     "dist/index.html": {
-      "checksum": "1cbc14166f5e5bcf06fbe9c6c35d55aa"
+      "checksum": "ae6f4b40d27ac5c0586b85fd13806c72"
     }
   }
 }

--- a/extensions/publisher-command-center/scss/index.scss
+++ b/extensions/publisher-command-center/scss/index.scss
@@ -39,6 +39,10 @@ $colors: (
   color: $blue;
 }
 
+.lock-loading {
+  color: $gray;
+}
+
 // Removes the white background of the modal
 .modal.show {
   background: none;

--- a/extensions/publisher-command-center/src/components/ContentsComponent.js
+++ b/extensions/publisher-command-center/src/components/ContentsComponent.js
@@ -2,8 +2,9 @@ import m from "mithril";
 import { format } from "date-fns";
 import Contents from "../models/Contents";
 import Languages from "./Languages";
-import DeleteModal from "./DeleteModal";
 import LockContentButton from "./LockContentButton";
+import DeleteModal from "./DeleteModal";
+import RenameModal from "./RenameModal";
 
 const ContentsComponent = {
   error: null,
@@ -44,6 +45,8 @@ const ContentsComponent = {
           m("th", { scope: "col" }, "Date Added"),
           m("th", { scope: "col" }, ""),
           m("th", { scope: "col" }, ""),
+          m("th", { scope: "col" }, ""),
+          m("th", { scope: "col" }, ""),
         ]),
       ),
       m(
@@ -71,8 +74,21 @@ const ContentsComponent = {
               m("td", format(content["created_time"], "MMM do, yyyy")),
               m(
                 "td",
+                m("button", {
+                  class: "action-btn",
+                  ariaLabel: `Rename ${title}`,
+                  title: `Rename ${title}`,
+                  "data-bs-toggle": "modal",
+                  "data-bs-target": `#renameModal-${guid}`,
+                }, [
+                  m("i", { class: "fa-solid fa-pencil" })
+                ]),
+              ),
+              m(
+                "td",
                 m(LockContentButton, {
                   contentId: guid,
+                  contentTitle: title,
                   isLocked: content["locked"],
                 }),
               ),
@@ -80,7 +96,8 @@ const ContentsComponent = {
                 "td",
                 m("button", {
                   class: "action-btn",
-                  ariaLabel: "Delete Content",
+                  title: `Delete ${title}`,
+                  ariaLabel: `Delete ${title}`,
                   "data-bs-toggle": "modal",
                   "data-bs-target": `#deleteModal-${guid}`,
                 }, [
@@ -92,11 +109,16 @@ const ContentsComponent = {
                 m("a", {
                   class: "fa-solid fa-arrow-up-right-from-square",
                   href: content["content_url"],
+                  title: `Open ${title} (opens in new tab)`,
                   target: "_blank",
                   onclick: (e) => e.stopPropagation(),
                 }),
               ),
               m(DeleteModal, {
+                contentId: guid,
+                contentTitle: title,
+              }),
+              m(RenameModal, {
                 contentId: guid,
                 contentTitle: title,
               }),

--- a/extensions/publisher-command-center/src/components/ContentsComponent.js
+++ b/extensions/publisher-command-center/src/components/ContentsComponent.js
@@ -109,7 +109,8 @@ const ContentsComponent = {
                 m("a", {
                   class: "fa-solid fa-arrow-up-right-from-square",
                   href: content["content_url"],
-                  title: `Open ${title} (opens in new tab)`,
+                  ariaLabel: `Open ${title} (opens in new tab)`,
+                  title: `Open ${title}`,
                   target: "_blank",
                   onclick: (e) => e.stopPropagation(),
                 }),

--- a/extensions/publisher-command-center/src/components/ContentsComponent.js
+++ b/extensions/publisher-command-center/src/components/ContentsComponent.js
@@ -3,6 +3,7 @@ import { format } from "date-fns";
 import Contents from "../models/Contents";
 import Languages from "./Languages";
 import DeleteModal from "./DeleteModal";
+import LockContentButton from "./LockContentButton";
 
 const ContentsComponent = {
   error: null,
@@ -70,8 +71,16 @@ const ContentsComponent = {
               m("td", format(content["created_time"], "MMM do, yyyy")),
               m(
                 "td",
+                m(LockContentButton, {
+                  contentId: guid,
+                  isLocked: content["locked"],
+                }),
+              ),
+              m(
+                "td",
                 m("button", {
                   class: "action-btn",
+                  ariaLabel: "Delete Content",
                   "data-bs-toggle": "modal",
                   "data-bs-target": `#deleteModal-${guid}`,
                 }, [

--- a/extensions/publisher-command-center/src/components/LockContentButton.js
+++ b/extensions/publisher-command-center/src/components/LockContentButton.js
@@ -3,7 +3,9 @@ import Contents from "../models/Contents";
 
 const LockedContentButton = {  
   view: function(vnode) {
-    const labelMessage = vnode.attrs.isLocked ? "Unlock Content" : "Lock Content";
+    const labelMessage = vnode.attrs.isLocked ?
+       `Unlock ${vnode.attrs.contentTitle}` :
+       `Lock Content ${vnode.attrs.contentTitle}`;
     const iconClassName = vnode.attrs.isLocked ? "fa-lock" : "fa-lock-open";
     return m("button", {
       class: "action-btn",

--- a/extensions/publisher-command-center/src/components/LockContentButton.js
+++ b/extensions/publisher-command-center/src/components/LockContentButton.js
@@ -1,21 +1,50 @@
 import m from "mithril";
 import Contents from "../models/Contents";
 
-const LockedContentButton = {  
+const LockedContentButton = {
+  oninit: function () {
+    this.isLoading = false;
+  },
+
   view: function(vnode) {
     const labelMessage = vnode.attrs.isLocked ?
        `Unlock ${vnode.attrs.contentTitle}` :
        `Lock Content ${vnode.attrs.contentTitle}`;
-    const iconClassName = vnode.attrs.isLocked ? "fa-lock" : "fa-lock-open";
+
+    const iconClassName = () => {
+      if (this.isLoading) return "fa-spinner fa-spin lock-loading";
+
+      if (vnode.attrs.isLocked) {
+        return "fa-lock";
+      } else {
+        return "fa-lock-open";
+      }
+    };
+
     return m("button", {
       class: "action-btn",
       ariaLabel: labelMessage,
       title: labelMessage,
-      onclick: () => {
-        Contents.lock(vnode.attrs.contentId)
+      disabled: this.isLoading,
+      onclick: async () => {
+        if (this.isLoading) { return; }
+
+        this.isLoading = true;
+        m.redraw();
+
+        try {
+          await Contents.lock(vnode.attrs.contentId)
+        } finally {
+          this.isLoading = false;
+          m.redraw();
+        }
       }
     }, [
-      m("i", { class: `fa-solid ${iconClassName}` })
+      m("i", {
+        class: `fa-solid ${iconClassName()}`,
+
+        }
+      )
     ])
   }
 };

--- a/extensions/publisher-command-center/src/components/LockContentButton.js
+++ b/extensions/publisher-command-center/src/components/LockContentButton.js
@@ -1,0 +1,21 @@
+import m from "mithril";
+import Contents from "../models/Contents";
+
+const LockedContentButton = {  
+  view: function(vnode) {
+    const labelMessage = vnode.attrs.isLocked ? "Unlock Content" : "Lock Content";
+    const iconClassName = vnode.attrs.isLocked ? "fa-lock" : "fa-lock-open";
+    return m("button", {
+      class: "action-btn",
+      ariaLabel: labelMessage,
+      title: labelMessage,
+      onclick: () => {
+        Contents.lock(vnode.attrs.contentId)
+      }
+    }, [
+      m("i", { class: `fa-solid ${iconClassName}` })
+    ])
+  }
+};
+
+export default LockedContentButton;

--- a/extensions/publisher-command-center/src/components/RenameModal.js
+++ b/extensions/publisher-command-center/src/components/RenameModal.js
@@ -1,5 +1,6 @@
 import m from "mithril";
 import Contents from "../models/Contents";
+import { Modal } from "bootstrap";
 
 const RenameModalForm = {
   newName: "",
@@ -11,8 +12,10 @@ const RenameModalForm = {
       Contents.rename(RenameModalForm.guid, RenameModalForm.newName);
 
       const modalEl = document.getElementById(`renameModal-${RenameModalForm.guid}`);
-      const modal = bootstrap.Modal.getInstance(modalEl);
+      const modal = Modal.getInstance(modalEl);
       modal.hide();
+
+      RenameModalForm.newName = "";
     }
   },
   view: function(vnode) {
@@ -21,7 +24,7 @@ const RenameModalForm = {
       },
       [
         m("section", { class: "modal-body" }, [
-          m("div", { class: "form-group has-validation" }, [
+          m("div", { class: "form-group" }, [
             m("label", {
               for: "rename-content-input",
               class: "mb-3",
@@ -40,6 +43,7 @@ const RenameModalForm = {
               required: true,
               minlength: 3,
               maxlength: 1024,
+              value: RenameModalForm.newName,
             }),
           ])
         ]),

--- a/extensions/publisher-command-center/src/components/RenameModal.js
+++ b/extensions/publisher-command-center/src/components/RenameModal.js
@@ -1,0 +1,89 @@
+import m from "mithril";
+import Contents from "../models/Contents";
+
+const RenameModalForm = {
+  newName: "",
+  guid: "",
+  isValid: false,
+  onsubmit: function(e) {
+    if (RenameModalForm.isValid) {
+      e.preventDefault();  
+      Contents.rename(RenameModalForm.guid, RenameModalForm.newName);
+
+      const modalEl = document.getElementById(`renameModal-${RenameModalForm.guid}`);
+      const modal = bootstrap.Modal.getInstance(modalEl);
+      modal.hide();
+    }
+  },
+  view: function(vnode) {
+    return m("form", {
+        onsubmit: (e) => { this.onsubmit(e); }
+      },
+      [
+        m("section", { class: "modal-body" }, [
+          m("div", { class: "form-group has-validation" }, [
+            m("label", {
+              for: "rename-content-input",
+              class: "mb-3",
+            }, "Enter new name for ", [
+              m("span", { class: "fw-bold" }, `${vnode.attrs.contentTitle}`)
+            ]),
+            m("input", {
+              oninput: function(e) {
+                RenameModalForm.isValid = e.target.validity.valid;
+                RenameModalForm.guid = vnode.attrs.contentId;
+                RenameModalForm.newName = e.target.value;
+              },
+              id: "rename-content-input",
+              type: "text",
+              class: "form-control",
+              required: true,
+              minlength: 3,
+              maxlength: 1024,
+            }),
+          ])
+        ]),
+      m("div", { class: "modal-footer" }, [
+        m(
+          "button",
+          {
+            type: "submit",
+            class: "btn btn-primary",
+            ariaLabel: "Rename Content",
+          },
+          "Rename Content",
+        ),
+      ]), 
+    ])
+  },
+}
+
+const RenameModal = {
+  view: function(vnode) {
+    return m("div", {
+        class: "modal",
+        id: `renameModal-${vnode.attrs.contentId}`,
+        tabindex: "-1",
+        ariaHidden: true
+      }, [
+      m("div", { class: "modal-dialog modal-dialog-centered" }, [
+        m("div", { class: "modal-content" }, [
+          m("div", { class: "modal-header"}, [
+            m("h1", { class: "modal-title fs-6" }, "Rename Content"),
+            m("button", {
+              class: "btn-close",
+              ariaLabel: "Close modal",
+              "data-bs-dismiss": "modal"
+            }),
+          ]),
+          m(RenameModalForm, {
+            contentTitle: vnode.attrs.contentTitle,
+            contentId: vnode.attrs.contentId,
+          })
+        ]),
+      ]),
+    ])
+  },
+};
+
+export default RenameModal;

--- a/extensions/publisher-command-center/src/index.js
+++ b/extensions/publisher-command-center/src/index.js
@@ -1,6 +1,6 @@
 import m from "mithril";
 
-import "bootstrap/dist/js/bootstrap.bundle.min.js";
+import * as bootstrap from "bootstrap";
 import "@fortawesome/fontawesome-free/css/all.min.css";
 
 import "../scss/index.scss";

--- a/extensions/publisher-command-center/src/models/Contents.js
+++ b/extensions/publisher-command-center/src/models/Contents.js
@@ -51,6 +51,9 @@ export default {
       body: {
         title: newName,
       },
+    }).then((response) => {
+      const targetContent = this.data.find((c) => c.guid === guid);
+      Object.assign(targetContent, response);
     });
   },
 

--- a/extensions/publisher-command-center/src/models/Contents.js
+++ b/extensions/publisher-command-center/src/models/Contents.js
@@ -34,6 +34,26 @@ export default {
     this.data = this.data.filter((c) => c.guid !== guid);
   },
 
+  lock: async function (guid) {
+    await m.request({
+      method: "PATCH",
+      url: `api/content/${guid}/lock`,
+    }).then((response) => {
+      const targetContent = this.data.find((c) => c.guid === guid);
+      Object.assign(targetContent, response);
+    });
+  },
+
+  rename: async function (guid, newName) {
+    await m.request({
+      method: "PATCH",
+      url: `api/content/${guid}/rename`,
+      body: {
+        title: newName,
+      },
+    });
+  },
+
   reset: function () {
     this.data = null;
     this._fetch = null;


### PR DESCRIPTION
## Intent
Addresses the last two items of the #122 

## Approach
Created two endpoints to handle locking/unlocking content and rename content.

## Example
[Publisher Command Center Test](https://dogfood.team.pct.posit.it/connect/#/apps/52cbb388-814d-4869-a8dd-b785dfd8066c/access) on DogFood

## Screenshots
![image](https://github.com/user-attachments/assets/ce55d0c2-a7b7-4860-ba15-83f97bea4802)

![image](https://github.com/user-attachments/assets/efd65236-18bf-4cb5-9cba-bb2b5097cd0a)