### PR TITLE
Add latest Connect release to integration version list

### DIFF
--- a/integration/Makefile
+++ b/integration/Makefile
@@ -57,6 +57,7 @@ PYTEST_ARGS ?= "-s"
 # possible versions to test against in CI or when using the `all` target.
 CONNECT_VERSIONS := \
 	connect-preview \
+	2025.06.0 \
 	2025.05.0 \
 	2025.04.0
 


### PR DESCRIPTION
Adds the latest release to the list.

A nice future change would be to fetch these programmatically and add any monthly release to the list.

```
❯ make -C ./integration print-versions
connect-preview
2025.06.0
2025.05.0
2025.04.0
```

```
make -C ./integration 2025.05.0 EXTENSION_NAME=portfolio-report
...
connect-1  | time="2025-06-17T21:33:27.369Z" level=info msg="Found 4 environment variables starting with 'CONNECT_' that may affect configuration.\n"
connect-1  | time="2025-06-17T21:33:27.370Z" level=info msg="Writing Posit Connect Service log in TEXT format to STDOUT."
connect-1  | time="2025-06-17T21:33:27.370Z" level=info msg="Starting Posit Connect v2025.05.0"
connect-1  | time="2025-06-17T21:33:27.370Z" level=info msg="Product version v2025.05.0 end-of-support: 2026-11-30"
connect-1  | time="2025-06-17T21:33:27.370Z" level=info msg="Posit Connect running with PID 8"
---
tests-1    | tests/posit/connect/test_deployments.py Bundle deployment completed after 224.1s
tests-1    | Content validated successfully after 0.2s
tests-1    | .
tests-1    | 
tests-1    | -- generated xml file: /connect-extensions/integration/reports/2025.05.0.xml ---
tests-1    | ======================== 1 passed in 224.63s (0:03:44) =========================
tests-1 exited with code 0
Aborting on container exit...
[+] Stopping 2/2 Desktop   o View Config   w Enable Watch
 ✔ Container connect-extensions-2025-05-0-tests-1    Stopped                                                                    0.0s 
 ✔ Container connect-extensions-2025-05-0-connect-1  Stopped 
```

