### PR TITLE
Show summary of total vulnerability count

### DIFF
--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The counts of packages are now clickable giving the option to show all
   packages, only Python packages, only R packages, or only vulnerable packages.
   The list defaults to showing vulnerable packages. (#207)
+- A total vulnerability count summary at the top of the content list (#208)
 
 ### Changed
 

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -20,14 +20,14 @@
   },
   "packages": {},
   "files": {
-    "dist/assets/index-C-y7BWfk.css": {
-      "checksum": "9c79124c79ef1f350c8af2a925a7f4ad"
+    "dist/assets/index-C92dnr65.js": {
+      "checksum": "a1211c10ac4a0cb77cdec545e6b9c8ec"
     },
-    "dist/assets/index-DR07zOgq.js": {
-      "checksum": "85c4e822c2db5e040c7934f7220715b7"
+    "dist/assets/index-DVtHq8Jo.css": {
+      "checksum": "6ed707ea2bfb24ea5166b8cfd531ea1d"
     },
     "dist/index.html": {
-      "checksum": "ca00c3d932a544bde20bfd1bbe5dfd15"
+      "checksum": "4882252f5fa82897c6b0b1879f0b69a6"
     },
     "main.py": {
       "checksum": "f8385dbd8a8cd24204f1eb6209f8bb30"

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -20,14 +20,14 @@
   },
   "packages": {},
   "files": {
-    "dist/assets/index-C92dnr65.js": {
-      "checksum": "a1211c10ac4a0cb77cdec545e6b9c8ec"
+    "dist/assets/index-BQs0PxZH.js": {
+      "checksum": "4b2beaa2ce5a6f08ea8de32774374fe4"
     },
     "dist/assets/index-DVtHq8Jo.css": {
       "checksum": "6ed707ea2bfb24ea5166b8cfd531ea1d"
     },
     "dist/index.html": {
-      "checksum": "4882252f5fa82897c6b0b1879f0b69a6"
+      "checksum": "e273af3ef688e22b1b868d4d1a686cee"
     },
     "main.py": {
       "checksum": "f8385dbd8a8cd24204f1eb6209f8bb30"

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -58,9 +58,7 @@ const totalVulnerabilities = computed<number>(() => {
 });
 
 const anyContentLoadingPackages = computed<boolean>(() => {
-  return scannerStore.content.some(
-    (content) => !packagesStore.contentItems[content.guid]?.isFetched,
-  );
+  return scannerStore.content.some((content) => content.isLoadingPackages);
 });
 </script>
 

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
+import { computed } from "vue";
+
 import { usePackagesStore } from "../stores/packages";
 import { useContentStore } from "../stores/content";
 import { useScannerStore } from "../stores/scanner";
 import StatusMessage from "./ui/StatusMessage.vue";
+import SkeletonText from "./ui/SkeletonText.vue";
 import ContentCard from "./ContentCard.vue";
 
 const packagesStore = usePackagesStore();
@@ -46,6 +49,19 @@ async function fetchPackagesInBatches(batchSize = 3) {
 }
 
 fetchPackagesInBatches();
+
+const totalVulnerabilities = computed<number>(() => {
+  return scannerStore.content.reduce(
+    (acc, item) => acc + item.vulnerabilityCount,
+    0,
+  );
+});
+
+const anyContentLoadingPackages = computed<boolean>(() => {
+  return scannerStore.content.some(
+    (content) => !packagesStore.contentItems[content.guid]?.isFetched,
+  );
+});
 </script>
 
 <template>
@@ -67,11 +83,16 @@ fetchPackagesInBatches();
     </div>
 
     <div v-else class="space-y-4">
-      <h2 class="text-xl font-semibold text-gray-800 mb-4">
-        Your Connect Content
-      </h2>
+      <h2 class="text-xl font-semibold text-gray-800">Your Connect Content</h2>
 
-      <p class="text-gray-600 mb-6">
+      <p class="text-gray-600">
+        Found {{ scannerStore.content.length }} content items with
+        <SkeletonText v-if="anyContentLoadingPackages" class="h-6 w-[2ch]" />
+        <span v-else>{{ totalVulnerabilities }}</span>
+        vulnerabilities.
+      </p>
+
+      <p class="text-gray-600">
         Select a content item to see details on package vulnerabilities.
       </p>
 

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { computed } from "vue";
-
 import { usePackagesStore } from "../stores/packages";
 import { useContentStore } from "../stores/content";
 import { useScannerStore } from "../stores/scanner";
@@ -49,17 +47,6 @@ async function fetchPackagesInBatches(batchSize = 3) {
 }
 
 fetchPackagesInBatches();
-
-const totalVulnerabilities = computed<number>(() => {
-  return scannerStore.content.reduce(
-    (acc, item) => acc + item.vulnerabilityCount,
-    0,
-  );
-});
-
-const anyContentLoadingPackages = computed<boolean>(() => {
-  return scannerStore.content.some((content) => content.isLoadingPackages);
-});
 </script>
 
 <template>
@@ -85,8 +72,11 @@ const anyContentLoadingPackages = computed<boolean>(() => {
 
       <p class="text-gray-600">
         Found {{ scannerStore.content.length }} content items with
-        <SkeletonText v-if="anyContentLoadingPackages" class="h-6 w-[2ch]" />
-        <span v-else>{{ totalVulnerabilities }}</span>
+        <SkeletonText
+          v-if="scannerStore.anyContentLoadingPackages"
+          class="h-6 w-[2ch]"
+        />
+        <span v-else>{{ scannerStore.totalVulnerabilities }}</span>
         vulnerabilities.
       </p>
 

--- a/extensions/package-vulnerability-scanner/src/components/ui/SkeletonText.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ui/SkeletonText.vue
@@ -1,0 +1,5 @@
+<template>
+  <div
+    class="inline-block align-bottom bg-gray-200 rounded relative overflow-hidden animate-pulse"
+  />
+</template>

--- a/extensions/package-vulnerability-scanner/src/stores/scanner.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/scanner.ts
@@ -58,9 +58,22 @@ export const useScannerStore = defineStore("scanner", () => {
     return content.value.length > 0;
   });
 
+  const totalVulnerabilities = computed<number>(() => {
+    return content.value.reduce(
+      (acc, item) => acc + item.vulnerabilityCount,
+      0,
+    );
+  });
+
+  const anyContentLoadingPackages = computed<boolean>(() => {
+    return content.value.some((content) => content.isLoadingPackages);
+  });
+
   return {
     currentContent,
     content,
     hasContent,
+    totalVulnerabilities,
+    anyContentLoadingPackages,
   };
 });


### PR DESCRIPTION
This PR introduces a new line on the first package of the Package Vulnerability Scanner showing the total number of content items and the total number of vulnerabilities across them.

Fixes #208 

While the package data is loading it uses a `SkeletonText` component to show a shimmering box to imply that data is still loading in. This can be seen in the preview below.

<details>
  <summary>Preview</summary>

https://github.com/user-attachments/assets/dea724cf-a58f-435d-9adb-c3ee9a0af197

</details> 

These changes have been [published to our internal Dogfood server here](https://dogfood.team.pct.posit.it/connect/#/apps/b6fd7c18-4819-44dd-a47e-40be0d4a1ab0).