### PR TITLE
Publisher CVEs: Prefer `ECOSYSTEM` fixed event

### DIFF
--- a/extensions/publisher-cves/manifest.json
+++ b/extensions/publisher-cves/manifest.json
@@ -20,14 +20,14 @@
 	},
 	"packages": {},
 	"files": {
+		"dist/assets/index-B41wDw7-.js": {
+			"checksum": "6f226fcbe63e27f856c8755bfa5f2cdc"
+		},
 		"dist/assets/index-CteWUkOR.css": {
 			"checksum": "e26ddbd6163e429121aaac82256c8f53"
 		},
-		"dist/assets/index-vlEy0F6m.js": {
-			"checksum": "da2cb1d917ec752760f9186b7d02d185"
-		},
 		"dist/index.html": {
-			"checksum": "0fed520b0a89f55e25e1bbce548aa482"
+			"checksum": "69a4a2125195046f07166dbdd55fcf8b"
 		},
 		"main.py": {
 			"checksum": "f8385dbd8a8cd24204f1eb6209f8bb30"

--- a/extensions/publisher-cves/src/components/VulnerabilityChecker.vue
+++ b/extensions/publisher-cves/src/components/VulnerabilityChecker.vue
@@ -2,7 +2,7 @@
 import { useVulnsStore } from "../stores/vulns";
 import { usePackagesStore } from "../stores/packages";
 import { useContentStore } from "../stores/content";
-import type { Vulnerability } from "../stores/vulns";
+import type { Vulnerability, VulnerabilityRange } from "../stores/vulns";
 import type { Package } from "../stores/packages";
 import { computed } from "vue";
 
@@ -68,19 +68,21 @@ function getFixedVersion(vuln: Vulnerability): string | null {
     return null;
   }
 
-  // Look through all ranges
+  let result: string | null = null;
+
+  const getFixedEventValue = (range: VulnerabilityRange): string | null => {
+    return range.events.find((e) => Boolean(e.fixed))?.fixed || null;
+  };
+
   for (const range of vuln.ranges) {
-    // Look for events with a "fixed" property
-    if (range.events && Array.isArray(range.events)) {
-      for (const event of range.events) {
-        if (event.fixed) {
-          return event.fixed;
-        }
-      }
+    if (range.type === "ECOSYSTEM" && range.events) {
+      return getFixedEventValue(range);
+    } else {
+      result = getFixedEventValue(range);
     }
   }
 
-  return null;
+  return result;
 }
 
 // Go back to content list

--- a/extensions/publisher-cves/src/stores/vulns.ts
+++ b/extensions/publisher-cves/src/stores/vulns.ts
@@ -1,16 +1,20 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 
+export interface VulnerabilityEvent {
+  introduced?: string;
+  fixed?: string;
+}
+
+export interface VulnerabilityRange {
+  type: string;
+  events: VulnerabilityEvent[];
+}
+
 export interface Vulnerability {
   id: string;
   versions: Record<string, any>;
-  ranges: Array<{
-    type: string;
-    events: Array<{
-      introduced?: string;
-      fixed?: string;
-    }>;
-  }>;
+  ranges: VulnerabilityRange[];
   summary: string;
   details: string;
   modified: string;


### PR DESCRIPTION
This PR adds a preference to the `publisher-cves` extension to show the latest `ECOSYSTEM` fix version from Posit Package Manager's [`GET /repos/{repo}/vulns`](https://packagemanager.posit.co/__api__/swagger/index.html#/default/get_repos__repo__vulns) API endpoint.

The `ECOSYSTEM` type range is described as: package ecosystem specific version range.

Previously the first `fixed` range version was used which resulted in a Git commit hash version for some vulnerability + package combinations.

[Deployed on Dogfood here](https://dogfood.team.pct.posit.it/connect/#/apps/b6fd7c18-4819-44dd-a47e-40be0d4a1ab0). 

Fixes #195