### PR TITLE
runtime version scanner: improve table display and filter controls

### DIFF
--- a/extensions/eol-runtime-scanner/app.R
+++ b/extensions/eol-runtime-scanner/app.R
@@ -129,7 +129,7 @@ ui <- page_sidebar(
 
     numericInput(
       "min_hits_filter",
-      label = "Minimum Hits",
+      label = "Minimum Views",
       value = 0,
       min = 0,
       step = 1
@@ -139,7 +139,7 @@ ui <- page_sidebar(
 
     checkboxInput(
       "show_guid",
-      label = "Show GUID"
+      label = "Show GUIDs"
     ),
 
     checkboxInput(
@@ -419,7 +419,7 @@ server <- function(input, output, session) {
         ),
 
         hits = colDef(
-          name = "Hits (1 Week)",
+          name = "Views (Last Week)",
           width = 125,
           class = "number-pre",
         )

--- a/extensions/eol-runtime-scanner/app.R
+++ b/extensions/eol-runtime-scanner/app.R
@@ -7,7 +7,6 @@ library(shinycssloaders)
 library(lubridate)
 library(bsicons)
 library(tidyr)
-library(shinyWidgets)
 
 source("get_usage.R")
 source("connect_module.R")
@@ -304,23 +303,23 @@ server <- function(input, output, session) {
 
       li_items <- list()
       if (input$use_r_cutoff) {
-        li_items[[length(li_items) + 1]] <- tags$li(glue::glue(
-          "R older than {rv} ({r_count} items)"
-        ))
+        li_items[[length(li_items) + 1]] <- tags$li(HTML(glue::glue(
+          "R older than <span class='number-pre'>{rv}</span> ({r_count} items)"
+        )))
       }
       if (input$use_py_cutoff) {
-        li_items[[length(li_items) + 1]] <- tags$li(glue::glue(
-          "Python older than {pv} ({py_count} items)"
-        ))
+        li_items[[length(li_items) + 1]] <- tags$li(HTML(glue::glue(
+          "Python older than <span class='number-pre'>{pv}</span> ({py_count} items)"
+        )))
       }
       if (input$use_quarto_cutoff) {
-        li_items[[length(li_items) + 1]] <- tags$li(glue::glue(
-          "Quarto older than {qv} ({quarto_count} items)"
-        ))
+        li_items[[length(li_items) + 1]] <- tags$li(HTML(glue::glue(
+          "Quarto older than <span class='number-pre'>{qv}</span> ({quarto_count} items)"
+        )))
       }
 
       tagList(
-        tags$p(glue::glue("Showing {total_count} items meeting any of:")),
+        tags$p(glue::glue("Showing {total_count} items with any of:")),
         tags$ul(
           style = "margin-top: 0.25rem; margin-bottom: 0.5rem;",
           tagList(li_items)

--- a/extensions/eol-runtime-scanner/renv.lock
+++ b/extensions/eol-runtime-scanner/renv.lock
@@ -1941,45 +1941,6 @@
       "Maintainer": "Winston Chang <winston@posit.co>",
       "Repository": "CRAN"
     },
-    "shinyWidgets": {
-      "Package": "shinyWidgets",
-      "Version": "0.9.0",
-      "Source": "Repository",
-      "Title": "Custom Inputs Widgets for Shiny",
-      "Authors@R": "c( person(\"Victor\", \"Perrier\", email = \"victor.perrier@dreamrs.fr\", role = c(\"aut\", \"cre\", \"cph\")), person(\"Fanny\", \"Meyer\", role = \"aut\"), person(\"David\", \"Granjon\", role = \"aut\"), person(\"Ian\", \"Fellows\", role = \"ctb\", comment = \"Methods for mutating vertical tabs & updateMultiInput\"), person(\"Wil\", \"Davis\", role = \"ctb\", comment = \"numericRangeInput function\"), person(\"Spencer\", \"Matthews\", role = \"ctb\", comment = \"autoNumeric methods\"), person(family = \"JavaScript and CSS libraries authors\", role = c(\"ctb\", \"cph\"), comment = \"All authors are listed in LICENSE.md\") )",
-      "Description": "Collection of custom input controls and user interface components for 'Shiny' applications.  Give your applications a unique and colorful style !",
-      "URL": "https://github.com/dreamRs/shinyWidgets, https://dreamrs.github.io/shinyWidgets/",
-      "BugReports": "https://github.com/dreamRs/shinyWidgets/issues",
-      "License": "GPL-3",
-      "Encoding": "UTF-8",
-      "LazyData": "true",
-      "RoxygenNote": "7.3.2",
-      "Depends": [
-        "R (>= 3.1.0)"
-      ],
-      "Imports": [
-        "bslib",
-        "sass",
-        "shiny (>= 1.6.0)",
-        "htmltools (>= 0.5.1)",
-        "jsonlite",
-        "grDevices",
-        "rlang"
-      ],
-      "Suggests": [
-        "testthat",
-        "covr",
-        "ggplot2",
-        "DT",
-        "scales",
-        "shinydashboard",
-        "shinydashboardPlus"
-      ],
-      "NeedsCompilation": "no",
-      "Author": "Victor Perrier [aut, cre, cph], Fanny Meyer [aut], David Granjon [aut], Ian Fellows [ctb] (Methods for mutating vertical tabs & updateMultiInput), Wil Davis [ctb] (numericRangeInput function), Spencer Matthews [ctb] (autoNumeric methods), JavaScript and CSS libraries authors [ctb, cph] (All authors are listed in LICENSE.md)",
-      "Maintainer": "Victor Perrier <victor.perrier@dreamrs.fr>",
-      "Repository": "CRAN"
-    },
     "shinycssloaders": {
       "Package": "shinycssloaders",
       "Version": "1.1.0",

--- a/extensions/eol-runtime-scanner/www/styles.css
+++ b/extensions/eol-runtime-scanner/www/styles.css
@@ -29,5 +29,5 @@
 .number-pre {
   font-family: "Fira Mono", Consolas, Monaco, monospace;
   white-space: pre;
-  font-size: 0.84375rem;
+  font-size: 96%;
 }

--- a/extensions/eol-runtime-scanner/www/styles.css
+++ b/extensions/eol-runtime-scanner/www/styles.css
@@ -1,3 +1,33 @@
+/* Reduce spacing between checkbox and conditional panel */
 .form-group.shiny-input-container.checkbox+.shiny-panel-conditional>.form-group.shiny-input-container {
-    margin-top: 0 !important;
+  margin-top: 0 !important;
+}
+
+/* Adjust the spacing for selectize inputs in conditional panels */
+.form-group.shiny-input-container.checkbox+.shiny-panel-conditional .selectize-control {
+  margin-top: -10px;
+}
+
+/* Compact selectizeInput in conditional panels */
+.shiny-panel-conditional .selectize-input {
+  margin-top: -10px;
+}
+
+/* Table styles */
+
+/* Styles used by the Most Used Content table */
+.content-tbl {
+  font-size: 0.875rem;
+  line-height: 1.125rem;
+}
+
+.content-tbl a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.number-pre {
+  font-family: "Fira Mono", Consolas, Monaco, monospace;
+  white-space: pre;
+  font-size: 0.84375rem;
 }


### PR DESCRIPTION
This PR contains a number of improvements to the runtime version scanner:

- Improved table display
  - Added GUID column
  - Improved styling and spacing of columns 
  - Added pagination back
  - (Checked version sorting; didn't appear to be broken in the current version)
- Updated filter controls
  - Changed version selector from a slider to a drop-down
  - Changed matching from <= to <
  - Added filtering based on hits (Considered adding to table, but added in sidebar so that it could affect a forthcoming "Export" button)
- Started to work with data on what runtimes are on the server
  - Added a control to highlight content with stale builds (i.e. it was last built against a runtime that no longer exists)
- Misc
  - Updated CSS

With the version selector control — I had wanted to do a "type in the version number" control, but I didn't have time to implement that, as it would have required significant refactoring of how the app handles versions. It might be worth postponing to a future iteration.

- https://dogfood.team.pct.posit.it/runtime-version-scanner/
- https://connect.posit.it/runtime-version-scanner/