### PR TITLE
Publisher Command Center: Move developer notes to CONTRIBUTING

### DIFF
--- a/extensions/publisher-command-center/CONTRIBUTING.md
+++ b/extensions/publisher-command-center/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing to Publisher Command Center
+
+## Uses
+
+- **Mithril.js** for lightweight and efficient UI rendering
+- **Bootstrap** for responsive and consistent styling
+- **FontAwesome** for scalable vector icons
+- **Vite** for a fast development build system
+- **FastAPI** as the backend framework
+
+## Getting Started
+
+### Prerequisites
+
+Ensure you have the following installed:
+
+- [Node.js](https://nodejs.org/) (for frontend development)
+- [Python](https://www.python.org/) (for backend development)
+- [uv](https://github.com/astral-sh/uv) (for running backend server)
+
+### Installation
+
+Clone the repository and install dependencies:
+
+```sh
+npm install
+uv sync
+```
+
+### Running the Development Server
+
+Start the frontend development server:
+
+```sh
+npm run preview
+```
+
+Start the backend development server:
+
+```sh
+npm run server
+```
+
+Start the watcher to enable continuous rebuilds of the frontend:
+
+```sh
+npm run watch
+```
+
+
+### Building for Production
+
+To build the frontend for production:
+
+```sh
+npm run build
+```
+
+### Deploying to Connect
+
+When deploying, include `app.py`, `requirements.txt`, and the contents of the `dist` directory created by `npm run build`.
+
+### Publishing on Connect
+
+This extension utilizes the [Connect API OAuth Integration](https://docs.posit.co/connect/admin/integrations/oauth-integrations/connect/index.html#create-connect-api-integration-in-posit-connect).
+
+After deploying the extension create a Connect API Viewer role integration, if
+one doesn't already exist on the server, and select it as a integration.
+
+## Technologies Used
+
+### [Mithril.js](https://mithril.js.org/)
+
+Mithril.js is a modern client-side JavaScript framework that focuses on simplicity and performance. It is lightweight (~10kb gzipped) and offers a virtual DOM implementation for efficient rendering.
+
+### [Bootstrap](https://getbootstrap.com/)
+
+Bootstrap is a popular CSS framework that helps create responsive and mobile-first designs with prebuilt components and utilities.
+
+### [FontAwesome](https://fontawesome.com/)
+
+FontAwesome provides scalable vector icons and social logos that can be used in web applications.
+
+### [Date-fns](https://date-fns.org/)
+
+Date-fns is a modern JavaScript date utility library that provides comprehensive, yet simple-to-use functions for date manipulation.
+
+### [Filesize.js](https://filesizejs.com/)
+
+Filesize.js is a small utility for formatting file sizes in human-readable formats.
+
+### [Vite](https://vitejs.dev/)
+
+Vite is a next-generation frontend tooling system that enables fast build times and instant development server start-up.
+
+### [SASS](https://sass-lang.com/)
+
+SASS (Syntactically Awesome Stylesheets) is a CSS preprocessor that extends CSS with features like variables, nested rules, and mixins.
+
+### [FastAPI](https://fastapi.tiangolo.com/)
+
+FastAPI is a modern web framework for building APIs with Python 3.7+ that provides automatic OpenAPI and JSON Schema documentation.
+
+## Code Formatting
+
+This project uses **Prettier** for consistent code formatting. Run the following command to format your code:
+
+```sh
+npx prettier --write .
+```

--- a/extensions/publisher-command-center/README.md
+++ b/extensions/publisher-command-center/README.md
@@ -2,111 +2,14 @@
 
 **Publisher Command Center** is a web-based application designed to help publishers manage and track their content.
 
-## Features
+## Setup
 
-- **Mithril.js** for lightweight and efficient UI rendering
-- **Bootstrap** for responsive and consistent styling
-- **FontAwesome** for scalable vector icons
-- **Vite** for a fast development build system
-- **FastAPI** as the backend framework
+After deploying **Publisher Command Center**, you'll need to add a Visitor API Key integration.
 
-## Getting Started
+In Posit Connect go to the app's control panel on the right of the screen, in
+the Access tab, click **"Add integration"**, then select a **Visitor API Key**
+integration.
 
-### Prerequisites
+If you don't see one in the list, an administrator must enable this feature on your Connect server.
+See the [Admin Guide](https://docs.posit.co/connect/admin/integrations/oauth-integrations/connect/) for setup instructions.
 
-Ensure you have the following installed:
-
-- [Node.js](https://nodejs.org/) (for frontend development)
-- [Python](https://www.python.org/) (for backend development)
-- [uv](https://github.com/astral-sh/uv) (for running backend server)
-
-### Installation
-
-Clone the repository and install dependencies:
-
-```sh
-npm install
-uv sync
-```
-
-### Running the Development Server
-
-Start the frontend development server:
-
-```sh
-npm run preview
-```
-
-Start the backend development server:
-
-```sh
-npm run server
-```
-
-Start the watcher to enable continuous rebuilds of the frontend:
-
-```sh
-npm run watch
-```
-
-
-### Building for Production
-
-To build the frontend for production:
-
-```sh
-npm run build
-```
-
-### Deploying to Connect
-
-When deploying, include `app.py`, `requirements.txt`, and the contents of the `dist` directory created by `npm run build`.
-
-### Publishing on Connect
-
-This extension utilizes the [Connect API OAuth Integration](https://docs.posit.co/connect/admin/integrations/oauth-integrations/connect/index.html#create-connect-api-integration-in-posit-connect).
-
-After deploying the extension create a Connect API Viewer role integration, if
-one doesn't already exist on the server, and select it as a integration.
-
-## Technologies Used
-
-### [Mithril.js](https://mithril.js.org/)
-
-Mithril.js is a modern client-side JavaScript framework that focuses on simplicity and performance. It is lightweight (~10kb gzipped) and offers a virtual DOM implementation for efficient rendering.
-
-### [Bootstrap](https://getbootstrap.com/)
-
-Bootstrap is a popular CSS framework that helps create responsive and mobile-first designs with prebuilt components and utilities.
-
-### [FontAwesome](https://fontawesome.com/)
-
-FontAwesome provides scalable vector icons and social logos that can be used in web applications.
-
-### [Date-fns](https://date-fns.org/)
-
-Date-fns is a modern JavaScript date utility library that provides comprehensive, yet simple-to-use functions for date manipulation.
-
-### [Filesize.js](https://filesizejs.com/)
-
-Filesize.js is a small utility for formatting file sizes in human-readable formats.
-
-### [Vite](https://vitejs.dev/)
-
-Vite is a next-generation frontend tooling system that enables fast build times and instant development server start-up.
-
-### [SASS](https://sass-lang.com/)
-
-SASS (Syntactically Awesome Stylesheets) is a CSS preprocessor that extends CSS with features like variables, nested rules, and mixins.
-
-### [FastAPI](https://fastapi.tiangolo.com/)
-
-FastAPI is a modern web framework for building APIs with Python 3.7+ that provides automatic OpenAPI and JSON Schema documentation.
-
-## Code Formatting
-
-This project uses **Prettier** for consistent code formatting. Run the following command to format your code:
-
-```sh
-npx prettier --write .
-```


### PR DESCRIPTION
This PR suggests moving the developer instructions to a `CONTRIBUTING.md` for the Publisher Command Center and making the `README` more focused on general description of the item for the Gallery - similar to [the Usage Metrics Dashboard's `README`](https://github.com/posit-dev/connect-extensions/blob/main/extensions/usage-metrics-dashboard/README.md).

I included very similar setup instructions for the OAuth Integration even with the fallback behavior this seemed handy. We can add additional feature descriptions in the future.