### PR TITLE
Publisher Command Center: One-click add integration for first-deploy workflow

### DIFF
--- a/extensions/publisher-command-center/app.py
+++ b/extensions/publisher-command-center/app.py
@@ -1,6 +1,6 @@
 from http import client
 import asyncio
-from fastapi import FastAPI, Header
+from fastapi import FastAPI, Header, Body
 from fastapi.staticfiles import StaticFiles
 from posit import connect
 from posit.connect.errors import ClientError
@@ -15,8 +15,9 @@ app = FastAPI()
 # Create cache with TTL=1hour and unlimited size
 client_cache = TTLCache(maxsize=float("inf"), ttl=3600)
 
-@app.get("/api/auth-status")
-async def auth_status(posit_connect_user_session_token: str = Header(None)):
+
+@app.get("/api/visitor-auth")
+async def integration_status(posit_connect_user_session_token: str = Header(None)):
     """
     If running on Connect, attempt to build a visitor client.
     If that raises the 212 error (no OAuth integration), return authorized=False.
@@ -30,9 +31,43 @@ async def auth_status(posit_connect_user_session_token: str = Header(None)):
         except ClientError as err:
             if err.error_code == 212:
                 return {"authorized": False}
-            raise # Other errors bubble up
+            raise
 
     return {"authorized": True}
+
+
+@app.put("/api/visitor-auth")
+async def set_integration(integration_guid: str = Body(..., embed=True)):
+    if os.getenv("RSTUDIO_PRODUCT") == "CONNECT":
+        content_guid = os.getenv("CONNECT_CONTENT_GUID")
+        content = client.content.get(content_guid)
+        content.oauth.associations.update(integration_guid)
+    else:
+        # Raise an error if not running on Connect
+        raise ClientError(
+            error_code=400,
+            message="This endpoint is only available when running on Posit Connect.",
+        )
+    return {"status": "success"}
+
+
+@app.get("/api/integrations")
+async def get_integrations():
+    print("get_integration()")
+    integrations = client.oauth.integrations.find()
+    admin_integrations = [
+        i
+        for i in integrations
+        if i["template"] == "connect" and i["config"]["max_role"] == "Admin"
+    ]
+    publisher_integrations = [
+        i
+        for i in integrations
+        if i["template"] == "connect" and i["config"]["max_role"] == "Publisher"
+    ]
+    eligible_integrations = admin_integrations + publisher_integrations
+    return eligible_integrations[0] if eligible_integrations else None
+
 
 @cached(client_cache)
 def get_visitor_client(token: str | None) -> connect.Client:
@@ -74,6 +109,7 @@ async def get_content_processes(
     active_jobs = [job for job in content.jobs if job["status"] == 0]
     return active_jobs
 
+
 @app.delete("/api/contents/{content_id}")
 async def delete_content(
     content_id: str,
@@ -83,6 +119,7 @@ async def delete_content(
 
     content = visitor.content.get(content_id)
     content.delete()
+
 
 @app.delete("/api/contents/{content_id}/processes/{process_id}")
 async def destroy_process(
@@ -101,6 +138,7 @@ async def destroy_process(
             if job["status"] != 0:
                 return
             await asyncio.sleep(1)
+
 
 @app.get("/api/contents/{content_id}/author")
 async def get_author(

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -27,14 +27,14 @@
     "API Publishing",
     "OAuth Integrations"
   ],
-  "version": "0.0.4"
+  "version": "0.0.5"
   },
   "files": {
     "requirements.txt": {
       "checksum": "a162a98758867a701ce693948ffdfa67"
     },
     "app.py": {
-      "checksum": "55729c283443e02bcfc4233ccf0c2b3d"
+      "checksum": "aaadcea0fdb7bfa396bd94ba800edf30"
     },
     "dist/assets/fa-brands-400.808443ae.ttf": {
       "checksum": "15d54d142da2f2d6f2e90ed1d55121af"
@@ -60,14 +60,14 @@
     "dist/assets/fa-v4compatibility.30f6abf6.ttf": {
       "checksum": "4ed293ceaca9b5b2d9cd74a477963fae"
     },
+    "dist/assets/index.d89621ca.js": {
+      "checksum": "13b6fe53962f89359121b4c77ff77805"
+    },
     "dist/assets/index.eba02280.css": {
       "checksum": "cb5a34d5ea88d4969288161bd3123ee4"
     },
-    "dist/assets/index.f987f996.js": {
-      "checksum": "f8a777db2d3d8e211a31f70bbca57234"
-    },
     "dist/index.html": {
-      "checksum": "c61715903d067cc4ece8190fbdddb516"
+      "checksum": "1743a09f8314278ee4393b80806f901e"
     }
   }
 }

--- a/extensions/publisher-command-center/src/components/UnauthorizedView.js
+++ b/extensions/publisher-command-center/src/components/UnauthorizedView.js
@@ -1,0 +1,94 @@
+import m from "mithril";
+
+const UnauthorizedView = {
+  oninit: function(vnode) {
+    vnode.state.integration = null;
+    vnode.state.loading = true;
+
+    // Check for available integration
+    m.request({ method: "GET", url: "api/integrations" })
+      .then(response => {
+        vnode.state.integration = response;
+        vnode.state.loading = false;
+        m.redraw();
+      })
+      .catch(err => {
+        console.error("Failed to fetch integrations", err);
+        vnode.state.loading = false;
+        m.redraw();
+      });
+  },
+
+  addIntegration: function(vnode) {
+    if (!vnode.state.integration) return;
+
+    m.request({
+      method: "PUT",
+      url: "api/visitor-auth",
+      body: { integration_guid: vnode.state.integration.guid }
+    })
+      .then(() => {
+        // Reload the top-most window to check authorization again
+        window.top.location.reload();
+      })
+      .catch(err => {
+        console.error("Failed to add integration", err);
+      });
+  },
+
+  view: function(vnode) {
+    // Show loading state
+    if (vnode.state.loading) {
+      return m("div.d-flex.justify-content-center", { style: { margin: "3rem" } }, [
+        m("div.spinner-border.text-primary", { role: "status" },
+          m("span.visually-hidden", "Loading...")
+        )
+      ]);
+    }
+
+    // We have an integration ready to add
+    if (vnode.state.integration) {
+      return m("div.alert.alert-info", { style: { margin: "1rem auto", maxWidth: "800px" } }, [
+        m("div", { style: { marginBottom: "1rem" } }, [
+          m.trust("This content uses a <strong>Visitor API Key</strong> " +
+            "integration to show users the content they have access to. " +
+            "A compatible integration is displayed below." +
+            "<br><br>" +
+            "For more information, see " +
+            "<a href='https://docs.posit.co/connect/user/oauth-integrations/#obtaining-a-visitor-api-key' " +
+            "target='_blank'>documentation on Visitor API Key integrations</a>.")
+        ]),
+        m("button.btn.btn-primary", {
+          onclick: () => this.addIntegration(vnode)
+        }, [
+          m("i.fas.fa-plus.me-2"),
+          m.trust("Add the <strong>'" + (vnode.state.integration.title || vnode.state.integration.name || "Connect API") + "'</strong> Integration")
+        ])
+      ]);
+    }
+
+    // No integration available
+    const baseUrl = window.location.origin;
+    const integrationSettingsUrl = `${baseUrl}/connect/#/system/integrations`;
+
+    return m("div.alert.alert-warning", { style: { margin: "1rem auto", maxWidth: "800px" } }, [
+      m("div", { style: { marginBottom: "1rem" } }, [
+        m.trust("This content needs permission to show users the content they have access to." +
+          "<br><br>" +
+          "To allow this, an Administrator must configure a " +
+          "<strong>Connect API</strong> integration on the " +
+          "<strong><a href='" + integrationSettingsUrl + "' target='_blank'>Integration Settings</a></strong> page. " +
+          "<br><br>" +
+          "On that page, select <strong>'+ Add Integration'</strong>. " +
+          "In the 'Select Integration' dropdown, choose <strong>'Connect API'</strong>. " +
+          "The 'Max Role' field must be set to <strong>'Administrator'</strong> " +
+          "or <strong>'Publisher'</strong>; 'Viewer' will not work. " +
+          "<br><br>" +
+          "See the <a href='https://docs.posit.co/connect/admin/integrations/oauth-integrations/connect/' " +
+          "target='_blank'>Connect API section of the Admin Guide</a> for more detailed setup instructions.")
+      ])
+    ]);
+  }
+};
+
+export default UnauthorizedView;

--- a/extensions/publisher-command-center/src/index.js
+++ b/extensions/publisher-command-center/src/index.js
@@ -8,38 +8,17 @@ import "../scss/index.scss";
 
 import Home from "./views/Home";
 import Edit from "./views/Edit";
-import Layout from './views/Layout'
+import Layout from './views/Layout';
+import UnauthorizedView from './components/UnauthorizedView';
 
 const root = document.getElementById("app");
 
 // First ask the server “are we authorized?”
-m.request({ method: "GET", url: "api/auth-status" })
+m.request({ method: "GET", url: "api/visitor-auth" })
   .then((res) => {
     if (!res.authorized) {
-      // Unauthorized → just show the banner, never mount the router
-      m.mount(root, {
-        view: () =>
-          m(
-            "div.alert.alert-info",
-            { style: { margin: "1rem" } },
-            [
-              m("p", [
-                "To finish setting up this content, you must add a Visitor API Key ",
-                "integration with the Publisher scope."
-              ]),
-              m("p", [
-                'Select "+ Add integration" in the Access settings panel to the ',
-                'right, and find an entry with "Authentication type: Visitor API Key".'
-              ]),
-              m("p", [
-                "If no such integration exists, an Administrator must configure one. ",
-                "Go to Connect's System page, select the Integrations tab, then ",
-                'click "+ Add Integration", choose "Connect API", pick Publisher or ',
-                "Administrator under Max Role, and give it a descriptive title."
-              ])
-            ]
-          ),
-      });
+      // Unauthorized → mount our UnauthorizedView component
+      m.mount(root, UnauthorizedView);
     } else {
       // Authorized → wire up routes
       m.route(root, "/contents", {
@@ -53,6 +32,5 @@ m.request({ method: "GET", url: "api/auth-status" })
     }
   })
   .catch((err) => {
-    console.error("failed to fetch auth-status", err);
-    // you might also render a generic “uh-oh” banner here
+    console.error("failed to fetch visitor-auth", err);
   });


### PR DESCRIPTION
Fixes #144 

This PR adds a one-click deployment experience to the Publisher Command Center, bringing it inline with the Usage Metrics Dashboard. Uses the same language for both screens (integration found / no integration found).

A version is published at https://connect.posit.it/publisher-command-center-one-click-setup/ — if you're a collaborator (and if I tagged you for review you are) you can play around with adding and removing the integration.

https://github.com/user-attachments/assets/160ff9a9-3cbe-4432-abf9-4f8b88c89fd6

(Claude was helpful figuring out the Mithral stuff.)