### PR TITLE
Render markdown in Package Vulnerability Scanner details

### DIFF
--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -20,14 +20,14 @@
 	},
 	"packages": {},
 	"files": {
-		"dist/assets/index-B41wDw7-.js": {
-			"checksum": "6f226fcbe63e27f856c8755bfa5f2cdc"
+		"dist/assets/index-CSszAiKH.js": {
+			"checksum": "093c0eb7acc66edde2aab26cc9e4ad60"
 		},
-		"dist/assets/index-CteWUkOR.css": {
-			"checksum": "e26ddbd6163e429121aaac82256c8f53"
+		"dist/assets/index-DVWF7g46.css": {
+			"checksum": "6fb3360431fb18dd78b2de42a2b1d77a"
 		},
 		"dist/index.html": {
-			"checksum": "69a4a2125195046f07166dbdd55fcf8b"
+			"checksum": "1d8f9dc388830a4a696b9523adf36392"
 		},
 		"main.py": {
 			"checksum": "f8385dbd8a8cd24204f1eb6209f8bb30"

--- a/extensions/package-vulnerability-scanner/package-lock.json
+++ b/extensions/package-vulnerability-scanner/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.8",
+        "markdown-it": "^14.1.0",
         "pinia": "^3.0.3",
         "tailwindcss": "^4.1.8",
         "vue": "^3.5.13"
@@ -1307,6 +1308,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1749,6 +1756,15 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -1757,6 +1773,29 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "9.0.5",
@@ -1937,6 +1976,15 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -2073,6 +2121,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.3.5",

--- a/extensions/package-vulnerability-scanner/package-lock.json
+++ b/extensions/package-vulnerability-scanner/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.16",
+        "@types/markdown-it": "^14.1.2",
         "@vitejs/plugin-vue": "^5.2.3",
         "@vue/tsconfig": "^0.7.0",
         "prettier": "3.5.3",
@@ -1085,6 +1086,31 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {

--- a/extensions/package-vulnerability-scanner/package-lock.json
+++ b/extensions/package-vulnerability-scanner/package-lock.json
@@ -15,6 +15,7 @@
         "vue": "^3.5.13"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.16",
         "@vitejs/plugin-vue": "^5.2.3",
         "@vue/tsconfig": "^0.7.0",
         "prettier": "3.5.3",
@@ -1050,6 +1051,22 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.10.tgz",
@@ -1362,6 +1379,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -1765,6 +1795,27 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -1960,6 +2011,20 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
@@ -2126,6 +2191,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/extensions/package-vulnerability-scanner/package.json
+++ b/extensions/package-vulnerability-scanner/package.json
@@ -18,6 +18,7 @@
     "vue": "^3.5.13"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.16",
     "@vitejs/plugin-vue": "^5.2.3",
     "@vue/tsconfig": "^0.7.0",
     "prettier": "3.5.3",

--- a/extensions/package-vulnerability-scanner/package.json
+++ b/extensions/package-vulnerability-scanner/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",
+    "@types/markdown-it": "^14.1.2",
     "@vitejs/plugin-vue": "^5.2.3",
     "@vue/tsconfig": "^0.7.0",
     "prettier": "3.5.3",

--- a/extensions/package-vulnerability-scanner/package.json
+++ b/extensions/package-vulnerability-scanner/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.8",
+    "markdown-it": "^14.1.0",
     "pinia": "^3.0.3",
     "tailwindcss": "^4.1.8",
     "vue": "^3.5.13"

--- a/extensions/package-vulnerability-scanner/src/components/MarkdownRenderer.vue
+++ b/extensions/package-vulnerability-scanner/src/components/MarkdownRenderer.vue
@@ -17,5 +17,5 @@ const renderedContent = computed(() => {
 </script>
 
 <template>
-  <div class="markdown-content" v-html="renderedContent"></div>
+  <div class="prose max-w-none" v-html="renderedContent"></div>
 </template>

--- a/extensions/package-vulnerability-scanner/src/components/MarkdownRenderer.vue
+++ b/extensions/package-vulnerability-scanner/src/components/MarkdownRenderer.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import MarkdownIt from "markdown-it";
+
+const props = defineProps<{
+  content: string;
+}>();
+
+const md = new MarkdownIt({
+  html: false,
+  linkify: true,
+});
+
+const renderedContent = computed(() => {
+  return md.render(props.content);
+});
+</script>
+
+<template>
+  <div class="markdown-content" v-html="renderedContent"></div>
+</template>

--- a/extensions/package-vulnerability-scanner/src/components/vulnerability/VulnerabilityDetails.vue
+++ b/extensions/package-vulnerability-scanner/src/components/vulnerability/VulnerabilityDetails.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import ArrowTopRight from "../icons/ArrowTopRight.vue";
+import MarkdownRenderer from "../MarkdownRenderer.vue";
 
 const props = defineProps<{
   id: string;
@@ -41,11 +42,12 @@ function getOsvUrl(vulnId: string): string {
     <p class="text-base mb-3">
       <strong>{{ summary }}</strong>
     </p>
-    <p
-      class="text-sm text-gray-600 whitespace-pre-line break-words leading-relaxed bg-gray-50 p-3 rounded-md my-3"
+    <div
+      v-if="details"
+      class="text-sm text-gray-600 break-words leading-relaxed bg-gray-50 p-3 rounded-md my-3"
     >
-      {{ details }}
-    </p>
+      <MarkdownRenderer :content="details" />
+    </div>
 
     <div class="flex justify-between text-xs text-gray-500 mt-3">
       <span>Published: {{ publishDate }}</span>

--- a/extensions/package-vulnerability-scanner/src/style.css
+++ b/extensions/package-vulnerability-scanner/src/style.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 @theme {
   --color-pypi: #0073b7;


### PR DESCRIPTION
This PR uses [`markdown-it`](https://github.com/markdown-it/markdown-it) to render the markdown we get in the `details` of a vulnerability from Posit Package Manager then styles it with [`tailwindcss-typography`](https://github.com/tailwindlabs/tailwindcss-typography).

<details>
  <summary>Before</summary>
  
![image](https://github.com/user-attachments/assets/2bcd3cf9-06fd-49fe-b771-ee422d77315d)

</details> 

<details>
  <summary>After</summary>
  
![CleanShot 2025-06-25 at 15 30 31@2x](https://github.com/user-attachments/assets/785f2413-8899-4dcc-b4f8-613c67241cdc)

</details> 

An example of the app can be found [on our Dogfood server here](https://dogfood.team.pct.posit.it/connect/#/apps/b6fd7c18-4819-44dd-a47e-40be0d4a1ab0).