### PR TITLE
Show last deployed time for content

### DIFF
--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tabs on the content list to see all content or only vulnerable content (#211)
 - The user's name to the content list header to make it clear whose content is
   being viewed (#210)
+- Added the last deployed time for content to the content list and individual
+  content page (#205)
 
 ### Changed
 

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -23,11 +23,11 @@
     "dist/assets/index-BjeLwUYG.css": {
       "checksum": "8c4d4e55843c35c73ca73bca1e47f044"
     },
-    "dist/assets/index-RrwFU8H9.js": {
-      "checksum": "e6aad6cd5246f249ee0ae98b5bde2b22"
+    "dist/assets/index-CwJOZsfJ.js": {
+      "checksum": "c45eed64ab1ce7ab3c4301f035f1b585"
     },
     "dist/index.html": {
-      "checksum": "cdcbd8d3628de7429d5691c4c3edde0a"
+      "checksum": "1244ea68821462601cae2a106d94b1d5"
     },
     "main.py": {
       "checksum": "e3063b5ce9771a34d7fa23f2234d3668"

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -20,14 +20,14 @@
   },
   "packages": {},
   "files": {
+    "dist/assets/index-B4SEo04k.js": {
+      "checksum": "382947b598c89e22e10babc0a432a11a"
+    },
     "dist/assets/index-BjeLwUYG.css": {
       "checksum": "8c4d4e55843c35c73ca73bca1e47f044"
     },
-    "dist/assets/index-CwJOZsfJ.js": {
-      "checksum": "c45eed64ab1ce7ab3c4301f035f1b585"
-    },
     "dist/index.html": {
-      "checksum": "1244ea68821462601cae2a106d94b1d5"
+      "checksum": "9dc4b54f049a2ffe8e5d527cad8e2b10"
     },
     "main.py": {
       "checksum": "e3063b5ce9771a34d7fa23f2234d3668"

--- a/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
@@ -25,6 +25,14 @@ const vulnerabilityText = computed(() => {
   return "No vulnerabilities";
 });
 
+const hasLanguageVersion = computed(() => {
+  return (
+    props.content.py_version ||
+    props.content.r_version ||
+    props.content.quarto_version
+  );
+});
+
 function handleClick() {
   scannerStore.currentContent = props.content;
   scrollTo({ top: 0, left: 0, behavior: "instant" });
@@ -57,7 +65,7 @@ function handleClick() {
     </div>
 
     <div
-      v-if="content.py_version || content.r_version || content.quarto_version"
+      v-if="hasLanguageVersion"
       class="mt-1 text-xs text-gray-600 flex flex-wrap gap-x-3"
     >
       <span v-if="content.py_version">Python: {{ content.py_version }}</span>

--- a/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
@@ -56,13 +56,21 @@ function handleClick() {
       Type: {{ content.app_mode || "Unknown type" }} · GUID: {{ content.guid }}
     </div>
 
-    <div class="mt-1 text-xs text-gray-600 flex flex-wrap gap-x-3">
+    <div
+      v-if="content.py_version || content.r_version || content.quarto_version"
+      class="mt-1 text-xs text-gray-600 flex flex-wrap gap-x-3"
+    >
       <span v-if="content.py_version">Python: {{ content.py_version }}</span>
       <span v-if="content.r_version">R: {{ content.r_version }}</span>
       <span v-if="content.quarto_version"
         >Quarto: {{ content.quarto_version }}</span
       >
     </div>
+
+    <p v-if="content.last_deployed_time" class="mt-1 text-xs text-gray-600">
+      Last Deployed:
+      {{ new Date(content.last_deployed_time).toLocaleString() }}
+    </p>
 
     <div class="mt-2 text-sm">
       <span v-if="packageCount > 0" class="text-gray-600">

--- a/extensions/package-vulnerability-scanner/src/components/VulnerabilityChecker.vue
+++ b/extensions/package-vulnerability-scanner/src/components/VulnerabilityChecker.vue
@@ -95,6 +95,14 @@ const filteredPackages = computed((): DetailedPackage[] => {
 const isIncomplete = computed(() => {
   return props.content.bundle_id === null;
 });
+
+const hasLanguageVersion = computed(() => {
+  return (
+    props.content.py_version ||
+    props.content.r_version ||
+    props.content.quarto_version
+  );
+});
 </script>
 
 <template>
@@ -127,9 +135,7 @@ const isIncomplete = computed(() => {
         </div>
 
         <div
-          v-if="
-            content.py_version || content.r_version || content.quarto_version
-          "
+          v-if="hasLanguageVersion"
           class="flex flex-wrap gap-x-4 text-sm text-gray-600"
         >
           <span v-if="content.py_version">

--- a/extensions/package-vulnerability-scanner/src/components/VulnerabilityChecker.vue
+++ b/extensions/package-vulnerability-scanner/src/components/VulnerabilityChecker.vue
@@ -125,7 +125,13 @@ const isIncomplete = computed(() => {
             <ArrowTopRight class="ml-1" />
           </a>
         </div>
-        <div class="flex flex-wrap gap-x-4 text-sm text-gray-600">
+
+        <div
+          v-if="
+            content.py_version || content.r_version || content.quarto_version
+          "
+          class="flex flex-wrap gap-x-4 text-sm text-gray-600"
+        >
           <span v-if="content.py_version">
             Python: {{ content.py_version }}
           </span>
@@ -134,6 +140,11 @@ const isIncomplete = computed(() => {
             Quarto: {{ content.quarto_version }}
           </span>
         </div>
+
+        <p v-if="content.last_deployed_time" class="text-sm text-gray-600">
+          Last Deployed:
+          {{ new Date(content.last_deployed_time).toLocaleString() }}
+        </p>
       </div>
     </div>
 


### PR DESCRIPTION
This adds the last deployed time as a date + time string to the ContentCard and the individual Content page for the Package Vulnerability Scanner. This gives users another bit of information to determine if it is worth addressing vulnerabilities for content.

Fixes #205 

<details>
  <summary>Preview</summary>
  
<img width="874" height="164" alt="CleanShot 2025-07-10 at 12 18 04" src="https://github.com/user-attachments/assets/2eefa406-e43f-4a74-992e-b4a7717bf8c1" />

<img width="924" height="133" alt="CleanShot 2025-07-10 at 12 18 15" src="https://github.com/user-attachments/assets/2dba0b33-c795-4f18-a2dd-15cbf790ffbc" />

</details> 

These changes have been [published to our internal Dogfood server here](https://dogfood.team.pct.posit.it/connect/#/apps/b6fd7c18-4819-44dd-a47e-40be0d4a1ab0).