### PR TITLE
Runtime Version Scanner: Version Selector Improvements

### DIFF
--- a/extensions/eol-runtime-scanner/app.R
+++ b/extensions/eol-runtime-scanner/app.R
@@ -188,7 +188,6 @@ server <- function(input, output, session) {
         # Check if this version is available on server
         is_server_version <- version %in% server_versions_for_runtime
 
-        # Use proper version comparison instead of string comparison
         is_selected <- !is.null(selected_version) &&
           as.numeric_version(version) <= as.numeric_version(selected_version)
         is_max <- !is.null(selected_version) &&

--- a/extensions/eol-runtime-scanner/app.R
+++ b/extensions/eol-runtime-scanner/app.R
@@ -73,9 +73,18 @@ ui <- page_sidebar(
     open = TRUE,
     width = 275,
 
-    h5("Scan for Runtimes"),
-
-    p("Select a version to filter for content using that version or earlier."),
+    tags$div(
+      style = "display: flex; align-items: center; gap: 0.25rem;",
+      h5("Scan for Runtimes", style = "margin: 0;"),
+      tooltip(
+        bsicons::bs_icon("question-circle-fill"),
+        paste0(
+          "Enable a runtime filter and select a version to show ",
+          "items using that version or earlier."
+        ),
+        placement = "right"
+      )
+    ),
 
     checkboxInput(
       "use_r_cutoff",
@@ -160,15 +169,22 @@ server <- function(input, output, session) {
     # Extract server runtime versions by type
     server_vers <- server_versions()
     r_server_vers <- server_vers |> filter(runtime == "r") |> pull(version)
-    py_server_vers <- server_vers |> filter(runtime == "python") |> pull(version)
-    quarto_server_vers <- server_vers |> filter(runtime == "quarto") |> pull(version)
+    py_server_vers <- server_vers |>
+      filter(runtime == "python") |>
+      pull(version)
+    quarto_server_vers <- server_vers |>
+      filter(runtime == "quarto") |>
+      pull(version)
 
     content <- get_content(client) |>
       filter(app_role %in% c("owner", "editor")) |>
       mutate(
         r_version = as_ordered_version_factor(r_version, r_server_vers),
         py_version = as_ordered_version_factor(py_version, py_server_vers),
-        quarto_version = as_ordered_version_factor(quarto_version, quarto_server_vers),
+        quarto_version = as_ordered_version_factor(
+          quarto_version,
+          quarto_server_vers
+        ),
       )
   })
 
@@ -299,7 +315,6 @@ server <- function(input, output, session) {
       group_by(content_guid) |>
       summarize(hits = n())
   })
-
 
   content_table_data <- reactive({
     # Filter by content type

--- a/extensions/eol-runtime-scanner/app.R
+++ b/extensions/eol-runtime-scanner/app.R
@@ -57,11 +57,15 @@ ui <- page_sidebar(
       "Scan for Runtimes",
       tooltip(
         bsicons::bs_icon("question-circle-fill"),
-        paste0(
-          "Enable a runtime filter and select a version to show ",
-          "items using that version or earlier."
-        ),
-        placement = "right"
+        tagList(
+          p(
+            "Enable a runtime filter and select a version to show ",
+            "items using that version or earlier.",
+          ),
+          p(
+            "Versions in italic are no longer available on the server."
+          )
+        )
       )
     ),
 

--- a/extensions/eol-runtime-scanner/connect_module.R
+++ b/extensions/eol-runtime-scanner/connect_module.R
@@ -102,7 +102,7 @@ connectVisitorClient <- function(
 }
 
 # ----
-# Your existing helper functions, unchanged:
+
 get_eligible_integrations <- function(client) {
   tryCatch(
     {

--- a/extensions/eol-runtime-scanner/tests/test_version_ordering.R
+++ b/extensions/eol-runtime-scanner/tests/test_version_ordering.R
@@ -59,3 +59,21 @@ test_that("as_ordered_version_factor produces properly ordered versions of chara
     )
   )
 })
+
+test_that("as_ordered_version_factor includes additional_versions in factor levels", {
+  # Test with additional versions that don't exist in the main versions
+  additional_vers <- c("3.9.0", "4.1.0")
+  vf <- as_ordered_version_factor(versions, additional_vers)
+  
+  # Check that levels include both the original versions and the additional ones
+  expect_equal(
+    levels(vf),
+    c("2.8.9", "3.8.2", "3.9.0", "3.11.2", "3.11.3", "3.12.1", "4.0.1", "4.1.0")
+  )
+  
+  # Check that the original values are assigned the correct factor levels
+  expect_equal(
+    as.character(vf)[!is.na(vf)],
+    c("3.8.2", "2.8.9", "4.0.1", "3.11.3", "3.11.2", "3.11.3", "3.12.1")
+  )
+})

--- a/extensions/eol-runtime-scanner/version_ordering.R
+++ b/extensions/eol-runtime-scanner/version_ordering.R
@@ -2,11 +2,12 @@
 
 # Turns a character vector of version numbers into a factor with levels
 # appropriately ordered.
-as_ordered_version_factor <- function(versions) {
+as_ordered_version_factor <- function(versions, additional_versions = NULL) {
   sanitized <- sanitize_versions(versions)
+  sanitized_additional <- sanitize_versions(additional_versions)
   factor(
     sanitized,
-    levels = sort_unique_versions(sanitized),
+    levels = sort_unique_versions(c(sanitized, sanitized_additional)),
     ordered = TRUE
   )
 }

--- a/extensions/eol-runtime-scanner/www/styles.css
+++ b/extensions/eol-runtime-scanner/www/styles.css
@@ -36,7 +36,7 @@
 
 /* Server version styling */
 .btn-version.server-version {
-  font-weight: bold;
+  /* Regular font weight for server versions */
 }
 
 /* Non-server version styling - make it italic */
@@ -72,6 +72,16 @@
 .btn-version.selected:hover {
   background-color: #385d7c;
   border-color: #385d7c;
+}
+
+/* Custom tooltip styling */
+.tooltip-inner {
+  text-align: left;
+}
+
+/* Keep spacing between paragraphs but remove extra space at the end */
+.tooltip-inner p:last-child {
+  margin-bottom: 0;
 }
 
 /* Table styles */

--- a/extensions/eol-runtime-scanner/www/styles.css
+++ b/extensions/eol-runtime-scanner/www/styles.css
@@ -13,6 +13,57 @@
   margin-top: -10px;
 }
 
+/* Version selector styles */
+.version-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding-top: 5px;
+}
+
+/* ActionButton version */
+.btn-version {
+  padding: 2px 6px;
+  font-size: 0.8rem;
+  font-family: "Fira Mono", Consolas, Monaco, monospace;
+  border: 1px solid #ddd;
+  background: #f8f9fa;
+  border-radius: 3px;
+  margin-right: 0;
+  margin-bottom: 4px;
+  transition: all 0.15s ease-in-out;
+}
+
+/* Selected versions */
+.btn-version.selected {
+  background-color: #447099; /* Posit Blue */
+  color: white;
+  border-color: #447099;
+}
+
+/* The specifically selected version */
+.btn-version.selected.max {
+  text-decoration: underline; /* Underline the max version */
+  text-underline-offset: 2px; /* Add some space between text and underline */
+}
+
+/* Add cursor pointer to btn-version for better UX */
+.btn-version {
+  cursor: pointer;
+}
+
+/* Hover effect for unselected buttons */
+.btn-version:hover:not(.selected) {
+  background-color: #e9ecef;
+  border-color: #ced4da;
+}
+
+/* Hover effect for selected buttons */
+.btn-version.selected:hover {
+  background-color: #385d7c;
+  border-color: #385d7c;
+}
+
 /* Table styles */
 
 /* Styles used by the Most Used Content table */

--- a/extensions/eol-runtime-scanner/www/styles.css
+++ b/extensions/eol-runtime-scanner/www/styles.css
@@ -79,7 +79,7 @@
   text-align: left;
 }
 
-/* Keep spacing between paragraphs but remove extra space at the end */
+/* Remove extra space at the end */
 .tooltip-inner p:last-child {
   margin-bottom: 0;
 }

--- a/extensions/eol-runtime-scanner/www/styles.css
+++ b/extensions/eol-runtime-scanner/www/styles.css
@@ -34,6 +34,16 @@
   transition: all 0.15s ease-in-out;
 }
 
+/* Server version styling */
+.btn-version.server-version {
+  font-weight: bold;
+}
+
+/* Non-server version styling - make it italic */
+.btn-version:not(.server-version) {
+  font-style: italic;
+}
+
 /* Selected versions */
 .btn-version.selected {
   background-color: #447099; /* Posit Blue */


### PR DESCRIPTION
This PR includes:

- A totally custom UI element for selecting versions. Versions are displayed in a row of buttons. Click a button to display content using that version and below. Selected versions are highlighted.
  - Server versions are included in the list of possible versions regardless of whether the user has content using them.
  - In the selector, versions are displayed in regular typeface; versions of runtimes no longer on the server are italic.
- Removed "Highlight stale builds" feature as it was just confusing.
- Improved summary text display when there is only one runtime selected for filtering.

Not implemented yet, but possibly planned for early next week:

- I think it might be helpful to show a parenthetical count of number of content items in the version selector buttons. However, I think that would only really be helpful if displays numbers _post_ filtering steps, which will require some refactoring of reactive dependencies.

Notes:

- The buttons can take a second to update if there are lots of versions. I think this could be optimized pretty easily.

Available here:
- https://dogfood.team.pct.posit.it/runtime-version-scanner/
- https://connect.posit.it/runtime-version-scanner/