### PR TITLE
Loosen `usage-metrics-dashboard` R requirement

### DIFF
--- a/extensions/usage-metrics-dashboard/manifest.json
+++ b/extensions/usage-metrics-dashboard/manifest.json
@@ -11,7 +11,7 @@
   },
   "environment": {
     "r": {
-      "requires": "~=4.3.0"
+      "requires": "~=4.3"
     }
   },
   "packages": {
@@ -3079,6 +3079,6 @@
     "requiredFeatures": [
       "OAuth Integrations"
     ],
-    "version": "1.0.3"
+    "version": "1.0.4"
   }
 }


### PR DESCRIPTION
This releases a new version of the Usage Metrics Dashboard that loosens the R environment requirement. Instead of requiring `~=4.3.0` (`4.3.x`) this allows for `4.x` R versions.