### PR TITLE
Include tabs to show all content or filter vulnerable content

### DIFF
--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   packages, only Python packages, only R packages, or only vulnerable packages.
   The list defaults to showing vulnerable packages. (#207)
 - A total vulnerability count summary at the top of the content list (#208)
+- Tabs on the content list to see all content or only vulnerable content (#211)
 
 ### Changed
 

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -20,14 +20,14 @@
   },
   "packages": {},
   "files": {
-    "dist/assets/index-BQs0PxZH.js": {
-      "checksum": "4b2beaa2ce5a6f08ea8de32774374fe4"
+    "dist/assets/index-BjeLwUYG.css": {
+      "checksum": "8c4d4e55843c35c73ca73bca1e47f044"
     },
-    "dist/assets/index-DVtHq8Jo.css": {
-      "checksum": "6ed707ea2bfb24ea5166b8cfd531ea1d"
+    "dist/assets/index-DHQEpkcq.js": {
+      "checksum": "f56149368a460f19dfb1e1990b2c916d"
     },
     "dist/index.html": {
-      "checksum": "e273af3ef688e22b1b868d4d1a686cee"
+      "checksum": "6228c1c56a304aa4dc11f10f5eb94f54"
     },
     "main.py": {
       "checksum": "f8385dbd8a8cd24204f1eb6209f8bb30"

--- a/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
@@ -32,8 +32,8 @@ function handleClick() {
 </script>
 
 <template>
-  <div
-    class="min-w-0 border border-gray-300 hover:border-gray-400 rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow cursor-pointer bg-white group"
+  <button
+    class="text-left min-w-0 border border-gray-300 hover:border-gray-400 rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow cursor-pointer bg-white group"
     @click="handleClick"
   >
     <div class="flex justify-between items-start mb-2 gap-4">
@@ -79,5 +79,5 @@ function handleClick() {
       </span>
       <span v-else class="text-gray-600"> No packages found </span>
     </div>
-  </div>
+  </button>
 </template>

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -51,15 +51,6 @@ async function fetchPackagesInBatches(batchSize = 3) {
 
 fetchPackagesInBatches();
 
-const contentWithVulnerabilities = computed<number>(() => {
-  return scannerStore.content.filter((item) => item.vulnerabilityCount > 0)
-    .length;
-});
-
-const anyContentLoadingPackages = computed<boolean>(() => {
-  return scannerStore.content.some((content) => content.isLoadingPackages);
-});
-
 const tabs = computed<Tab[]>(() => {
   const result: Tab[] = [];
 
@@ -72,9 +63,9 @@ const tabs = computed<Tab[]>(() => {
   result.push({
     name: "With Vulnerabilities",
     color: "error",
-    count: anyContentLoadingPackages.value
+    count: scannerStore.anyContentLoadingPackages
       ? undefined
-      : contentWithVulnerabilities.value,
+      : scannerStore.contentWithVulnerabilities.length,
   });
 
   return result;
@@ -84,9 +75,7 @@ const activeTab = ref("All");
 
 const filteredContent = computed(() => {
   if (activeTab.value === "With Vulnerabilities") {
-    return scannerStore.content.filter(
-      (content) => content.vulnerabilityCount > 0,
-    );
+    return scannerStore.contentWithVulnerabilities;
   }
 
   return scannerStore.content;

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
+import { computed, ref } from "vue";
+
 import { usePackagesStore } from "../stores/packages";
 import { useContentStore } from "../stores/content";
 import { useScannerStore } from "../stores/scanner";
 import StatusMessage from "./ui/StatusMessage.vue";
 import SkeletonText from "./ui/SkeletonText.vue";
+import BadgeTabs, { type Tab } from "./ui/BadgeTabs.vue";
 import ContentCard from "./ContentCard.vue";
 
 const packagesStore = usePackagesStore();
@@ -47,6 +50,47 @@ async function fetchPackagesInBatches(batchSize = 3) {
 }
 
 fetchPackagesInBatches();
+
+const contentWithVulnerabilities = computed<number>(() => {
+  return scannerStore.content.filter((item) => item.vulnerabilityCount > 0)
+    .length;
+});
+
+const anyContentLoadingPackages = computed<boolean>(() => {
+  return scannerStore.content.some((content) => content.isLoadingPackages);
+});
+
+const tabs = computed<Tab[]>(() => {
+  const result: Tab[] = [];
+
+  result.push({
+    name: "All",
+    color: "primary",
+    count: scannerStore.content.length,
+  });
+
+  result.push({
+    name: "With Vulnerabilities",
+    color: "error",
+    count: anyContentLoadingPackages.value
+      ? undefined
+      : contentWithVulnerabilities.value,
+  });
+
+  return result;
+});
+
+const activeTab = ref("All");
+
+const filteredContent = computed(() => {
+  if (activeTab.value === "With Vulnerabilities") {
+    return scannerStore.content.filter(
+      (content) => content.vulnerabilityCount > 0,
+    );
+  }
+
+  return scannerStore.content;
+});
 </script>
 
 <template>
@@ -84,9 +128,11 @@ fetchPackagesInBatches();
         Select a content item to see details on package vulnerabilities.
       </p>
 
+      <BadgeTabs v-model="activeTab" :tabs="tabs" />
+
       <div class="grid gap-4">
         <ContentCard
-          v-for="content in scannerStore.content"
+          v-for="content in filteredContent"
           :key="content.guid"
           :content="content"
         />

--- a/extensions/package-vulnerability-scanner/src/components/ui/BadgeTabs.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ui/BadgeTabs.vue
@@ -1,0 +1,61 @@
+<template>
+  <div>
+    <div class="block">
+      <div class="border-b border-gray-200">
+        <nav class="-mb-px flex" aria-label="Tabs">
+          <button
+            v-for="tab in tabs"
+            :key="tab.name"
+            :class="[
+              model === tab.name
+                ? getActiveTabClasses(tab.color)
+                : 'border-transparent text-gray-600 hover:border-gray-300 hover:text-gray-700',
+              'flex items-center border-b-2 px-4 py-2 text-sm font-medium whitespace-nowrap cursor-pointer',
+            ]"
+            :aria-selected="model === tab.name"
+            @click="model = tab.name"
+          >
+            {{ tab.name }}
+
+            <ColorBadge
+              v-if="tab.count"
+              :type="model === tab.name ? tab.color : 'neutral'"
+              class="ml-3"
+            >
+              {{ tab.count }}
+            </ColorBadge>
+          </button>
+        </nav>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import ColorBadge from "./ColorBadge.vue";
+
+export type Tab = {
+  name: string;
+  count?: number;
+  color: "success" | "error" | "neutral" | "primary";
+};
+
+const model = defineModel<string>({ required: true });
+
+defineProps<{
+  tabs: Tab[];
+}>();
+
+const getActiveTabClasses = (color: Tab["color"]) => {
+  switch (color) {
+    case "error":
+      return "border-red-600 text-red-700";
+    case "success":
+      return "border-green-700 text-green-600";
+    case "neutral":
+      return "border-gray-500 text-gray-600";
+    case "primary":
+      return "border-blue-700 text-blue-700";
+  }
+};
+</script>

--- a/extensions/package-vulnerability-scanner/src/components/ui/BadgeTabs.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ui/BadgeTabs.vue
@@ -6,12 +6,12 @@
           <button
             v-for="tab in tabs"
             :key="tab.name"
-            :class="[
+            class="flex items-center border-b-2 px-4 py-2 text-sm font-medium whitespace-nowrap cursor-pointer"
+            :class="
               model === tab.name
                 ? getActiveTabClasses(tab.color)
-                : 'border-transparent text-gray-600 hover:border-gray-300 hover:text-gray-700',
-              'flex items-center border-b-2 px-4 py-2 text-sm font-medium whitespace-nowrap cursor-pointer',
-            ]"
+                : 'border-transparent text-gray-600 hover:border-gray-300 hover:text-gray-700'
+            "
             :aria-selected="model === tab.name"
             @click="model = tab.name"
           >

--- a/extensions/package-vulnerability-scanner/src/components/ui/ColorBadge.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ui/ColorBadge.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  type: "success" | "error" | "neutral";
+  type: "success" | "error" | "neutral" | "primary";
 }>();
 </script>
 
@@ -11,6 +11,7 @@ defineProps<{
       'bg-red-50 text-red-700 ring-red-600/10': type === 'error',
       'bg-green-50 text-green-700 ring-green-600/20': type === 'success',
       'bg-gray-50 text-gray-600 ring-gray-500/10': type === 'neutral',
+      'bg-blue-50 text-blue-700 ring-blue-700/10': type === 'primary',
     }"
   >
     <slot></slot>

--- a/extensions/package-vulnerability-scanner/src/stores/scanner.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/scanner.ts
@@ -54,6 +54,10 @@ export const useScannerStore = defineStore("scanner", () => {
     });
   });
 
+  const contentWithVulnerabilities = computed<Content[]>(() => {
+    return content.value.filter((item) => item.vulnerabilityCount > 0);
+  });
+
   const hasContent = computed<boolean>(() => {
     return content.value.length > 0;
   });
@@ -72,6 +76,7 @@ export const useScannerStore = defineStore("scanner", () => {
   return {
     currentContent,
     content,
+    contentWithVulnerabilities,
     hasContent,
     totalVulnerabilities,
     anyContentLoadingPackages,


### PR DESCRIPTION
This PR includes tabs (and a new component to support them) for the content list page in the Package Vulnerability Scanner.

This allows users to select "With Vulnerabilities" to show only content with vulnerabilities. A badge is included for each tab to show the number of content items for both tabs.

Fixes #211 

<details>
  <summary>Preview</summary>
  
![CleanShot 2025-07-09 at 16 05 08](https://github.com/user-attachments/assets/f526214c-e635-4ce9-b135-0274f2f0b73e)

![CleanShot 2025-07-09 at 16 05 19](https://github.com/user-attachments/assets/89ca5eca-1271-4646-94c4-cd251a3b28d1)

</details> 

These changes have been [published to our internal Dogfood server here](https://dogfood.team.pct.posit.it/connect/#/apps/b6fd7c18-4819-44dd-a47e-40be0d4a1ab0).