### PR TITLE
Refactor package vulnerability scanner stores

### DIFF
--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -1,51 +1,49 @@
 {
-	"version": 1,
-	"metadata": {
-		"appmode": "python-fastapi",
-		"entrypoint": "main.py"
-	},
-	"python": {
-		"version": "3.13.5",
-		"package_manager": {
-			"name": "pip",
-			"package_file": "requirements.txt"
-		}
-	},
-	"environment": {
-		"image": "",
-		"prebuilt": false,
-		"python": {
-			"requires": "~=3.8"
-		}
-	},
-	"packages": {},
-	"files": {
-		"dist/assets/index-C-y7BWfk.css": {
-			"checksum": "9c79124c79ef1f350c8af2a925a7f4ad"
-		},
-		"dist/assets/index-CIpfqLN8.js": {
-			"checksum": "f39ee65bd9c1a23d4b5babf37e39683f"
-		},
-		"dist/index.html": {
-			"checksum": "13d888e5f1a3a3c9953e1099082a9d48"
-		},
-		"main.py": {
-			"checksum": "f8385dbd8a8cd24204f1eb6209f8bb30"
-		},
-		"requirements.txt": {
-			"checksum": "3b9b57b849bc53863f92c720581ee6d8"
-		}
-	},
-	"extension": {
-		"name": "package-vulnerability-scanner",
+  "version": 1,
+  "metadata": {
+    "appmode": "python-fastapi",
+    "entrypoint": "main.py"
+  },
+  "python": {
+    "version": "3.13.5",
+    "package_manager": {
+      "name": "pip",
+      "package_file": "requirements.txt"
+    }
+  },
+  "environment": {
+    "image": "",
+    "prebuilt": false,
+    "python": {
+      "requires": "~=3.8"
+    }
+  },
+  "packages": {},
+  "files": {
+    "dist/assets/index-C-y7BWfk.css": {
+      "checksum": "9c79124c79ef1f350c8af2a925a7f4ad"
+    },
+    "dist/assets/index-DR07zOgq.js": {
+      "checksum": "85c4e822c2db5e040c7934f7220715b7"
+    },
+    "dist/index.html": {
+      "checksum": "ca00c3d932a544bde20bfd1bbe5dfd15"
+    },
+    "main.py": {
+      "checksum": "f8385dbd8a8cd24204f1eb6209f8bb30"
+    },
+    "requirements.txt": {
+      "checksum": "3b9b57b849bc53863f92c720581ee6d8"
+    }
+  },
+  "extension": {
+    "name": "package-vulnerability-scanner",
     "title": "Package Vulnerability Scanner",
     "description": "Scan for security vulnerabilities in your published content on Connect using Posit Package Manager. View an overview of CVEs (Common Vulnerabilities and Exposures) across all your apps, and get guidance on upgrading affected packages.",
-		"homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/package-vulnerability-scanner",
-		"category": "extension",
-		"minimumConnectVersion": "2025.04.0",
-		"requiredFeatures": [
-			"API Publishing"
-		],
-		"version": "1.0.0"
-	}
+    "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/package-vulnerability-scanner",
+    "category": "extension",
+    "minimumConnectVersion": "2025.04.0",
+    "requiredFeatures": ["API Publishing"],
+    "version": "1.0.0"
+  }
 }

--- a/extensions/package-vulnerability-scanner/src/App.vue
+++ b/extensions/package-vulnerability-scanner/src/App.vue
@@ -4,10 +4,12 @@ import ContentList from "./components/ContentList.vue";
 import PoweredByFooter from "./components/PoweredByFooter.vue";
 import { useVulnsStore } from "./stores/vulns";
 import { useContentStore } from "./stores/content";
+import { useScannerStore } from "./stores/scanner";
 import LoadingSpinner from "./components/ui/LoadingSpinner.vue";
 
 const vulnStore = useVulnsStore();
 const contentStore = useContentStore();
+const scannerStore = useScannerStore();
 
 vulnStore.fetchVulns();
 contentStore.fetchContentList();
@@ -24,7 +26,10 @@ const loadingMessage = "Fetching content and vulnerabilities...";
     />
     <main v-else class="flex-1 p-4 md:p-8 bg-gray-100">
       <div class="max-w-4xl mx-auto">
