### PR TITLE
Publisher CVEs: Scroll to top when swapping pages

### DIFF
--- a/extensions/publisher-cves/manifest.json
+++ b/extensions/publisher-cves/manifest.json
@@ -23,11 +23,11 @@
 		"dist/assets/index-CteWUkOR.css": {
 			"checksum": "e26ddbd6163e429121aaac82256c8f53"
 		},
-		"dist/assets/index-l2VTngKw.js": {
-			"checksum": "4f068289d30f758c18bd7f9cb05d6d6f"
+		"dist/assets/index-vlEy0F6m.js": {
+			"checksum": "da2cb1d917ec752760f9186b7d02d185"
 		},
 		"dist/index.html": {
-			"checksum": "ea3a868abc19067f9de6ba46808ba337"
+			"checksum": "0fed520b0a89f55e25e1bbce548aa482"
 		},
 		"main.py": {
 			"checksum": "f8385dbd8a8cd24204f1eb6209f8bb30"

--- a/extensions/publisher-cves/src/components/ContentCard.vue
+++ b/extensions/publisher-cves/src/components/ContentCard.vue
@@ -72,6 +72,7 @@ const vulnerabilityText = computed(() => {
 // Handle card click
 function handleClick() {
   contentStore.currentContentId = props.content.guid;
+  scrollTo({ top: 0, left: 0, behavior: "instant" });
 }
 </script>
 

--- a/extensions/publisher-cves/src/components/VulnerabilityChecker.vue
+++ b/extensions/publisher-cves/src/components/VulnerabilityChecker.vue
@@ -86,6 +86,7 @@ function getFixedVersion(vuln: Vulnerability): string | null {
 // Go back to content list
 function goBack() {
   contentStore.currentContentId = undefined;
+  scrollTo({ top: 0, left: 0, behavior: "instant" });
 }
 
 // Find vulnerable packages by comparing package data with vulnerability data


### PR DESCRIPTION
This PR fixes an issue with the `publisher-cves` content where swapping between the list of content and the individual vulnerabilities page remembers the scroll position. Now when swapping between the two the app is scrolled to the top instantly to behave a big more like a webpage navigation.

[Deployed on Dogfood here](https://dogfood.team.pct.posit.it/connect/#/apps/b6fd7c18-4819-44dd-a47e-40be0d4a1ab0). 

The easiest way to see the new behavior is to scroll and open the bottom piece of content and see that you are now at the top of the page with the content's name, GUID, the "Back to Content List" button, etc.

Fixes #193 