### PR TITLE
Usage Metrics Dashboard: Test out using session cache

### DIFF
--- a/extensions/usage-metrics-dashboard/app.R
+++ b/extensions/usage-metrics-dashboard/app.R
@@ -187,9 +187,7 @@ ui <- function(request) {
           multiple = TRUE
         ),
         uiOutput("email_selected_visitors_button")
-      ),
-
-      tags$hr()
+      )
     ),
 
     # Main content views ----

--- a/extensions/usage-metrics-dashboard/app.R
+++ b/extensions/usage-metrics-dashboard/app.R
@@ -11,10 +11,6 @@ library(ggplot2)
 library(plotly)
 library(shinycssloaders)
 
-shinyOptions(
-  cache = cachem::cache_disk("./app_cache/cache/", max_age = 60 * 60)
-)
-
 options(
   spinner.type = 1,
   spinner.color = "#7494b1"
@@ -193,11 +189,7 @@ ui <- function(request) {
         uiOutput("email_selected_visitors_button")
       ),
 
-      tags$hr(),
-
-      # TODO: Possibly remove or hide in a "Troubleshooting" or Advanced
-      # accordion section
-      actionLink("clear_cache", "Clear Cache", icon = icon("refresh")),
+      tags$hr()
     ),
 
     # Main content views ----
@@ -449,15 +441,6 @@ server <- function(input, output, session) {
     )
   })
 
-  # Cache invalidation button ----
-
-  cache <- cachem::cache_disk("./app_cache/cache/")
-  observeEvent(input$clear_cache, {
-    print("Cache cleared!")
-    cache$reset()
-    session$reload()
-  })
-
   # Visit Merge Window controls: sync slider and text input ----
 
   observeEvent(input$visit_merge_window, {
@@ -576,7 +559,7 @@ server <- function(input, output, session) {
   content_unscoped <- reactive({
     get_content(client)
   }) |>
-    bindCache(active_user_guid)
+    bindCache(active_user_guid, cache = "session")
 
   content <- reactive({
     req(input$content_scope)
@@ -611,7 +594,7 @@ server <- function(input, output, session) {
       ) |>
       select(user_guid = guid, full_name, username, display_name, email)
   }) |>
-    bindCache(active_user_guid)
+    bindCache(active_user_guid, cache = "session")
 
   usage_data_raw <- reactive({
     req(active_user_role %in% c("administrator", "publisher"))
@@ -621,7 +604,7 @@ server <- function(input, output, session) {
       to = date_range()$to
     )
   }) |>
-    bindCache(active_user_guid, date_range())
+    bindCache(active_user_guid, date_range(), cache = "session")
 
   # Multi-content table data ----
 


### PR DESCRIPTION
This PR tests out switching the cache to a _session cache_, which means that refreshing the page is the way to refresh the cache (no more "clear cache" / "refresh data" button). This is so much simpler for users to comprehend, and probably matches their expectations better.

Compare to #133.

Available here: https://connect.posit.it/megadashboard-session-cache/ (note it's in use with Max Role: Admin)