### PR TITLE
Runtime Version Scanner: Display only a publisher's content

### DIFF
--- a/extensions/eol-runtime-scanner/Makefile
+++ b/extensions/eol-runtime-scanner/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	Rscript -e 'testthat::test_dir("tests")'

--- a/extensions/eol-runtime-scanner/app.R
+++ b/extensions/eol-runtime-scanner/app.R
@@ -8,6 +8,7 @@ library(lubridate)
 library(bsicons)
 
 source("get_usage.R")
+source("connect_module.R")
 
 options(
   spinner.type = 1,
@@ -49,7 +50,10 @@ ui <- page_sidebar(
 )
 
 server <- function(input, output, session) {
-  client <- connect()
+  client <- connectVisitorClient()
+  if (is.null(client)) {
+    return()
+  }
 
   content <- reactive({
     content <- get_content(client) |>

--- a/extensions/eol-runtime-scanner/app.R
+++ b/extensions/eol-runtime-scanner/app.R
@@ -11,6 +11,7 @@ library(shinyWidgets)
 
 source("get_usage.R")
 source("connect_module.R")
+source("version_ordering.R")
 
 options(
   spinner.type = 1,
@@ -38,41 +39,6 @@ app_mode_lookup <- with(
   stack(app_mode_groups),
   setNames(as.character(ind), values)
 )
-
-# Functions to handle versions
-
-# Takes a column from a data frame and returns a character vector sorted as
-# version numbers.
-ordered_version_levels <- function(versions) {
-  rv <- versions |>
-    na.omit() |>
-    unique() |>
-    as.numeric_version() |>
-    sort() |>
-    as.character()
-}
-
-# turns a character vector of version numbers into an ordered factor
-as_ordered_version_factor <- function(versions) {
-  # Safely coerce versions, invalid ones become NA.
-  # (Some versions on Dogfood were malformed as "", and this caused crashes.)
-  safe_versions <- vapply(
-    versions,
-    function(v) {
-      tryCatch(
-        as.character(as.numeric_version(v)),
-        error = function(e) NA_character_
-      )
-    },
-    character(1)
-  )
-
-  factor(
-    safe_versions,
-    levels = ordered_version_levels(safe_versions),
-    ordered = TRUE
-  )
-}
 
 # Shiny app definition
 

--- a/extensions/eol-runtime-scanner/app.R
+++ b/extensions/eol-runtime-scanner/app.R
@@ -177,19 +177,19 @@ server <- function(input, output, session) {
       updateSliderTextInput(
         session,
         "min_r_version",
-        choices = rv
+        choices = I(rv)
       )
 
       updateSliderTextInput(
         session,
         "min_py_version",
-        choices = pv
+        choices = I(pv)
       )
 
       updateSliderTextInput(
         session,
         "min_quarto_version",
-        choices = qv
+        choices = I(qv)
       )
     },
     ignoreNULL = TRUE
@@ -308,7 +308,9 @@ server <- function(input, output, session) {
           width = 32,
           sortable = FALSE,
           cell = function(url) {
-            if (is.na(url) || url == "") return("")
+            if (is.na(url) || url == "") {
+              return("")
+            }
             HTML(as.character(tags$div(
               onclick = "event.stopPropagation()",
               tags$a(

--- a/extensions/eol-runtime-scanner/connect_module.R
+++ b/extensions/eol-runtime-scanner/connect_module.R
@@ -1,0 +1,140 @@
+library(shiny)
+library(connectapi)
+library(purrr)
+library(dplyr)
+
+
+connectVisitorClient <- function(
+  id = ".connect_visitor_client",
+  publisher_client = connect()
+) {
+  moduleServer(id, function(input, output, session) {
+    selected_integration_guid <- reactiveVal(NULL)
+
+    client <- NULL
+    tryCatch(
+      {
+        client <- connect(
+          token = session$request$HTTP_POSIT_CONNECT_USER_SESSION_TOKEN
+        )
+      },
+      error = function(e) {
+        eligible_integrations <- get_eligible_integrations(publisher_client)
+        selected_integration <- eligible_integrations %>%
+          arrange(config) %>%
+          slice_head(n = 1)
+        selected_integration_guid(selected_integration$guid)
+
+        if (nrow(selected_integration) == 1) {
+          message <- paste0(
+            "This content uses a <strong>Visitor API Key</strong> ",
+            "integration to show users the content they have access to. ",
+            "A compatible integration is already available; use it below.",
+            "<br><br>",
+            "For more information, see ",
+            "<a href='https://docs.posit.co/connect/user/oauth-integrations/#obtaining-a-visitor-api-key' ",
+            "target='_blank'>documentation on Visitor API Key integrations</a>."
+          )
+        } else if (nrow(selected_integration) == 0) {
+          integration_settings_url <- publisher_client$server_url(
+            connectapi:::unversioned_url(
+              "connect",
+              "#",
+              "system",
+              "integrations"
+            )
+          )
+          message <- paste0(
+            "This content needs permission to ",
+            " show users the content they have access to.",
+            "<br><br>",
+            "To allow this, an Administrator must configure a ",
+            "<strong>Connect API</strong> integration on the ",
+            "<strong><a href='",
+            integration_settings_url,
+            "' target='_blank'>Integration Settings</a></strong> page. ",
+            "<br><br>",
+            "On that page, select <strong>'+ Add Integration'</strong>. ",
+            "In the 'Select Integration' dropdown, choose <strong>'Connect API'</strong>. ",
+            "The 'Max Role' field must be set to <strong>'Administrator'</strong> ",
+            "or <strong>'Publisher'</strong>; 'Viewer' will not work. ",
+            "<br><br>",
+            "See the <a href='https://docs.posit.co/connect/admin/integrations/oauth-integrations/connect/' ",
+            "target='_blank'>Connect API section of the Admin Guide</a> for more detailed setup instructions."
+          )
+        }
+
+        footer <- if (nrow(selected_integration) == 1) {
+          button_label <- HTML(paste0(
+            "Use the ",
+            "<strong>'",
+            selected_integration$name,
+            "'</strong> ",
+            "Integration"
+          ))
+          actionButton(
+            inputId = session$ns("auto_add_integration"),
+            label = button_label,
+            icon = icon("plus"),
+            class = "btn btn-primary"
+          )
+        } else {
+          NULL
+        }
+
+        showModal(
+          modalDialog(
+            footer = footer,
+            HTML(message)
+          )
+        )
+      }
+    )
+
+    # “Use the ‘…’ Integration” button logic
+    observeEvent(input$auto_add_integration, {
+      auto_add_integration(publisher_client, selected_integration_guid())
+      session$reload()
+    })
+
+    return(client)
+  })
+}
+
+# ----
+# Your existing helper functions, unchanged:
+get_eligible_integrations <- function(client) {
+  tryCatch(
+    {
+      integrations <- client$GET("v1/oauth/integrations")
+      map_dfr(integrations, function(record) {
+        main_fields <- discard(record, is.list)
+        config <- paste(
+          imap_chr(record$config, ~ paste(.y, .x, sep = ": ")),
+          collapse = ", "
+        )
+        c(main_fields, config = config)
+      }) %>%
+        filter(
+          template == "connect",
+          config %in% c("max_role: Admin", "max_role: Publisher")
+        )
+    },
+    error = function(e) {
+      tibble() # return empty if the GET fails
+    }
+  )
+}
+
+auto_add_integration <- function(client, integration_guid) {
+  client$PUT(
+    connectapi:::v1_url(
+      "content",
+      Sys.getenv("CONNECT_CONTENT_GUID"),
+      "oauth",
+      "integrations",
+      "associations"
+    ),
+    body = list(list(oauth_integration_guid = integration_guid))
+  )
+}

--- a/extensions/eol-runtime-scanner/renv.lock
+++ b/extensions/eol-runtime-scanner/renv.lock
@@ -1995,6 +1995,80 @@
       "NeedsCompilation": "yes",
       "Repository": "CRAN"
     },
+    "stringi": {
+      "Package": "stringi",
+      "Version": "1.8.7",
+      "Source": "Repository",
+      "Date": "2025-03-27",
+      "Title": "Fast and Portable Character String Processing Facilities",
+      "Description": "A collection of character string/text/natural language processing tools for pattern searching (e.g., with 'Java'-like regular expressions or the 'Unicode' collation algorithm), random string generation, case mapping, string transliteration, concatenation, sorting, padding, wrapping, Unicode normalisation, date-time formatting and parsing, and many more. They are fast, consistent, convenient, and - thanks to 'ICU' (International Components for Unicode) - portable across all locales and platforms. Documentation about 'stringi' is provided via its website at <https://stringi.gagolewski.com/> and the paper by Gagolewski (2022, <doi:10.18637/jss.v103.i02>).",
+      "URL": "https://stringi.gagolewski.com/, https://github.com/gagolews/stringi, https://icu.unicode.org/",
+      "BugReports": "https://github.com/gagolews/stringi/issues",
+      "SystemRequirements": "ICU4C (>= 61, optional)",
+      "Type": "Package",
+      "Depends": [
+        "R (>= 3.4)"
+      ],
+      "Imports": [
+        "tools",
+        "utils",
+        "stats"
+      ],
+      "Biarch": "TRUE",
+      "License": "file LICENSE",
+      "Authors@R": "c(person(given = \"Marek\", family = \"Gagolewski\", role = c(\"aut\", \"cre\", \"cph\"), email = \"marek@gagolewski.com\", comment = c(ORCID = \"0000-0003-0637-6028\")), person(given = \"Bartek\", family = \"Tartanus\", role = \"ctb\"), person(\"Unicode, Inc. and others\", role=\"ctb\", comment = \"ICU4C source code, Unicode Character Database\") )",
+      "RoxygenNote": "7.3.2",
+      "Encoding": "UTF-8",
+      "NeedsCompilation": "yes",
+      "Author": "Marek Gagolewski [aut, cre, cph] (<https://orcid.org/0000-0003-0637-6028>), Bartek Tartanus [ctb], Unicode, Inc. and others [ctb] (ICU4C source code, Unicode Character Database)",
+      "Maintainer": "Marek Gagolewski <marek@gagolewski.com>",
+      "License_is_FOSS": "yes",
+      "Repository": "CRAN"
+    },
+    "stringr": {
+      "Package": "stringr",
+      "Version": "1.5.1",
+      "Source": "Repository",
+      "Title": "Simple, Consistent Wrappers for Common String Operations",
+      "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = c(\"aut\", \"cre\", \"cph\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")) )",
+      "Description": "A consistent, simple and easy to use set of wrappers around the fantastic 'stringi' package. All function and argument names (and positions) are consistent, all functions deal with \"NA\"'s and zero length vectors in the same way, and the output from one function is easy to feed into the input of another.",
+      "License": "MIT + file LICENSE",
+      "URL": "https://stringr.tidyverse.org, https://github.com/tidyverse/stringr",
+      "BugReports": "https://github.com/tidyverse/stringr/issues",
+      "Depends": [
+        "R (>= 3.6)"
+      ],
+      "Imports": [
+        "cli",
+        "glue (>= 1.6.1)",
+        "lifecycle (>= 1.0.3)",
+        "magrittr",
+        "rlang (>= 1.0.0)",
+        "stringi (>= 1.5.3)",
+        "vctrs (>= 0.4.0)"
+      ],
+      "Suggests": [
+        "covr",
+        "dplyr",
+        "gt",
+        "htmltools",
+        "htmlwidgets",
+        "knitr",
+        "rmarkdown",
+        "testthat (>= 3.0.0)",
+        "tibble"
+      ],
+      "VignetteBuilder": "knitr",
+      "Config/Needs/website": "tidyverse/tidytemplate",
+      "Config/testthat/edition": "3",
+      "Encoding": "UTF-8",
+      "LazyData": "true",
+      "RoxygenNote": "7.2.3",
+      "NeedsCompilation": "no",
+      "Author": "Hadley Wickham [aut, cre, cph], Posit Software, PBC [cph, fnd]",
+      "Maintainer": "Hadley Wickham <hadley@posit.co>",
+      "Repository": "CRAN"
+    },
     "sys": {
       "Package": "sys",
       "Version": "3.4.3",
@@ -2086,6 +2160,56 @@
       "NeedsCompilation": "yes",
       "Author": "Kirill Müller [aut, cre] (<https://orcid.org/0000-0002-1416-3412>), Hadley Wickham [aut], Romain Francois [ctb], Jennifer Bryan [ctb], RStudio [cph, fnd]",
       "Maintainer": "Kirill Müller <kirill@cynkra.com>",
+      "Repository": "CRAN"
+    },
+    "tidyr": {
+      "Package": "tidyr",
+      "Version": "1.3.1",
+      "Source": "Repository",
+      "Title": "Tidy Messy Data",
+      "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = c(\"aut\", \"cre\")), person(\"Davis\", \"Vaughan\", , \"davis@posit.co\", role = \"aut\"), person(\"Maximilian\", \"Girlich\", role = \"aut\"), person(\"Kevin\", \"Ushey\", , \"kevin@posit.co\", role = \"ctb\"), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")) )",
+      "Description": "Tools to help to create tidy data, where each column is a variable, each row is an observation, and each cell contains a single value.  'tidyr' contains tools for changing the shape (pivoting) and hierarchy (nesting and 'unnesting') of a dataset, turning deeply nested lists into rectangular data frames ('rectangling'), and extracting values out of string columns. It also includes tools for working with missing values (both implicit and explicit).",
+      "License": "MIT + file LICENSE",
+      "URL": "https://tidyr.tidyverse.org, https://github.com/tidyverse/tidyr",
+      "BugReports": "https://github.com/tidyverse/tidyr/issues",
+      "Depends": [
+        "R (>= 3.6)"
+      ],
+      "Imports": [
+        "cli (>= 3.4.1)",
+        "dplyr (>= 1.0.10)",
+        "glue",
+        "lifecycle (>= 1.0.3)",
+        "magrittr",
+        "purrr (>= 1.0.1)",
+        "rlang (>= 1.1.1)",
+        "stringr (>= 1.5.0)",
+        "tibble (>= 2.1.1)",
+        "tidyselect (>= 1.2.0)",
+        "utils",
+        "vctrs (>= 0.5.2)"
+      ],
+      "Suggests": [
+        "covr",
+        "data.table",
+        "knitr",
+        "readr",
+        "repurrrsive (>= 1.1.0)",
+        "rmarkdown",
+        "testthat (>= 3.0.0)"
+      ],
+      "LinkingTo": [
+        "cpp11 (>= 0.4.0)"
+      ],
+      "VignetteBuilder": "knitr",
+      "Config/Needs/website": "tidyverse/tidytemplate",
+      "Config/testthat/edition": "3",
+      "Encoding": "UTF-8",
+      "LazyData": "true",
+      "RoxygenNote": "7.3.0",
+      "NeedsCompilation": "yes",
+      "Author": "Hadley Wickham [aut, cre], Davis Vaughan [aut], Maximilian Girlich [aut], Kevin Ushey [ctb], Posit Software, PBC [cph, fnd]",
+      "Maintainer": "Hadley Wickham <hadley@posit.co>",
       "Repository": "CRAN"
     },
     "tidyselect": {

--- a/extensions/eol-runtime-scanner/renv.lock
+++ b/extensions/eol-runtime-scanner/renv.lock
@@ -1941,6 +1941,45 @@
       "Maintainer": "Winston Chang <winston@posit.co>",
       "Repository": "CRAN"
     },
+    "shinyWidgets": {
+      "Package": "shinyWidgets",
+      "Version": "0.9.0",
+      "Source": "Repository",
+      "Title": "Custom Inputs Widgets for Shiny",
+      "Authors@R": "c( person(\"Victor\", \"Perrier\", email = \"victor.perrier@dreamrs.fr\", role = c(\"aut\", \"cre\", \"cph\")), person(\"Fanny\", \"Meyer\", role = \"aut\"), person(\"David\", \"Granjon\", role = \"aut\"), person(\"Ian\", \"Fellows\", role = \"ctb\", comment = \"Methods for mutating vertical tabs & updateMultiInput\"), person(\"Wil\", \"Davis\", role = \"ctb\", comment = \"numericRangeInput function\"), person(\"Spencer\", \"Matthews\", role = \"ctb\", comment = \"autoNumeric methods\"), person(family = \"JavaScript and CSS libraries authors\", role = c(\"ctb\", \"cph\"), comment = \"All authors are listed in LICENSE.md\") )",
+      "Description": "Collection of custom input controls and user interface components for 'Shiny' applications.  Give your applications a unique and colorful style !",
+      "URL": "https://github.com/dreamRs/shinyWidgets, https://dreamrs.github.io/shinyWidgets/",
+      "BugReports": "https://github.com/dreamRs/shinyWidgets/issues",
+      "License": "GPL-3",
+      "Encoding": "UTF-8",
+      "LazyData": "true",
+      "RoxygenNote": "7.3.2",
+      "Depends": [
+        "R (>= 3.1.0)"
+      ],
+      "Imports": [
+        "bslib",
+        "sass",
+        "shiny (>= 1.6.0)",
+        "htmltools (>= 0.5.1)",
+        "jsonlite",
+        "grDevices",
+        "rlang"
+      ],
+      "Suggests": [
+        "testthat",
+        "covr",
+        "ggplot2",
+        "DT",
+        "scales",
+        "shinydashboard",
+        "shinydashboardPlus"
+      ],
+      "NeedsCompilation": "no",
+      "Author": "Victor Perrier [aut, cre, cph], Fanny Meyer [aut], David Granjon [aut], Ian Fellows [ctb] (Methods for mutating vertical tabs & updateMultiInput), Wil Davis [ctb] (numericRangeInput function), Spencer Matthews [ctb] (autoNumeric methods), JavaScript and CSS libraries authors [ctb, cph] (All authors are listed in LICENSE.md)",
+      "Maintainer": "Victor Perrier <victor.perrier@dreamrs.fr>",
+      "Repository": "CRAN"
+    },
     "shinycssloaders": {
       "Package": "shinycssloaders",
       "Version": "1.1.0",

--- a/extensions/eol-runtime-scanner/tests/test_version_ordering.R
+++ b/extensions/eol-runtime-scanner/tests/test_version_ordering.R
@@ -41,7 +41,10 @@ test_that("sort_unique_versions returns a sorted vector of unique versions", {
   )
 
   # The input vector must already be sanitized.
-  expect_error(sort_unique_versions(versions))
+  expect_error(
+    sort_unique_versions(versions),
+    "invalid version specification ‘’, ‘three’, ‘a.b.c’"
+  )
 })
 
 test_that("as_ordered_version_factor produces properly ordered versions of character vectors.", {
@@ -54,16 +57,5 @@ test_that("as_ordered_version_factor produces properly ordered versions of chara
       levels = c("2.8.9", "3.8.2", "3.11.2", "3.11.3", "3.12.1", "4.0.1"),
       class = c("ordered", "factor")
     )
-  )
-
-  # Comparisons work as expected
-  expect_true(
-    all(c(
-      vf[1] > vf[2],
-      vf[2] < vf[6],
-      vf[6] > vf[11],
-      vf[7] > vf[8],
-      vf[7] == vf[9]
-    ))
   )
 })

--- a/extensions/eol-runtime-scanner/tests/test_version_ordering.R
+++ b/extensions/eol-runtime-scanner/tests/test_version_ordering.R
@@ -1,0 +1,69 @@
+source("../version_ordering.R")
+
+versions <- c(
+  "3.8.2",
+  "2.8.9",
+  NA,
+  "",
+  "three",
+  "4.0.1",
+  "3.11.3",
+  "3.11.2",
+  "3.11.3",
+  "a.b.c",
+  "3.12.1"
+)
+
+test_that("sanitize_versions replaces malformed versions wth NA", {
+  expect_equal(
+    sanitize_versions(versions),
+    c(
+      "3.8.2",
+      "2.8.9",
+      NA,
+      NA,
+      NA,
+      "4.0.1",
+      "3.11.3",
+      "3.11.2",
+      "3.11.3",
+      NA,
+      "3.12.1"
+    )
+  )
+})
+
+test_that("sort_unique_versions returns a sorted vector of unique versions", {
+  sanitized <- sanitize_versions(versions)
+  expect_equal(
+    sort_unique_versions(sanitized),
+    c("2.8.9", "3.8.2", "3.11.2", "3.11.3", "3.12.1", "4.0.1")
+  )
+
+  # The input vector must already be sanitized.
+  expect_error(sort_unique_versions(versions))
+})
+
+test_that("as_ordered_version_factor produces properly ordered versions of character vectors.", {
+  vf <- as_ordered_version_factor(versions)
+
+  expect_equal(
+    vf,
+    structure(
+      c(2L, 1L, NA, NA, NA, 6L, 4L, 3L, 4L, NA, 5L),
+      levels = c("2.8.9", "3.8.2", "3.11.2", "3.11.3", "3.12.1", "4.0.1"),
+      class = c("ordered", "factor")
+    )
+  )
+
+  # Comparisons work as expected
+  expect_true(
+    all(c(
+      vf[1] > vf[2],
+      vf[2] < vf[6],
+      vf[6] > vf[11],
+      vf[7] > vf[8],
+      vf[7] == vf[9]
+    ))
+  )
+})

--- a/extensions/eol-runtime-scanner/version_ordering.R
+++ b/extensions/eol-runtime-scanner/version_ordering.R
@@ -1,0 +1,39 @@
+# Functions to create ordered factors of versions.
+
+# Turns a character vector of version numbers into a factor with levels
+# appropriately ordered.
+as_ordered_version_factor <- function(versions) {
+  sanitized <- sanitize_versions(versions)
+  factor(
+    sanitized,
+    levels = sort_unique_versions(sanitized),
+    ordered = TRUE
+  )
+}
+
+
+# Sanitize version inputs, because invalid versions cause as.numeric_version() to crash.
+sanitize_versions <- function(versions) {
+  vapply(
+    versions,
+    function(v) {
+      tryCatch(
+        as.character(as.numeric_version(v)),
+        error = function(e) NA_character_
+      )
+    },
+    character(1),
+    USE.NAMES = FALSE
+  )
+}
+
+# Takes a character vector of sanitized versions and returns a character vector
+# of those versions, unique and sorted by version order.
+sort_unique_versions <- function(versions) {
+  versions |>
+    na.omit() |>
+    unique() |>
+    as.numeric_version() |>
+    sort() |>
+    as.character()
+}

--- a/extensions/eol-runtime-scanner/www/styles.css
+++ b/extensions/eol-runtime-scanner/www/styles.css
@@ -1,0 +1,3 @@
+.form-group.shiny-input-container.checkbox+.shiny-panel-conditional>.form-group.shiny-input-container {
+    margin-top: 0 !important;
+}


### PR DESCRIPTION
This PR adds the following features:

- Displays only visitor-scoped content. Currently, it still uses the `v1/content` API, so behind the scenes admin users still see all content downloaded and have it scoped client-side to their owned/collaborating content. However, this is factored in the app such that it'd be easy to replace it with a call to the `v1/search/content` endpoint.
- Uses a visitor-scoped Connect client. This is added as a Shiny module, moving all but two lines of code out of the main app (in the interests of clarity and exploring how we might better provide this functionality to our users).
- Only displays content that uses selected EOL runtimes. Table highlights the matching runtime, in case the content uses more than one runtime and only one is EOL.
- Displays summary text at the top about the selected EOL runtimes and the number of matching pieces of content.

The app is deployed on Dogfood and connect.posit.it:
https://dogfood.team.pct.posit.it/runtime-version-scanner/
https://connect.posit.it/runtime-version-scanner/

@jonkeane I mentioned that I felt like I had a bit more clarity about when the app was ready for feedback — I think the changes made here make the app fit the top-level brief [here](https://github.com/posit-dev/connect/issues/29629) (although that does need refinement, I'll get to that later). I feel like the functionality here could spark opinions about what people would _actually_ want to see.

---- 

Updates after feedback

- Displays the entire content data frame when nothing is selected for filtering.
- Uses sliders to display filter controls.
- Renamed from "EOL Runtime Scanner" to "Runtime Version Scanner"
- Adds tests