### PR TITLE
Dotnomad/213

### DIFF
--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed the styling to make vulnerable package names more prominent in the
   vulnerable packages list (#203)
+- Moved the Back to Content List button to the top left of the page for better
+  visibility (#216)
 
 ### Fixed
 

--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to the Package Vulnerability Scanner extension will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Render markdown in vulnerability details using markdown-it (#212)
+
+### Fixed
+
+- Fix long content titles breaking the layout of ContentCard component (#213)
+
+## [1.0.0] - 2025-06-26
+
+Initial release of the Package Vulnerability Scanner extension

--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Render markdown in vulnerability details using markdown-it (#212)
+- Render markdown in vulnerability details using markdown-it (#204)
 
 ### Changed
 

--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Render markdown in vulnerability details using markdown-it (#212)
 
+### Changed
+
+- Changed the styling to make vulnerable package names more prominent in the
+  vulnerable packages list (#203)
+
 ### Fixed
 
 - Fix long content titles breaking the layout of ContentCard component (#213)

--- a/extensions/package-vulnerability-scanner/CONTRIBUTING.md
+++ b/extensions/package-vulnerability-scanner/CONTRIBUTING.md
@@ -29,3 +29,21 @@ From there the required files to be sent in the bundle are:
 - `main.py',
 - 'requirements.txt'
 - `dist/**`
+
+## Changelog
+
+We use the [CHANGELOG](./CHANGELOG.md) to document all notable changes to the
+Package Vulnerability Scanner. When contributing, update the changelog as
+follows:
+
+1. For unreleased changes:
+
+   - Add your changes to the "Unreleased" section
+   - Include a brief description under the appropriate subsection
+     using the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
+   - Reference any PR or issue number (e.g., #123)
+
+2. For releases:
+
+   - A new version section will be created during the release process
+   - Follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) guidelines

--- a/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
@@ -78,10 +78,10 @@ function handleClick() {
 
 <template>
   <div
-    class="border border-gray-300 hover:border-gray-400 rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow cursor-pointer bg-white group"
+    class="min-w-0 border border-gray-300 hover:border-gray-400 rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow cursor-pointer bg-white group"
     @click="handleClick"
   >
-    <div class="flex justify-between items-start mb-2">
+    <div class="flex justify-between items-start mb-2 gap-4">
       <h3 class="font-medium text-blue-600 truncate group-hover:underline">
         {{ content.title || "Unnamed Content" }}
       </h3>

--- a/extensions/package-vulnerability-scanner/src/components/VulnerabilityChecker.vue
+++ b/extensions/package-vulnerability-scanner/src/components/VulnerabilityChecker.vue
@@ -209,7 +209,13 @@ const totalVulnerabilities = computed(() => {
 </script>
 
 <template>
-  <!-- Only show the component if we have content to analyze -->
+  <button
+    @click="goBack"
+    class="px-4 py-2 mb-4 bg-white shrink-0 cursor-pointer hover:bg-gray-200 text-gray-800 rounded-md shadow-sm hover:shadow-md transition-colors"
+  >
+    ← Back to Content List
+  </button>
+
   <div class="max-w-4xl mx-auto p-5 bg-white rounded-lg shadow-md">
     <!-- Content header with title and back button -->
     <div class="flex justify-between items-center mb-6">
@@ -231,13 +237,6 @@ const totalVulnerabilities = computed(() => {
           </a>
         </div>
       </div>
-
-      <button
-        @click="goBack"
-        class="px-4 py-2 bg-gray-100 shrink-0 cursor-pointer hover:bg-gray-200 text-gray-800 rounded-md transition-colors"
-      >
-        ← Back to Content List
-      </button>
     </div>
 
     <!-- Loading state -->

--- a/extensions/package-vulnerability-scanner/src/components/ui/ColorBadge.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ui/ColorBadge.vue
@@ -6,7 +6,7 @@ defineProps<{
 
 <template>
   <span
-    class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ring-1 ring-inset"
+    class="shrink-0 inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ring-1 ring-inset"
     :class="{
       'bg-red-50 text-red-700 ring-red-600/10': type === 'error',
       'bg-green-50 text-green-700 ring-green-600/20': type === 'success',

--- a/extensions/package-vulnerability-scanner/src/components/vulnerability/PackageHeader.vue
+++ b/extensions/package-vulnerability-scanner/src/components/vulnerability/PackageHeader.vue
@@ -7,15 +7,15 @@ defineProps<{
 </script>
 
 <template>
-  <div class="flex justify-between items-center mb-3">
-    <h4 class="text-gray-800 m-0">
+  <div class="flex items-center mb-3 gap-2 font-mono">
+    <h4 class="text-gray-800 text-lg m-0 font-semibold">
       {{ packageName }}
-
-      <span class="font-mono text-gray-500 text-sm">v{{ packageVersion }}</span>
     </h4>
 
+    <span class="text-gray-500">v{{ packageVersion }}</span>
+
     <span
-      class="text-xs font-bold text-white py-1 px-2 rounded"
+      class="text-xs font-bold text-white py-1 px-2 rounded self-end ml-auto"
       :class="repo === 'pypi' ? 'bg-pypi' : 'bg-cran'"
     >
       {{ repo.toUpperCase() }}

--- a/extensions/package-vulnerability-scanner/src/components/vulnerability/VulnerabilityCard.vue
+++ b/extensions/package-vulnerability-scanner/src/components/vulnerability/VulnerabilityCard.vue
@@ -13,17 +13,23 @@ defineProps<{
 </script>
 
 <template>
-  <div class="bg-red-50 border-l-4 border-red-500 p-4 mb-5 rounded-r-md">
+  <div>
     <PackageHeader
       :packageName="packageInfo.name"
       :packageVersion="packageInfo.version"
       :repo="repo"
     />
 
-    <!-- Fix info at the top if available -->
+    <p
+      v-if="vulnerabilities.length > 1"
+      class="text-sm font-medium text-gray-700 mb-3"
+    >
+      {{ vulnerabilities.length }} vulnerabilities found for this package
+    </p>
+
     <div
       v-if="latestFixedVersion"
-      class="bg-green-50 border-l-3 border-green-500 py-2 px-3 my-4 rounded-r-md"
+      class="bg-green-50 border-l-3 border-green-500 py-2 px-3 my-3 rounded-r-md"
     >
       <p class="m-0 text-[15px] text-green-700 flex items-center">
         <span class="mr-2">🛠️</span>
@@ -38,28 +44,15 @@ defineProps<{
       </p>
     </div>
 
-    <!-- Vulnerabilities count if more than 1 -->
-    <p
-      v-if="vulnerabilities.length > 1"
-      class="text-sm font-medium text-gray-700 mb-3"
-    >
-      {{ vulnerabilities.length }} vulnerabilities found for this package:
-    </p>
-
-    <!-- List of vulnerabilities -->
-    <div
-      v-for="(vulnerability, index) in vulnerabilities"
-      :key="vulnerability.id"
-      class="mb-4 last:mb-0 pt-4 first:pt-0"
-      :class="{ 'border-t border-gray-200': index > 0 }"
-    >
+    <template v-for="vulnerability in vulnerabilities" :key="vulnerability.id">
       <VulnerabilityDetails
         :id="vulnerability.id"
+        class="not-last:mb-6"
         :summary="vulnerability.summary"
         :details="vulnerability.details"
         :publishDate="vulnerability.published"
         :modifiedDate="vulnerability.modified"
       />
-    </div>
+    </template>
   </div>
 </template>

--- a/extensions/package-vulnerability-scanner/src/components/vulnerability/VulnerabilityDetails.vue
+++ b/extensions/package-vulnerability-scanner/src/components/vulnerability/VulnerabilityDetails.vue
@@ -24,24 +24,23 @@ function getOsvUrl(vulnId: string): string {
 </script>
 
 <template>
-  <div>
-    <div class="flex justify-between items-center mb-3">
-      <p class="font-mono text-gray-500 text-sm m-0">
-        <a
-          :href="getOsvUrl(id)"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="text-blue-600 hover:text-blue-800 hover:underline inline-flex items-center"
-        >
-          {{ id }}
-          <ArrowTopRight class="ml-1" />
-        </a>
-      </p>
-    </div>
-
-    <p class="text-base mb-3">
+  <div class="bg-red-50 border-l-4 border-red-500 rounded-r-md p-4">
+    <p class="mb-1">
       <strong>{{ summary }}</strong>
     </p>
+
+    <p class="font-mono text-gray-500 text-sm mb-3">
+      <a
+        :href="getOsvUrl(id)"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-blue-600 hover:text-blue-800 hover:underline inline-flex items-center"
+      >
+        {{ id }}
+        <ArrowTopRight class="ml-1" />
+      </a>
+    </p>
+
     <div
       v-if="details"
       class="text-sm text-gray-600 break-words leading-relaxed bg-gray-50 p-3 rounded-md my-3"

--- a/extensions/package-vulnerability-scanner/src/components/vulnerability/VulnerabilityList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/vulnerability/VulnerabilityList.vue
@@ -22,6 +22,7 @@ defineProps<{
     <VulnerabilityCard
       v-for="(item, index) in vulnerablePackages"
       :key="index"
+      class="not-last:border-b border-gray-300 not-last:pb-6 not-last:mb-6"
       :packageInfo="item.packageInfo"
       :vulnerabilities="item.vulnerabilities"
       :repo="item.repo"


### PR DESCRIPTION
This PR addresses a few easy to tackle styling issues:
- #203
- #213
- #216 

In addition to all of the changes I introduced a CHANGELOG for this particular extension figuring that would be helpful down the line.

### #203

The first is a re-styling of the Vulnerable Packages list mainly how the package name is presented. Now it has much more emphasis and the red background is only around the vulnerability details.

<details>
  <summary>Before</summary>
  
![CleanShot 2025-06-26 at 13 34 14@2x](https://github.com/user-attachments/assets/3df7cc34-9a9d-4975-8df0-7c89f9290981)

</details> 

<details>
  <summary>After</summary>
  
![CleanShot 2025-06-26 at 13 34 34@2x](https://github.com/user-attachments/assets/d13033f4-4c65-477c-b80c-94e46f0d585c)

</details> 

### #213 

The next truncates really long content names. Previously it would break out of the grid container.

<details>
  <summary>Before</summary>
  
![CleanShot 2025-06-26 at 13 35 30@2x](https://github.com/user-attachments/assets/baef5035-4bb6-408f-9b8e-a231baf00788)

</details> 

<details>
  <summary>After</summary>
  
![CleanShot 2025-06-26 at 13 36 04@2x](https://github.com/user-attachments/assets/31b6242a-6466-417a-b0bd-d3581b8a4c47)

</details> 

### #216 

The final change is around moving the "Back to Content List" button. Now it is up and to the left to make it more prominent and match expectations about it being to the left.

<details>
  <summary>Before</summary>
  
![CleanShot 2025-06-26 at 13 37 06@2x](https://github.com/user-attachments/assets/3e1351d2-7fc6-4d2f-9bc3-f5b5319eca63)

</details> 

<details>
  <summary>After</summary>
  
![CleanShot 2025-06-26 at 13 37 15@2x](https://github.com/user-attachments/assets/3d492632-fec4-4436-8518-0ea45a041ece)

</details> 


These changes are deployed [on our internal Dogfood server here](https://dogfood.team.pct.posit.it/connect/#/apps/b6fd7c18-4819-44dd-a47e-40be0d4a1ab0).