-        <VulnerabilityChecker v-if="contentStore.currentContentId" />
+        <VulnerabilityChecker
+          v-if="scannerStore.currentContent"
+          :content="scannerStore.currentContent"
+        />
         <ContentList v-else />
       </div>
     </main>

--- a/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
@@ -13,9 +13,13 @@ const scannerStore = useScannerStore();
 const packageCount = computed(() => props.content.packages.length);
 const isIncomplete = computed(() => props.content.bundle_id === null);
 
+const hasVulnerabilities = computed(() => {
+  return props.content.vulnerabilityCount > 0;
+});
+
 const vulnerabilityText = computed(() => {
-  const count = props.content.vulnerabilityCount;
-  if (count > 0) {
+  if (hasVulnerabilities.value) {
+    const count = props.content.vulnerabilityCount;
     return count === 1 ? "1 vulnerability" : `${count} vulnerabilities`;
   }
   return "No vulnerabilities";
@@ -42,10 +46,7 @@ function handleClick() {
           Loading...
         </ColorBadge>
 
-        <ColorBadge
-          v-else
-          :type="content.vulnerabilityCount > 0 ? 'error' : 'success'"
-        >
+        <ColorBadge v-else :type="hasVulnerabilities ? 'error' : 'success'">
           {{ vulnerabilityText }}
         </ColorBadge>
       </template>

--- a/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
@@ -1,82 +1,28 @@
 <script setup lang="ts">
 import { computed, defineProps } from "vue";
 import ColorBadge from "./ui/ColorBadge.vue";
-import { usePackagesStore } from "../stores/packages";
-import { useVulnsStore } from "../stores/vulns";
-import { useContentStore } from "../stores/content";
+import { useScannerStore } from "../stores/scanner";
+import type { Content } from "../stores/scanner";
 
 const props = defineProps<{
-  content: {
-    guid: string;
-    title: string;
-    app_mode?: string;
-    content_url?: string;
-    dashboard_url?: string;
-    py_version?: string;
-    r_version?: string;
-    quarto_version?: string;
-    bundle_id?: string | null;
-  };
+  content: Content;
 }>();
 
-const packagesStore = usePackagesStore();
-const contentStore = useContentStore();
-const vulnStore = useVulnsStore();
+const scannerStore = useScannerStore();
 
-// Compute if this content has been fetched
-const isFetched = computed(
-  () => !!packagesStore.contentItems[props.content.guid]?.isFetched,
-);
-const isLoading = computed(
-  () => !!packagesStore.contentItems[props.content.guid]?.isLoading,
-);
-const hasError = computed(
-  () => !!packagesStore.contentItems[props.content.guid]?.error,
-);
-const packageCount = computed(
-  () => packagesStore.contentItems[props.content.guid]?.packages.length || 0,
-);
+const packageCount = computed(() => props.content.packages.length);
 const isIncomplete = computed(() => props.content.bundle_id === null);
 
-// Count vulnerable packages in this content item
-function countVulnerablePackages(): number {
-  const content = packagesStore.contentItems[props.content.guid];
-  if (!content || !content.packages.length) return 0;
-
-  let count = 0;
-  for (const pkg of content.packages) {
-    const vulnerabilityMap =
-      pkg.language.toLowerCase() === "python" ? vulnStore.pypi : vulnStore.cran;
-    const packageName = pkg.name.toLowerCase();
-
-    if (
-      vulnerabilityMap[packageName] &&
-      vulnerabilityMap[packageName].some(
-        (vuln) => vuln.versions && vuln.versions[pkg.version],
-      )
-    ) {
-      count++;
-    }
-  }
-
-  return count;
-}
-
-// Computed properties for display
-const hasVulnerabilities = computed(() => countVulnerablePackages() > 0);
 const vulnerabilityText = computed(() => {
-  const count = countVulnerablePackages();
+  const count = props.content.vulnerabilityCount;
   if (count > 0) {
-    return count === 1
-      ? "1 vulnerable package"
-      : `${count} vulnerable packages`;
+    return count === 1 ? "1 vulnerability" : `${count} vulnerabilities`;
   }
   return "No vulnerabilities";
 });
 
-// Handle card click
 function handleClick() {
-  contentStore.currentContentId = props.content.guid;
+  scannerStore.currentContent = props.content;
   scrollTo({ top: 0, left: 0, behavior: "instant" });
 }
 </script>
@@ -91,15 +37,17 @@ function handleClick() {
         {{ content.title || "Unnamed Content" }}
       </h3>
 
-      <template v-if="!hasError">
+      <template v-if="!content.packageFetchError">
+        <ColorBadge v-if="content.isLoadingPackages" type="neutral">
+          Loading...
+        </ColorBadge>
+
         <ColorBadge
-          v-if="isFetched"
-          :type="hasVulnerabilities ? 'error' : 'success'"
+          v-else
+          :type="content.vulnerabilityCount > 0 ? 'error' : 'success'"
         >
           {{ vulnerabilityText }}
         </ColorBadge>
-
-        <ColorBadge v-else-if="isLoading" type="neutral">Loading...</ColorBadge>
       </template>
     </div>
 
@@ -122,10 +70,10 @@ function handleClick() {
       <span v-else-if="isIncomplete" class="text-red-700">
         Incomplete content
       </span>
-      <span v-else-if="hasError" class="text-red-700">
+      <span v-else-if="content.packageFetchError" class="text-red-700">
         Error loading packages
       </span>
-      <span v-else-if="isLoading" class="text-gray-600">
+      <span v-else-if="content.isLoadingPackages" class="text-gray-600">
         Loading packages...
       </span>
       <span v-else class="text-gray-600"> No packages found </span>

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { usePackagesStore } from "../stores/packages";
 import { useContentStore } from "../stores/content";
+import { useScannerStore } from "../stores/scanner";
 import StatusMessage from "./ui/StatusMessage.vue";
 import ContentCard from "./ContentCard.vue";
 
 const packagesStore = usePackagesStore();
 const contentStore = useContentStore();
+const scannerStore = useScannerStore();
 
 // Fetch packages in batches to avoid overwhelming the server
 async function fetchPackagesInBatches(batchSize = 3) {
@@ -56,7 +58,7 @@ fetchPackagesInBatches();
       />
     </div>
 
-    <div v-else-if="contentStore.contentList.length === 0">
+    <div v-else-if="scannerStore.content.length === 0">
       <StatusMessage
         type="warning"
         message="No content found"
@@ -75,7 +77,7 @@ fetchPackagesInBatches();
 
       <div class="grid gap-4">
         <ContentCard
-          v-for="content in contentStore.contentList"
+          v-for="content in scannerStore.content"
           :key="content.guid"
           :content="content"
         />

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -58,7 +58,7 @@ fetchPackagesInBatches();
       />
     </div>
 
-    <div v-else-if="scannerStore.content.length === 0">
+    <div v-else-if="!scannerStore.hasContent">
       <StatusMessage
         type="warning"
         message="No content found"

--- a/extensions/package-vulnerability-scanner/src/components/VulnerabilityChecker.vue
+++ b/extensions/package-vulnerability-scanner/src/components/VulnerabilityChecker.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { useVulnsStore } from "../stores/vulns";
-import { usePackagesStore } from "../stores/packages";
-import { useContentStore } from "../stores/content";
+import {
+  useScannerStore,
+  type Content,
+  type DetailedPackage,
+} from "../stores/scanner";
 import { computed, ref } from "vue";
 
 // Import UI components
@@ -13,100 +15,43 @@ import StatsPanel, { type FilterType } from "./vulnerability/StatsPanel.vue";
 import EmptyState from "./vulnerability/EmptyState.vue";
 import PackageList from "./vulnerability/PackageList.vue";
 import ArrowTopRight from "./icons/ArrowTopRight.vue";
-import type { PackageWithVulnsAndFix } from "../types";
 
-const vulnStore = useVulnsStore();
-const packagesStore = usePackagesStore();
-const contentStore = useContentStore();
+const props = defineProps<{
+  content: Content;
+}>();
 
-const packages = computed((): PackageWithVulnsAndFix[] => {
-  // Get the current content's packages
-  const currentId = contentStore.currentContentId;
-  if (!currentId) return [];
+const scannerStore = useScannerStore();
 
-  const contentItem = packagesStore.contentItems[currentId];
-  const result = contentItem ? contentItem.packages : [];
-
-  return result.map((pkg): PackageWithVulnsAndFix => {
-    return {
-      package: pkg,
-      ...vulnStore.getDetailsForPackageVersion(
-        pkg.name,
-        pkg.version,
-        pkg.language.toLowerCase() === "python" ? "pypi" : "cran",
-      ),
-    };
-  });
-});
-
-// Track loading states
-const isLoadingVulns = computed(() => vulnStore.isLoading);
-const isLoadingPackages = computed(() => {
-  // Check if the current content is loading
-  const currentId = contentStore.currentContentId;
-  if (!currentId) return false;
-
-  const contentItem = packagesStore.contentItems[currentId];
-  return contentItem ? contentItem.isLoading : false;
-});
-const isLoading = computed(
-  () => isLoadingPackages.value || isLoadingVulns.value,
-);
-const hasError = computed(() => {
-  const currentId = contentStore.currentContentId;
-  if (!currentId) return vulnStore.error;
-
-  const contentItem = packagesStore.contentItems[currentId];
-  return vulnStore.error || (contentItem ? contentItem.error : null);
-});
-
-// Check if we have packages to analyze
 const hasPackages = computed(() => {
-  return packages.value.length > 0;
+  return props.content.packages.length > 0;
 });
 
 // Go back to content list
 function goBack() {
-  contentStore.currentContentId = undefined;
+  scannerStore.currentContent = undefined;
   scrollTo({ top: 0, left: 0, behavior: "instant" });
 }
 
-// Find vulnerable packages by comparing package data with vulnerability data
-const vulnerablePackages = computed((): PackageWithVulnsAndFix[] => {
-  return packages.value.filter((pkg) => {
+const vulnerablePackages = computed((): DetailedPackage[] => {
+  return props.content.packages.filter((pkg) => {
     return pkg.vulnerabilities && pkg.vulnerabilities.length > 0;
   });
 });
 
-// Status messages based on loading state
-const loadingMessage = computed(() => {
-  if (isLoadingPackages.value && isLoadingVulns.value) {
-    return "Loading package and vulnerability data...";
-  } else if (isLoadingPackages.value) {
-    return "Loading package data...";
-  } else if (isLoadingVulns.value) {
-    return "Loading vulnerability data...";
-  }
-  return "";
+const pythonPackages = computed((): DetailedPackage[] => {
+  const packages = props.content.packages;
+
+  return packages.filter((p) => {
+    return p.language.toLowerCase() === "python";
+  });
 });
 
-// Get the current content information and derived properties
-const contentInfo = computed(() => contentStore.currentContent);
-const contentTitle = computed(
-  () => contentInfo.value?.title || "Unnamed Content",
-);
-const dashboardUrl = computed(() => contentInfo.value?.dashboard_url || null);
+const rPackages = computed((): DetailedPackage[] => {
+  const packages = props.content.packages;
 
-const pythonPackages = computed((): PackageWithVulnsAndFix[] => {
-  if (isLoading.value || !packages.value.length) return [];
-  return packages.value.filter(
-    (p) => p.package.language.toLowerCase() === "python",
-  );
-});
-
-const rPackages = computed((): PackageWithVulnsAndFix[] => {
-  if (isLoading.value || !packages.value.length) return [];
-  return packages.value.filter((p) => p.package.language.toLowerCase() === "r");
+  return packages.filter((p) => {
+    return p.language.toLowerCase() === "r";
+  });
 });
 
 // Total number of vulnerabilities (CVEs) across all packages
@@ -134,9 +79,7 @@ const filterTitle = computed(() => {
 });
 
 // Use the filtered arrays for the displayed packages
-const filteredPackages = computed((): PackageWithVulnsAndFix[] => {
-  if (isLoading.value || !packages.value.length) return [];
-
+const filteredPackages = computed((): DetailedPackage[] => {
   switch (activeFilter.value) {
     case "python":
       return pythonPackages.value;
@@ -145,13 +88,12 @@ const filteredPackages = computed((): PackageWithVulnsAndFix[] => {
     case "vulnerable":
       return vulnerablePackages.value;
     default:
-      return packages.value;
+      return props.content.packages;
   }
 });
 
 const isIncomplete = computed(() => {
-  const content = contentStore.currentContent;
-  return content ? content.bundle_id === null : false;
+  return props.content.bundle_id === null;
 });
 </script>
 
@@ -167,14 +109,14 @@ const isIncomplete = computed(() => {
     <!-- Content header with title and back button -->
     <div class="flex justify-between items-center mb-6">
       <div>
-        <h2 class="text-xl text-gray-800 font-semibold">{{ contentTitle }}</h2>
+        <h2 class="text-xl text-gray-800 font-semibold">{{ content.title }}</h2>
         <div class="flex flex-wrap space-x-2 mb-1">
           <p class="text-sm text-gray-600">
-            {{ contentStore.currentContentId }}
+            {{ content.guid }}
           </p>
           <a
-            v-if="dashboardUrl"
-            :href="dashboardUrl"
+            v-if="content.dashboard_url"
+            :href="content.dashboard_url"
             target="_blank"
             rel="noopener noreferrer"
             class="text-sm text-blue-600 hover:text-blue-800 flex items-center"
@@ -183,25 +125,24 @@ const isIncomplete = computed(() => {
             <ArrowTopRight class="ml-1" />
           </a>
         </div>
-        <div
-          v-if="contentInfo"
-          class="flex flex-wrap gap-x-4 text-sm text-gray-600"
-        >
-          <span v-if="contentInfo.py_version"
-            >Python: {{ contentInfo.py_version }}</span
-          >
-          <span v-if="contentInfo.r_version"
-            >R: {{ contentInfo.r_version }}</span
-          >
-          <span v-if="contentInfo.quarto_version"
-            >Quarto: {{ contentInfo.quarto_version }}</span
-          >
+        <div class="flex flex-wrap gap-x-4 text-sm text-gray-600">
+          <span v-if="content.py_version">
+            Python: {{ content.py_version }}
+          </span>
+          <span v-if="content.r_version">R: {{ content.r_version }}</span>
+          <span v-if="content.quarto_version">
+            Quarto: {{ content.quarto_version }}
+          </span>
         </div>
       </div>
     </div>
 
     <!-- Loading state -->
-    <LoadingSpinner v-if="isLoading" :message="loadingMessage" size="md" />
+    <LoadingSpinner
+      v-if="content.isLoadingPackages"
+      message="Loading package data..."
+      size="md"
+    />
 
     <StatusMessage
       v-if="isIncomplete"
@@ -210,7 +151,7 @@ const isIncomplete = computed(() => {
     />
 
     <StatusMessage
-      v-else-if="hasError"
+      v-else-if="content.packageFetchError"
       type="error"
       message="Error analyzing packages. The content may not be fully deployed."
     />
@@ -219,7 +160,7 @@ const isIncomplete = computed(() => {
     <template v-else>
       <StatsPanel
         v-model="activeFilter"
-        :totalPackages="packages.length"
+        :totalPackages="content.packages.length"
         :pythonPackages="pythonPackages.length"
         :rPackages="rPackages.length"
         :vulnerabilities="totalVulnerabilities"

--- a/extensions/package-vulnerability-scanner/src/components/vulnerability/PackageList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/vulnerability/PackageList.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
+import type { DetailedPackage } from "../../stores/scanner";
 import PackageCard from "./PackageCard.vue";
-import type { PackageWithVulnsAndFix } from "../../types";
 
 defineProps<{
-  packages: PackageWithVulnsAndFix[];
+  packages: DetailedPackage[];
 }>();
 </script>
 
@@ -13,7 +13,7 @@ defineProps<{
       v-for="(pkg, index) in packages"
       :key="index"
       class="not-last:border-b border-gray-300 not-last:pb-6 not-last:mb-6"
-      :package="pkg.package"
+      :package="pkg"
       :vulnerabilities="pkg.vulnerabilities"
       :latest-fixed-version="pkg.latestFixedVersion"
     />

--- a/extensions/package-vulnerability-scanner/src/stores/content.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/content.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref, computed } from "vue";
+import { ref } from "vue";
 
 export interface ContentListItem {
   guid: string;
@@ -20,20 +20,9 @@ export const useContentStore = defineStore("content", () => {
   const contentList = ref<ContentListItem[]>([]);
   const isLoading = ref(false);
   const error = ref<Error | null>(null);
-  const currentContentId = ref<string>();
 
   // Track if content has been loaded
   const isContentLoaded = ref(false);
-
-  // Get the current content item
-  const currentContent = computed(() => {
-    if (!currentContentId.value) return null;
-    return (
-      contentList.value.find(
-        (content) => content.guid === currentContentId.value,
-      ) || null
-    );
-  });
 
   // Fetch all available content items
   async function fetchContentList() {
@@ -67,11 +56,7 @@ export const useContentStore = defineStore("content", () => {
     contentList,
     isLoading,
     error,
-    currentContentId,
     isContentLoaded,
-
-    // Computed getters
-    currentContent,
 
     // Actions
     fetchContentList,

--- a/extensions/package-vulnerability-scanner/src/stores/scanner.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/scanner.ts
@@ -54,8 +54,13 @@ export const useScannerStore = defineStore("scanner", () => {
     });
   });
 
+  const hasContent = computed<boolean>(() => {
+    return content.value.length > 0;
+  });
+
   return {
     currentContent,
     content,
+    hasContent,
   };
 });

--- a/extensions/package-vulnerability-scanner/src/stores/scanner.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/scanner.ts
@@ -1,0 +1,61 @@
+import { ref, computed } from "vue";
+import { defineStore } from "pinia";
+
+import { useContentStore, type ContentListItem } from "./content";
+import { usePackagesStore, type Package } from "./packages";
+import { useVulnsStore, type Vulnerability } from "./vulns";
+
+export interface DetailedPackage extends Package {
+  vulnerabilities: Vulnerability[];
+  latestFixedVersion: string | null;
+}
+
+export interface Content extends ContentListItem {
+  packages: DetailedPackage[];
+  vulnerabilityCount: number;
+  isLoadingPackages: boolean;
+  packageFetchError?: Error;
+}
+
+export const useScannerStore = defineStore("scanner", () => {
+  const currentContent = ref<Content>();
+
+  const content = computed<Content[]>(() => {
+    const contentStore = useContentStore();
+    const packagesStore = usePackagesStore();
+    const vulnsStore = useVulnsStore();
+
+    return contentStore.contentList.map<Content>((content) => {
+      let packages: DetailedPackage[] = [];
+      const pkgData = packagesStore.contentItems[content.guid];
+
+      if (packagesStore.contentItems[content.guid]) {
+        packages = pkgData.packages.map((pkg) => ({
+          ...pkg,
+          ...vulnsStore.getDetailsForPackageVersion(
+            pkg.name,
+            pkg.version,
+            pkg.language.toLowerCase() === "python" ? "pypi" : "cran",
+          ),
+        }));
+      }
+
+      const vulnerabilityCount = packages.reduce((acc, pkg) => {
+        return acc + pkg.vulnerabilities.length;
+      }, 0);
+
+      return {
+        ...content,
+        isLoadingPackages: pkgData === undefined ? true : pkgData.isLoading,
+        packageFetchError: pkgData?.error || undefined,
+        packages: packages,
+        vulnerabilityCount,
+      };
+    });
+  });
+
+  return {
+    currentContent,
+    content,
+  };
+});

--- a/extensions/package-vulnerability-scanner/src/types/index.ts
+++ b/extensions/package-vulnerability-scanner/src/types/index.ts
@@ -1,8 +1,0 @@
-import type { Package } from "../stores/packages";
-import type { Vulnerability } from "../stores/vulns";
-
-export interface PackageWithVulnsAndFix {
-  package: Package;
-  vulnerabilities?: Vulnerability[];
-  latestFixedVersion?: string | null;
-}


### PR DESCRIPTION
In an effort to improve the Package Vulnerability Scanner with additional features a bit of a store refactor was required to raise information about Content, their packages, and the vulnerabilities related to those packages. Previously this information was split across components and used as needed. Now there is a `scanner` store that collects that information into a `Content` type to be used by several components.

The new `Content` type consolidates the `packages` and `vulnerabilityCount` info so it can be used in a cleaner way. This also opens up the door for some more features to be done in a cleaner way.

These changes have been [published to our internal Dogfood server here](https://dogfood.team.pct.posit.it/connect/#/apps/b6fd7c18-4819-44dd-a47e-40be0d4a1ab0).