### PR TITLE
Publisher CVEs: Show vulnerability page with 0 package content

### DIFF
--- a/extensions/publisher-cves/manifest.json
+++ b/extensions/publisher-cves/manifest.json
@@ -23,11 +23,11 @@
 		"dist/assets/index-CteWUkOR.css": {
 			"checksum": "e26ddbd6163e429121aaac82256c8f53"
 		},
-		"dist/assets/index-D9njY8KV.js": {
-			"checksum": "ed84b7e7f30da13f30b2d2022e2dffcc"
+		"dist/assets/index-l2VTngKw.js": {
+			"checksum": "4f068289d30f758c18bd7f9cb05d6d6f"
 		},
 		"dist/index.html": {
-			"checksum": "0db7cc766b97ee12ea2a91470ea5a36e"
+			"checksum": "ea3a868abc19067f9de6ba46808ba337"
 		},
 		"main.py": {
 			"checksum": "f8385dbd8a8cd24204f1eb6209f8bb30"

--- a/extensions/publisher-cves/src/App.vue
+++ b/extensions/publisher-cves/src/App.vue
@@ -24,8 +24,8 @@ const loadingMessage = "Fetching content and vulnerabilities...";
     />
     <main v-else class="flex-1 p-4 md:p-8 bg-gray-100">
       <div class="max-w-4xl mx-auto">
-        <ContentList v-if="!contentStore.currentContentId" />
-        <VulnerabilityChecker v-else />
+        <VulnerabilityChecker v-if="contentStore.currentContentId" />
+        <ContentList v-else />
       </div>
     </main>
 

--- a/extensions/publisher-cves/src/components/VulnerabilityChecker.vue
+++ b/extensions/publisher-cves/src/components/VulnerabilityChecker.vue
@@ -207,10 +207,7 @@ const totalVulnerabilities = computed(() => {
 
 <template>
   <!-- Only show the component if we have content to analyze -->
-  <div
-    v-if="hasPackages || isLoadingPackages"
-    class="max-w-4xl mx-auto p-5 bg-white rounded-lg shadow-md"
-  >
+  <div class="max-w-4xl mx-auto p-5 bg-white rounded-lg shadow-md">
     <!-- Content header with title and back button -->
     <div class="flex justify-between items-center mb-6">
       <div>
@@ -247,12 +244,11 @@ const totalVulnerabilities = computed(() => {
     <StatusMessage
       v-else-if="hasError"
       type="error"
-      message="Error analyzing packages. Please try again."
+      message="Error analyzing packages. The content may not be fully deployed."
     />
 
     <!-- Content loaded successfully -->
-    <div v-else-if="hasPackages">
-      <!-- Stats panel -->
+    <template v-else>
       <StatsPanel
         :totalPackages="totalPackages"
         :pythonPackages="pythonPackages"
@@ -260,13 +256,15 @@ const totalVulnerabilities = computed(() => {
         :vulnerabilities="totalVulnerabilities"
       />
 
-      <!-- No vulnerabilities found -->
-      <EmptyState v-if="vulnerablePackages.length === 0">
+      <EmptyState v-if="!hasPackages">
+        <p>This content has no packages. No vulnerabilities found.</p>
+      </EmptyState>
+
+      <EmptyState v-else-if="vulnerablePackages.length === 0">
         <p>No vulnerabilities found.</p>
       </EmptyState>
 
-      <!-- Vulnerability list -->
       <VulnerabilityList v-else :vulnerablePackages="vulnerablePackages" />
-    </div>
+    </template>
   </div>
 </template>


### PR DESCRIPTION
This PR fixes an issue with the `publisher-cves` content where content with no packages (either because it is static, a pin, or was not fully deployed) would show a blank page trapping the viewer without the "Back to Content List" button.

[Deployed on Dogfood here](https://dogfood.team.pct.posit.it/connect/#/apps/b6fd7c18-4819-44dd-a47e-40be0d4a1ab0). This is my content on Dogfood. To see the difference in behavior either select the "Static HTML landing page" or "gradio" content which have zero packages.

Be sure when viewing the dogfood deployment to clear cache to avoid getting old JS behavior.

To reproduce with your own content deploy this extension and create a piece of content with no packages. You can do this by using the gallery to add "Static HTML landing page" content.



Fixes #191 