### PR TITLE
Show user name in content list header

### DIFF
--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The list defaults to showing vulnerable packages. (#207)
 - A total vulnerability count summary at the top of the content list (#208)
 - Tabs on the content list to see all content or only vulnerable content (#211)
+- The user's name to the content list header to make it clear whose content is
+  being viewed (#210)
 
 ### Changed
 

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -40,4 +40,8 @@ async def get_vulnerabilities():
         
     return results
 
+@app.get("/api/user")
+async def get_current_user():
+    return client.me
+
 app.mount("/", StaticFiles(directory="dist", html=True), name="static")

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -23,14 +23,14 @@
     "dist/assets/index-BjeLwUYG.css": {
       "checksum": "8c4d4e55843c35c73ca73bca1e47f044"
     },
-    "dist/assets/index-DHQEpkcq.js": {
-      "checksum": "f56149368a460f19dfb1e1990b2c916d"
+    "dist/assets/index-RrwFU8H9.js": {
+      "checksum": "e6aad6cd5246f249ee0ae98b5bde2b22"
     },
     "dist/index.html": {
-      "checksum": "6228c1c56a304aa4dc11f10f5eb94f54"
+      "checksum": "cdcbd8d3628de7429d5691c4c3edde0a"
     },
     "main.py": {
-      "checksum": "f8385dbd8a8cd24204f1eb6209f8bb30"
+      "checksum": "e3063b5ce9771a34d7fa23f2234d3668"
     },
     "requirements.txt": {
       "checksum": "3b9b57b849bc53863f92c720581ee6d8"

--- a/extensions/package-vulnerability-scanner/src/App.vue
+++ b/extensions/package-vulnerability-scanner/src/App.vue
@@ -5,12 +5,15 @@ import PoweredByFooter from "./components/PoweredByFooter.vue";
 import { useVulnsStore } from "./stores/vulns";
 import { useContentStore } from "./stores/content";
 import { useScannerStore } from "./stores/scanner";
+import { useUserStore } from "./stores/user";
 import LoadingSpinner from "./components/ui/LoadingSpinner.vue";
 
 const vulnStore = useVulnsStore();
 const contentStore = useContentStore();
 const scannerStore = useScannerStore();
+const userStore = useUserStore();
 
+userStore.fetchCurrentUser();
 vulnStore.fetchVulns();
 contentStore.fetchContentList();
 
@@ -20,7 +23,7 @@ const loadingMessage = "Fetching content and vulnerabilities...";
 <template>
   <div class="flex flex-col min-h-svh">
     <LoadingSpinner
-      v-if="vulnStore.isLoading || contentStore.isLoading"
+      v-if="vulnStore.isLoading || contentStore.isLoading || !userStore.user"
       class="grow bg-gray-100"
       :message="loadingMessage"
     />
@@ -30,7 +33,7 @@ const loadingMessage = "Fetching content and vulnerabilities...";
           v-if="scannerStore.currentContent"
           :content="scannerStore.currentContent"
         />
-        <ContentList v-else />
+        <ContentList :user="userStore.user" v-else />
       </div>
     </main>
 

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -4,10 +4,15 @@ import { computed, ref } from "vue";
 import { usePackagesStore } from "../stores/packages";
 import { useContentStore } from "../stores/content";
 import { useScannerStore } from "../stores/scanner";
+import type { User } from "../stores/user";
 import StatusMessage from "./ui/StatusMessage.vue";
 import SkeletonText from "./ui/SkeletonText.vue";
 import BadgeTabs, { type Tab } from "./ui/BadgeTabs.vue";
 import ContentCard from "./ContentCard.vue";
+
+const props = defineProps<{
+  user: User;
+}>();
 
 const packagesStore = usePackagesStore();
 const contentStore = useContentStore();
@@ -80,6 +85,24 @@ const filteredContent = computed(() => {
 
   return scannerStore.content;
 });
+
+const userHeader = computed(() => {
+  let name;
+
+  if (props.user.first_name && props.user.last_name) {
+    name = `${props.user.first_name} ${props.user.last_name}`;
+  } else if (props.user.first_name) {
+    name = props.user.first_name;
+  } else if (props.user.last_name) {
+    name = props.user.last_name;
+  }
+
+  if (name === undefined) {
+    name = props.user.username;
+  }
+
+  return `${name}'s Connect Content`;
+});
 </script>
 
 <template>
@@ -101,7 +124,9 @@ const filteredContent = computed(() => {
     </div>
 
     <div v-else class="space-y-4">
-      <h2 class="text-xl font-semibold text-gray-800">Your Connect Content</h2>
+      <h2 class="text-xl font-semibold text-gray-800">
+        {{ userHeader }}
+      </h2>
 
       <p class="text-gray-600">
         Found {{ scannerStore.content.length }} content items with

--- a/extensions/package-vulnerability-scanner/src/stores/user.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/user.ts
@@ -1,0 +1,33 @@
+import { ref } from "vue";
+import { defineStore } from "pinia";
+
+export interface User {
+  email: string;
+  username: string;
+  first_name: string;
+  last_name: string;
+  user_role: string;
+  created_time: string;
+  updated_time: string;
+  active_time: string;
+  confirmed: boolean;
+  locked: boolean;
+  guid: string;
+}
+
+export const useUserStore = defineStore("user", () => {
+  const user = ref<User>();
+
+  async function fetchCurrentUser() {
+    const response = await fetch("api/user");
+    const data = await response.json();
+
+    user.value = data;
+  }
+
+  return {
+    user,
+
+    fetchCurrentUser,
+  };
+});


### PR DESCRIPTION
This PR shows the user's name in the content list header in the Package Vulnerability Scanner making it clear whose content you are viewing.

It will use first name + last name if both are available, falling back to one or the other, and finally the user name if neither are set.

Fixes #210 

<details>
  <summary>Preview</summary>
  
<img width="939" height="160" alt="CleanShot 2025-07-10 at 11 48 54" src="https://github.com/user-attachments/assets/68df0dc7-b366-48df-9f31-6d42c1c2c48c" />

</details> 

These changes have been [published to our internal Dogfood server here](https://dogfood.team.pct.posit.it/connect/#/apps/b6fd7c18-4819-44dd-a47e-40be0d4a1ab0).