### PR TITLE
Usage Metrics Dashboard: Persist search string across filter changes

### DIFF
--- a/extensions/usage-metrics-dashboard/app.R
+++ b/extensions/usage-metrics-dashboard/app.R
@@ -60,8 +60,9 @@ full_url <- function(session) {
     session$clientData$url_protocol,
     "//",
     session$clientData$url_hostname,
-    if (nzchar(session$clientData$url_port))
-      paste0(":", session$clientData$url_port),
+    if (nzchar(session$clientData$url_port)) {
+      paste0(":", session$clientData$url_port)
+    },
     session$clientData$url_pathname
   )
 }
@@ -746,10 +747,39 @@ server <- function(input, output, session) {
     paste0("Updated ", format(usage_last_updated(), fmt))
   })
 
+  # JavaScript for persisting search terms across table rerenders
+  table_js <- "
+  function(el, x) {
+    const tableId = el.id;
+
+    // Initialize global store for search terms if needed
+    if (!window.currentSessionSearches) {
+      window.currentSessionSearches = {};
+    }
+
+    setTimeout(function() {
+      const searchInput = el.querySelector('input.rt-search');
+      if (!searchInput) return;
+
+      // Restore previous search if available
+      const savedSearch = window.currentSessionSearches[tableId];
+      if (savedSearch) {
+        searchInput.value = savedSearch;
+        searchInput.dispatchEvent(new Event('input', {bubbles: true}));
+      }
+
+      // Save search terms as they're entered
+      searchInput.addEventListener('input', function() {
+        window.currentSessionSearches[tableId] = this.value;
+      });
+    }, 100);
+  }
+  "
+
   output$content_usage_table <- renderReactable({
     data <- multi_content_table_data()
 
-    reactable(
+    table <- reactable(
       data,
       defaultSortOrder = "desc",
       onClick = JS(
@@ -792,7 +822,9 @@ server <- function(input, output, session) {
           width = 32,
           sortable = FALSE,
           cell = function(url) {
-            if (is.na(url) || url == "") return("")
+            if (is.na(url) || url == "") {
+              return("")
+            }
             HTML(as.character(tags$div(
               onclick = "event.stopPropagation()",
               tags$a(
@@ -864,6 +896,9 @@ server <- function(input, output, session) {
         )
       )
     )
+
+    # Apply any onRender JS for capturing search value
+    onRender(table, table_js)
   })
 
   output$export_raw_visits <- downloadHandler(
@@ -964,7 +999,9 @@ server <- function(input, output, session) {
           width = 32,
           sortable = FALSE,
           cell = function(url) {
-            if (is.na(url) || url == "") return("")
+            if (is.na(url) || url == "") {
+              return("")
+            }
             subject <- glue::glue(
               "\"{selected_content_info()$title}\" on Posit Connect"
             )
@@ -1020,8 +1057,11 @@ server <- function(input, output, session) {
       users <- aggregated_visits_data() |>
         filter(user_guid %in% input$selected_users) |>
         pull(display_name)
-      user_string <- if (length(users) == 1) users else
+      user_string <- if (length(users) == 1) {
+        users
+      } else {
         "multiple selected users"
+      }
       tagList(
         HTML(glue::glue(
           "{nrow(hits)} visits from <b>{user_string}</b> between ",
@@ -1121,8 +1161,11 @@ server <- function(input, output, session) {
       type = "button",
       class = "btn btn-sm btn-outline-secondary",
       disabled = disabled,
-      onclick = if (is.null(disabled))
-        sprintf("window.location.href='%s'", mailto) else NULL,
+      onclick = if (is.null(disabled)) {
+        sprintf("window.location.href='%s'", mailto)
+      } else {
+        NULL
+      },
       tagList(icon("envelope"), "Email Selected Visitors")
     )
   })

--- a/extensions/usage-metrics-dashboard/app.R
+++ b/extensions/usage-metrics-dashboard/app.R
@@ -898,7 +898,7 @@ server <- function(input, output, session) {
     )
 
     # Apply any onRender JS for capturing search value
-    onRender(table, table_js)
+    htmlwidgets::onRender(table, table_js)
   })
 
   output$export_raw_visits <- downloadHandler(

--- a/extensions/usage-metrics-dashboard/app.R
+++ b/extensions/usage-metrics-dashboard/app.R
@@ -765,7 +765,9 @@ server <- function(input, output, session) {
       const savedSearch = window.currentSessionSearches[tableId];
       if (savedSearch) {
         searchInput.value = savedSearch;
-        searchInput.dispatchEvent(new Event('input', {bubbles: true}));
+        if (window.Reactable && typeof window.Reactable.setSearch === 'function') {
+          window.Reactable.setSearch(tableId, savedSearch);
+        }
       }
 
       // Save search terms as they're entered

--- a/extensions/usage-metrics-dashboard/app.R
+++ b/extensions/usage-metrics-dashboard/app.R
@@ -751,30 +751,30 @@ server <- function(input, output, session) {
   table_js <- "
   function(el, x) {
     const tableId = el.id;
+    const storageKey = 'search_' + tableId;
+    
+    // Clear search value when the page is refreshed
+    window.addEventListener('beforeunload', function() {
+      sessionStorage.removeItem(storageKey);
+    });
 
-    // Initialize global store for search terms if needed
-    if (!window.currentSessionSearches) {
-      window.currentSessionSearches = {};
+    const searchInput = el.querySelector('input.rt-search');
+    if (!searchInput) return;
+
+    // Restore previous search if available
+    const savedSearch = sessionStorage.getItem(storageKey);
+    
+    if (savedSearch) {
+      searchInput.value = savedSearch;
+      if (window.Reactable && typeof window.Reactable.setSearch === 'function') {
+        window.Reactable.setSearch(tableId, savedSearch);
+      }
     }
 
-    setTimeout(function() {
-      const searchInput = el.querySelector('input.rt-search');
-      if (!searchInput) return;
-
-      // Restore previous search if available
-      const savedSearch = window.currentSessionSearches[tableId];
-      if (savedSearch) {
-        searchInput.value = savedSearch;
-        if (window.Reactable && typeof window.Reactable.setSearch === 'function') {
-          window.Reactable.setSearch(tableId, savedSearch);
-        }
-      }
-
-      // Save search terms as they're entered
-      searchInput.addEventListener('input', function() {
-        window.currentSessionSearches[tableId] = this.value;
-      });
-    }, 100);
+    // Save search terms as they're entered
+    searchInput.addEventListener('input', function() {
+      sessionStorage.setItem(storageKey, this.value);
+    });
   }
   "
 

--- a/extensions/usage-metrics-dashboard/manifest.json
+++ b/extensions/usage-metrics-dashboard/manifest.json
@@ -3068,6 +3068,6 @@
     "requiredFeatures": [
       "OAuth Integrations"
     ],
-    "version": "1.0.5"
+    "version": "1.0.6"
   }
 }


### PR DESCRIPTION
Fixes #153

This PR uses some JavaScript to store the state of the search string in session storage and restore it after something triggers a `reactable` rerender.

This is definitely a bit of a workaround — but I tried a few other approaches (including using `updateReactable(data = new_data)`) and none of them worked simply. Perhaps it could be made more seamless if the `setTimeout()` value was lower. Definitely would appreciate a look from someone with more JS experience than me!

Available:
- https://dogfood.team.pct.posit.it/usage-metrics-dashboard-auto-add/
- https://connect.posit.it/usage-metrics-dashboard-2025-06-05/