### PR TITLE
Adjust add OAuth Integration messaging to be more friendly

### DIFF
--- a/extensions/publisher-command-center/src/components/UnauthorizedView.js
+++ b/extensions/publisher-command-center/src/components/UnauthorizedView.js
@@ -59,7 +59,8 @@ const UnauthorizedView = {
           m("p", [
             "This content uses a ",
             m("strong", "Visitor API Key"),
-            " integration to show users the content they have access to. A compatible integration is displayed below."
+            " integration to show users the content they have access to.",
+            " A compatible integration is already available; use it below."
           ]),
           m("p", [
             "For more information, see ",
@@ -73,7 +74,7 @@ const UnauthorizedView = {
           onclick: () => this.addIntegration(vnode)
         }, [
           m("i.fas.fa-plus.me-2"),
-          "Add the ",
+          "Use the ",
           m("strong", vnode.state.integration.title || vnode.state.integration.name || "Connect API"),
           " Integration"
         ])

--- a/extensions/usage-metrics-dashboard/app.R
+++ b/extensions/usage-metrics-dashboard/app.R
@@ -323,7 +323,7 @@ server <- function(input, output, session) {
         message <- paste0(
           "This content uses a <strong>Visitor API Key</strong> ",
           "integration to show users the content they have access to. ",
-          "A compatible integration is displayed below.",
+          "A compatible integration is already available; use it below.",
           "<br><br>",
           "For more information, see ",
           "<a href='https://docs.posit.co/connect/user/oauth-integrations/#obtaining-a-visitor-api-key' ",
@@ -358,7 +358,7 @@ server <- function(input, output, session) {
 
       footer <- if (nrow(selected_integration) == 1) {
         button_label <- HTML(paste0(
-          "Add the ",
+          "Use the ",
           "<strong>'",
           selected_integration$name,
           "'</strong> ",
@@ -367,7 +367,8 @@ server <- function(input, output, session) {
         actionButton(
           "auto_add_integration",
           button_label,
-          icon = icon("plus")
+          icon = icon("plus"),
+          class = "btn btn-primary"
         )
       } else if (nrow(selected_integration) == 0) {
         NULL


### PR DESCRIPTION
This PR updates the buttons to be primary for adding integrations, and adjusts the text slightly.