### PR TITLE
Publisher Command Center: Minor UI improvements

### DIFF
--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -60,14 +60,14 @@
     "dist/assets/fa-v4compatibility.30f6abf6.ttf": {
       "checksum": "4ed293ceaca9b5b2d9cd74a477963fae"
     },
-    "dist/assets/index.586405aa.js": {
-      "checksum": "f3a6c1af2c3d4f6eb22a8f8f76b5ddf9"
+    "dist/assets/index.90f1ae46.js": {
+      "checksum": "8b85382a2fd0bb7f106cf03488e3bd72"
     },
     "dist/assets/index.eba02280.css": {
       "checksum": "cb5a34d5ea88d4969288161bd3123ee4"
     },
     "dist/index.html": {
-      "checksum": "e52a1ca0146288f14854111cb598886e"
+      "checksum": "af4c52e366ba6e5be8f9776014856862"
     }
   }
 }

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -60,14 +60,14 @@
     "dist/assets/fa-v4compatibility.30f6abf6.ttf": {
       "checksum": "4ed293ceaca9b5b2d9cd74a477963fae"
     },
+    "dist/assets/index.586405aa.js": {
+      "checksum": "f3a6c1af2c3d4f6eb22a8f8f76b5ddf9"
+    },
     "dist/assets/index.eba02280.css": {
       "checksum": "cb5a34d5ea88d4969288161bd3123ee4"
     },
-    "dist/assets/index.f987f996.js": {
-      "checksum": "f8a777db2d3d8e211a31f70bbca57234"
-    },
     "dist/index.html": {
-      "checksum": "c61715903d067cc4ece8190fbdddb516"
+      "checksum": "e52a1ca0146288f14854111cb598886e"
     }
   }
 }

--- a/extensions/publisher-command-center/src/components/Releases.js
+++ b/extensions/publisher-command-center/src/components/Releases.js
@@ -91,7 +91,7 @@ export default {
     return m(".pt-3.border-top", [
       m(".", [
         m("h5", [
-          "Releases ",
+          "Source Versions ",
           m("span.badge.rounded-pill.text-bg-secondary", releases.length),
         ]),
         recent,

--- a/extensions/publisher-command-center/src/views/Edit.js
+++ b/extensions/publisher-command-center/src/views/Edit.js
@@ -36,15 +36,24 @@ const Edit = {
 
     return m(
       "div",
-      m(".d-flex.flex-row.justify-content-between.align-items-center.my-3", [
-        m("h2.mb-0", content?.title || m("i", "No Name")),
+      m(".d-flex.flex-row.justify-content-between.align-items-baseline.my-3", [
+        m(".d-flex.align-items-baseline", [
+          m(
+            "a.btn.btn-md.btn-outline-primary.d-flex.align-items-center.justify-content-center.gap-2",
+            {
+              onclick: () => m.route.set("/contents")
+            },
+            [m("i.fa-solid.fa-arrow-left"), "Back"],
+          ),
+          m("h3.mb-0.ms-3", content?.title || m("i", "No Name")),
+        ]),
         m(
-          "a.btn.btn-lg.btn-outline-primary.d-flex.align-items-center.justify-content-center.gap-2",
+          "a.btn.btn-md.btn-outline-primary.d-flex.align-items-center.justify-content-center.gap-2.ms-3",
           {
             href: content?.dashboard_url,
             target: "_blank",
           },
-          ["Open in Connect", m("i.fa-solid.fa-arrow-up-right-from-square")],
+          ["Open", m("i.fa-solid.fa-arrow-up-right-from-square")],
         ),
       ]),
       m(".row", m(".pb-3", m(Languages, content))),

--- a/extensions/publisher-command-center/src/views/Edit.js
+++ b/extensions/publisher-command-center/src/views/Edit.js
@@ -52,6 +52,7 @@ const Edit = {
           {
             href: content?.dashboard_url,
             target: "_blank",
+            ariaLabel: "Open in a new tab"
           },
           ["Open", m("i.fa-solid.fa-arrow-up-right-from-square")],
         ),


### PR DESCRIPTION
Minor improvements to UI language and layout in the Publisher Command Center:

- "Releases" -> "Source Versions"
- "Open in Connect" -> "Open"
- Added a back button, improved sizing and alignment in title bar while I was there

Fixes https://github.com/posit-dev/connect-extensions/issues/119

![Screen Shot 2025-05-22 at 11 41 50 AM@2x](https://github.com/user-attachments/assets/dd3fb044-f1ee-4ed1-b9e1-e8f1d05f0f2f)
![Screen Shot 2025-05-22 at 11 41 39 AM@2x](https://github.com/user-attachments/assets/1bd87adc-ef06-4870-b2c0-544f22837160)
