### PR TITLE
refactor(app-canary): monitor only a single GUID

### DIFF
--- a/extensions/app-canary/app-canary.qmd
+++ b/extensions/app-canary/app-canary.qmd
@@ -25,24 +25,27 @@ show_error = False
 error_message = ""
 error_guid = ""
 
-# Read CONNECT_SERVER from environment, this is automatically configured on Connect, set manually for local dev
-connect_server = os.environ.get("CONNECT_SERVER", "")
-if not connect_server:
-    show_instructions = True
-    instructions.append("Please set the <b>CONNECT_SERVER</b> environment variable.")
+# Variable to store app monitoring result
+app_result = None
 
-# Read CONNECT_API_KEY from environment, this is automatically configured on Connect, set manually for local dev
-api_key = os.environ.get("CONNECT_API_KEY", "")
-if not api_key:
-    show_instructions = True
-    instructions.append("Please set the <b>CONNECT_API_KEY</b> environment variable.")
+# Helper function to read environment variables and add instructions if missing
+def get_env_var(var_name, description=""):
+    """Get environment variable and add instruction if missing"""
+    global show_instructions
+    
+    value = os.environ.get(var_name, "")
+    if not value:
+        show_instructions = True
+        instruction = f"Please set the <b>{var_name}</b> environment variable."
+        if description:
+            instruction += f" {description}"
+        instructions.append(instruction)
+    return value
 
-# Read CANARY_GUID from environment, needs to be manually configured on Connect and for local dev
-canary_guid = os.environ.get("CANARY_GUID", "")
-if not canary_guid:
-    show_instructions = True
-    instructions.append("Please set the <b>CANARY_GUID</b> environment variable. It should be the GUID of the content you wish to monitor.")
-    canary_guid = ""
+# Read environment variables
+connect_server = get_env_var("CONNECT_SERVER")
+api_key = get_env_var("CONNECT_API_KEY")
+canary_guid = get_env_var("CANARY_GUID", "It should be the GUID of the content you wish to monitor.")
 
 # Instantiate a Connect client using posit-sdk where api_key and url are automatically read from our environment vars
 client = connect.Client()

--- a/extensions/app-canary/app-canary.qmd
+++ b/extensions/app-canary/app-canary.qmd
@@ -226,7 +226,67 @@ if not show_instructions:
 #| echo: false
 #| label: display
 
-# Define a function to create the report display for a result
+# Define helper functions for generating HTML components
+
+def create_about_box(about_content):
+    """Creates the About callout box HTML"""
+    return f"""
+    <div style="border: 1px solid #ccc; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #f8f9fa;">
+        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">ℹ️ About</div>
+        <div style="padding: 5px 0;">{about_content}</div>
+    </div>
+    """
+
+def create_error_box(guid, error_msg):
+    """Creates the Error callout box HTML"""
+    return f"""
+    <div style="border: 1px solid #cc0000; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fff8f8;">
+        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ Error Monitoring Content</div>
+        
+        <div style="display: grid; grid-template-columns: 150px auto; grid-gap: 8px; margin-top: 10px; padding-bottom: 8px; border-bottom: 1px solid #eaecef;">
+            <div style="font-weight: bold;">Content GUID:</div>
+            <div>{guid}</div>
+            
+            <div style="font-weight: bold;">Error:</div>
+            <div style="color: #cc0000;">{error_msg}</div>
+        </div>
+        
+        <div style="padding-top: 8px; font-size: 0.9em;">
+            Please check that your CANARY_GUID environment variable contains a valid content identifier.
+        </div>
+    </div>
+    """
+
+def create_no_results_box():
+    """Creates the No Results callout box HTML"""
+    return f"""
+    <div style="border: 1px solid #f0ad4e; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fcf8e3;">
+        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ No results available</div>
+        <div style="padding: 5px 0;">
+            No monitoring results were found. This could be because:
+            <ul>
+                <li>No valid GUID was provided</li>
+                <li>There was an issue connecting to the specified content</li>
+                <li>The environment is properly configured but there was an error that caused no data to be returned</li>
+            </ul>
+            <p>Please check your CANARY_GUID environment variable and ensure it contains a valid content identifier.</p>
+        </div>
+    </div>
+    """
+
+def create_instructions_box(instructions_html_content):
+    """Creates the Setup Instructions callout box HTML"""
+    return f"""
+    <div style="border: 1px solid #cc0000; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fff8f8;">
+        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ Setup Instructions</div>
+        {instructions_html_content}
+        <div style="padding-top: 8px; font-size: 0.9em; border-top: 1px solid #eaecef;">
+            See Posit Connect documentation for <a href='https://docs.posit.co/connect/user/content-settings/#content-vars' target='_blank'>Vars (environment variables)</a>
+        </div>
+    </div>
+    """
+
+# Function to create the report display for a result
 def create_report_display(result_data, check_time_value):
     # Format app name with link if dashboard_url is available
     app_name = result_data.get('name', 'Unknown')
@@ -311,12 +371,7 @@ application reports a failure.
 </div>"""
 
 # Always display the About callout box
-display(HTML(f"""
-<div style="border: 1px solid #ccc; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #f8f9fa;">
-    <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">ℹ️ About</div>
-    <div style="padding: 5px 0;">{about}</div>
-</div>
-"""))
+display(HTML(create_about_box(about)))
 
 if not show_instructions and 'df' in locals() and not df.empty and not show_error:
     # We're working with a single result since we only monitor a single GUID
@@ -330,23 +385,7 @@ if not show_instructions and 'df' in locals() and not df.empty and not show_erro
 
 elif show_error:
     # Create a callout box for API errors
-    display(HTML(f"""
-    <div style="border: 1px solid #cc0000; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fff8f8;">
-        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ Error Monitoring Content</div>
-        
-        <div style="display: grid; grid-template-columns: 150px auto; grid-gap: 8px; margin-top: 10px; padding-bottom: 8px; border-bottom: 1px solid #eaecef;">
-            <div style="font-weight: bold;">Content GUID:</div>
-            <div>{error_guid}</div>
-            
-            <div style="font-weight: bold;">Error:</div>
-            <div style="color: #cc0000;">{error_message}</div>
-        </div>
-        
-        <div style="padding-top: 8px; font-size: 0.9em;">
-            Please check that your CANARY_GUID environment variable contains a valid content identifier.
-        </div>
-    </div>
-    """))
+    display(HTML(create_error_box(error_guid, error_message)))
     
     # Using HTML display instead of tables
     
@@ -357,33 +396,12 @@ elif show_instructions:
     for instruction in instructions:
         instructions_html += f"<div style='margin-bottom: 10px;'>{instruction}</div>"
     
-    display(HTML(f"""
-    <div style="border: 1px solid #cc0000; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fff8f8;">
-        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ Setup Instructions</div>
-        {instructions_html}
-        <div style="padding-top: 8px; font-size: 0.9em; border-top: 1px solid #eaecef;">
-            See Posit Connect documentation for <a href='https://docs.posit.co/connect/user/content-settings/#content-vars' target='_blank'>Vars (environment variables)</a>
-        </div>
-    </div>
-    """))
+    display(HTML(create_instructions_box(instructions_html)))
     
     # Using HTML display instead of tables
 else:
     # We should only hit this catchall if the dataframe is empty (a likely error) and there are no instructions
-    display(HTML(f"""
-    <div style="border: 1px solid #f0ad4e; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fcf8e3;">
-        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ No results available</div>
-        <div style="padding: 5px 0;">
-            No monitoring results were found. This could be because:
-            <ul>
-                <li>No valid GUID was provided</li>
-                <li>There was an issue connecting to the specified content</li>
-                <li>The environment is properly configured but there was an error that caused no data to be returned</li>
-            </ul>
-            <p>Please check your CANARY_GUID environment variable and ensure it contains a valid content identifier.</p>
-        </div>
-    </div>
-    """))
+    display(HTML(create_no_results_box()))
     
     # Using HTML display instead of tables
 
@@ -420,32 +438,11 @@ App Canary - ❌ one or more apps have failed monitoring
 #| echo: false
 
 # Always show the about section in the email
-display(HTML(f"""
-<div style="border: 1px solid #ccc; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #f8f9fa;">
-    <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">ℹ️ About</div>
-    <div style="padding: 5px 0;">{about}</div>
-</div>
-"""))
+display(HTML(create_about_box(about)))
 
 # If there's an API error, display it in the email
 if show_error:
-    display(HTML(f"""
-    <div style="border: 1px solid #cc0000; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fff8f8;">
-        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ Error Monitoring Content</div>
-        
-        <div style="display: grid; grid-template-columns: 150px auto; grid-gap: 8px; margin-top: 10px; padding-bottom: 8px; border-bottom: 1px solid #eaecef;">
-            <div style="font-weight: bold;">Content GUID:</div>
-            <div>{error_guid}</div>
-            
-            <div style="font-weight: bold;">Error:</div>
-            <div style="color: #cc0000;">{error_message}</div>
-        </div>
-        
-        <div style="padding-top: 8px; font-size: 0.9em;">
-            Please check that your CANARY_GUID environment variable contains a valid content identifier.
-        </div>
-    </div>
-    """))
+    display(HTML(create_error_box(error_guid, error_message)))
 elif 'df' in locals() and not df.empty:
     # Display the report-style format in the email
     # We're working with a single result since we only monitor a single GUID
@@ -456,13 +453,6 @@ elif 'df' in locals() and not df.empty:
     display(HTML(report_html))
 else:
     # Display a message if neither error nor data is available
-    display(HTML(f"""
-    <div style="border: 1px solid #f0ad4e; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fcf8e3;">
-        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ No results available</div>
-        <div style="padding: 5px 0;">
-            No monitoring results were found. Please check your configuration.
-        </div>
-    </div>
-    """))
+    display(HTML(create_no_results_box()))
 ```
 :::

--- a/extensions/app-canary/app-canary.qmd
+++ b/extensions/app-canary/app-canary.qmd
@@ -13,7 +13,6 @@ import json
 import os
 import requests
 import datetime
-import pandas as pd
 from posit import connect
 from IPython.display import HTML, display
 
@@ -227,22 +226,17 @@ if not show_instructions:
             }
         return None
         
-    # Check the app and collect result
-    results = []
-    result = None
+    # Check the app and get result
+    app_result = None
     if canary_guid:
-        result = validate_app(canary_guid)
-        results.append(result)
+        app_result = validate_app(canary_guid)
         
         # Check if there was an error with the GUID
-        if has_error(result):
+        if has_error(app_result):
             show_error = True
-            error_details = extract_error_details(result)
+            error_details = extract_error_details(app_result)
             error_message = error_details["message"]
             error_guid = error_details["guid"]
-
-    # Convert results to DataFrame for easy display
-    df = pd.DataFrame(results)
 
     # Store the current time
     check_time = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
@@ -428,46 +422,52 @@ def create_report_display(result_data, check_time_value):
     
     return html_output
 
-about = """<div>
+# Create the about content text
+about_content = """<div>
 This report uses the publisher's API key to monitor an application GUID, verifies that the monitored app is 
 reachable at its content URL, and reports the results. If run on a schedule, reports will be emailed when the monitored 
 application reports a failure.
 </div>"""
 
+# Store HTML components in variables for reuse
+about_box_html = create_about_box(about_content)
+error_box_html = ""
+no_results_box_html = ""
+report_box_html = ""
+
+# Generate the appropriate HTML based on the state
+if show_error:
+    # Create error box HTML
+    error_box_html = create_error_box(error_guid, error_message)
+elif app_result and not has_error(app_result):
+    # Create report box HTML using the function
+    report_box_html = create_report_display(app_result, check_time)
+else:
+    # Create no results box HTML
+    no_results_box_html = create_no_results_box()
+
 # Always display the About callout box
-display(HTML(create_about_box(about)))
+display(HTML(about_box_html))
 
-if not show_instructions and 'df' in locals() and not df.empty and not show_error:
-    # We're working with a single result since we only monitor a single GUID
-    result_data = df.iloc[0]
-    
-    # Use the function to create and display the report
-    report_html = create_report_display(result_data, check_time)
-    display(HTML(report_html))
-    
-    # No need for table display since we're using HTML callouts
-
-elif show_error:
-    # Create a callout box for API errors
-    display(HTML(create_error_box(error_guid, error_message)))
-    
-    # Using HTML display instead of tables
-    
-elif show_instructions:
+# Display the appropriate content based on the state
+if show_instructions:
     # Create a callout box for instructions
     instructions_html = ""
-
     for instruction in instructions:
         instructions_html += f"<div style='margin-bottom: 10px;'>{instruction}</div>"
     
-    display(HTML(create_instructions_box(instructions_html)))
-    
-    # Using HTML display instead of tables
+    # Create and display instructions box
+    instructions_box_html = create_instructions_box(instructions_html)
+    display(HTML(instructions_box_html))
+elif show_error:
+    # Display the error box that was already created
+    display(HTML(error_box_html))
+elif report_box_html:
+    # Display the report box that was already created
+    display(HTML(report_box_html))
 else:
-    # We should only hit this catchall if the dataframe is empty (a likely error) and there are no instructions
-    display(HTML(create_no_results_box()))
-    
-    # Using HTML display instead of tables
+    # Display the no results box that was already created
+    display(HTML(no_results_box_html))
 
 # Helper function to determine if we should send an email
 def should_send_email():
@@ -476,9 +476,9 @@ def should_send_email():
     if show_error:
         return True
     
-    # Send email if at least one app has a failure status
-    if 'df' in locals() and not df.empty and 'status' in df.columns:
-        return bool(df['status'] == STATUS_FAIL).any()
+    # Send email if the monitored app has a failure status
+    if app_result and 'status' in app_result:
+        return app_result['status'] == STATUS_FAIL
     
     return False
 
@@ -501,28 +501,23 @@ send_email = should_send_email()
 :::
 
 ::: {.subject}
-App Canary - ❌ one or more apps have failed monitoring
+App Canary - ❌ The monitored app has failed
 :::
 
 ```{python}
 #| echo: false
 
 # Always show the about section in the email
-display(HTML(create_about_box(about)))
+display(HTML(about_box_html))
 
-# If there's an API error, display it in the email
-if show_error:
-    display(HTML(create_error_box(error_guid, error_message)))
-elif 'df' in locals() and not df.empty:
-    # Display the report-style format in the email
-    # We're working with a single result since we only monitor a single GUID
-    result_data = df.iloc[0]
-    
-    # Use the function to create and display the report
-    report_html = create_report_display(result_data, check_time)
-    display(HTML(report_html))
+# Display the appropriate content based on the state - use the same HTML as the main report
+if show_instructions:
+    display(HTML(instructions_box_html))
+elif show_error:
+    display(HTML(error_box_html))
+elif report_box_html:
+    display(HTML(report_box_html))
 else:
-    # Display a message if neither error nor data is available
-    display(HTML(create_no_results_box()))
+    display(HTML(no_results_box_html))
 ```
 :::

--- a/extensions/app-canary/app-canary.qmd
+++ b/extensions/app-canary/app-canary.qmd
@@ -35,18 +35,12 @@ if not api_key:
     show_instructions = True
     instructions.append("Please set the <b>CONNECT_API_KEY</b> environment variable.")
 
-# Read CANARY_GUIDS from environment, needs to be manually configured on Connect and for local dev
-canary_guids_str = os.environ.get("CANARY_GUIDS", "")
-if not canary_guids_str:
+# Read CANARY_GUID from environment, needs to be manually configured on Connect and for local dev
+canary_guid = os.environ.get("CANARY_GUID", "")
+if not canary_guid:
     show_instructions = True
-    instructions.append("Please set the <b>CANARY_GUIDS</b> environment variable. It should be a comma separated list of GUID you wish to monitor.")
-    canary_guids = []
-else:
-    # Clean up the GUIDs
-    canary_guids = [guid.strip() for guid in canary_guids_str.split(',') if guid.strip()]
-    if not canary_guids:
-        show_instructions = True
-        instructions.append(f"CANARY_GUIDS environment variable is set but is empty or contains only whitespace. It should be a comma separated list of GUID you wish to monitor. Raw CANARY_GUIDS value: '{canary_guids_str}'")
+    instructions.append("Please set the <b>CANARY_GUID</b> environment variable. It should be the GUID of the content you wish to monitor.")
+    canary_guid = ""
 
 # Instantiate a Connect client using posit-sdk where api_key and url are automatically read from our environment vars
 client = connect.Client()
@@ -202,10 +196,10 @@ if not show_instructions:
                 "http_code": str(e)
             }
 
-    # Check all apps and collect results
+    # Check the app and collect result
     results = []
-    for guid in canary_guids:
-        results.append(validate_app(guid))
+    if canary_guid:
+        results.append(validate_app(canary_guid))
 
     # Convert results to DataFrame for easy display
     df = pd.DataFrame(results)
@@ -220,23 +214,18 @@ if not show_instructions:
 #| label: display
 
 about = """<div style="margin-bottom: 10px;">
-This report uses the publisher's API key to monitor a list of application GUIDs, verifies each of the monitored apps are 
-reachable at their content URL, and reports the results. If run on a schedule, reports will be emailed when any monitored 
+This report uses the publisher's API key to monitor an application GUID, verifies that the monitored app is 
+reachable at its content URL, and reports the results. If run on a schedule, reports will be emailed when the monitored 
 application reports a failure.
 </div>"""
 
 if not show_instructions and not df.empty:
-    
-    # Format the canary_guids as a string for display
-    canary_guids_str = ", ".join(canary_guids)
     
     # Use HTML to create a callout box
     display(HTML(f"""
     <div style="border: 1px solid #ccc; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #f8f9fa;">
         <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">App Canary Monitor</div>
         <div style="padding: 5px 0;">{about}</div>
-        <div style="margin-top: 10px; padding-top: 8px; border-top: 1px solid #eaecef; font-weight: bold;">Monitored GUIDs:</div>
-        <div style="padding: 5px 0;">{canary_guids_str}</div>
     </div>
     """))
     
@@ -354,11 +343,11 @@ else:
         <div style="padding: 5px 0;">
             No monitoring results were found. This could be because:
             <ul>
-                <li>No valid GUIDs were provided</li>
+                <li>No valid GUID was provided</li>
                 <li>There was an issue connecting to the specified content</li>
                 <li>The environment is properly configured but there was an error that caused no data to be returned</li>
             </ul>
-            <p>Please check your CANARY_GUIDS environment variable and ensure it contains valid content identifiers.</p>
+            <p>Please check your CANARY_GUID environment variable and ensure it contains a valid content identifier.</p>
         </div>
     </div>
     """))

--- a/extensions/app-canary/app-canary.qmd
+++ b/extensions/app-canary/app-canary.qmd
@@ -23,6 +23,10 @@ show_instructions = False
 instructions = []
 gt_tbl = None
 
+# Used to display on-screen error messages if API errors occur
+show_error = False
+error_message = ""
+
 # Read CONNECT_SERVER from environment, this is automatically configured on Connect, set manually for local dev
 connect_server = os.environ.get("CONNECT_SERVER", "")
 if not connect_server:
@@ -199,7 +203,16 @@ if not show_instructions:
     # Check the app and collect result
     results = []
     if canary_guid:
-        results.append(validate_app(canary_guid))
+        result = validate_app(canary_guid)
+        
+        # Check if there was an error with the GUID
+        if result["name"].startswith("ERROR:"):
+            show_error = True
+            error_message = result["name"].replace("ERROR: ", "")
+            # Still add to results so we have a non-empty dataframe
+            results.append(result)
+        else:
+            results.append(result)
 
     # Convert results to DataFrame for easy display
     df = pd.DataFrame(results)
@@ -213,21 +226,21 @@ if not show_instructions:
 #| echo: false
 #| label: display
 
-about = """<div style="margin-bottom: 10px;">
+about = """<div>
 This report uses the publisher's API key to monitor an application GUID, verifies that the monitored app is 
 reachable at its content URL, and reports the results. If run on a schedule, reports will be emailed when the monitored 
 application reports a failure.
 </div>"""
 
-if not show_instructions and not df.empty:
-    
-    # Use HTML to create a callout box
-    display(HTML(f"""
-    <div style="border: 1px solid #ccc; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #f8f9fa;">
-        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">App Canary Monitor</div>
-        <div style="padding: 5px 0;">{about}</div>
-    </div>
-    """))
+# Always display the About callout box
+display(HTML(f"""
+<div style="border: 1px solid #ccc; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #f8f9fa;">
+    <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">ℹ️ About</div>
+    <div style="padding: 5px 0;">{about}</div>
+</div>
+"""))
+
+if not show_instructions and not df.empty and not show_error:
     
     # First create links for name and guid columns
     df_display = df.copy()
@@ -316,9 +329,25 @@ if not show_instructions and not df.empty:
               )
               )
 
+elif show_error:
+    # Create a callout box for API errors
+    display(HTML(f"""
+    <div style="border: 1px solid #cc0000; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fff8f8;">
+        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ Error Monitoring Content</div>
+        <div style="margin-top: 10px; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold;">Error Details:</div>
+        <div style="padding: 5px 0; color: #cc0000;">{error_message}</div>
+        <div style="padding-top: 8px; font-size: 0.9em;">
+            Please check that your CANARY_GUID environment variable contains a valid content identifier.
+        </div>
+    </div>
+    """))
+    
+    # Set gt_tbl to None since we're using HTML display instead
+    gt_tbl = None
+    
 elif show_instructions:
     # Create a callout box for instructions
-    instructions_html = about  # Start with the about message
+    instructions_html = ""
 
     for instruction in instructions:
         instructions_html += f"<div style='margin-bottom: 10px;'>{instruction}</div>"
@@ -360,6 +389,10 @@ if 'df' in locals() and 'status' in df.columns:
     send_email = bool(not df.empty and (df['status'] == 'FAIL').any())
 else:
     send_email = False
+
+# Also send email if we have an API error
+if show_error:
+    send_email = True
 ```
 
 
@@ -383,6 +416,28 @@ App Canary - ❌ one or more apps have failed monitoring
 
 ```{python}
 #| echo: false
-gt_tbl
+
+# Always show the about section in the email
+display(HTML(f"""
+<div style="border: 1px solid #ccc; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #f8f9fa;">
+    <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">ℹ️ About</div>
+    <div style="padding: 5px 0;">{about}</div>
+</div>
+"""))
+
+# If there's an API error, display it in the email
+if show_error:
+    display(HTML(f"""
+    <div style="border: 1px solid #cc0000; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fff8f8;">
+        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ Error Monitoring Content</div>
+        <div style="margin-top: 10px; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold;">Error Details:</div>
+        <div style="padding: 5px 0; color: #cc0000;">{error_message}</div>
+        <div style="padding-top: 8px; font-size: 0.9em;">
+            Please check that your CANARY_GUID environment variable contains a valid content identifier.
+        </div>
+    </div>
+    """))
+else:
+    gt_tbl
 ```
 :::

--- a/extensions/app-canary/app-canary.qmd
+++ b/extensions/app-canary/app-canary.qmd
@@ -242,92 +242,86 @@ display(HTML(f"""
 
 if not show_instructions and not df.empty and not show_error:
     
-    # First create links for name and guid columns
-    df_display = df.copy()
+    # Process the results to display in a top-to-bottom report format
+    # We're working with a single result since we only monitor a single GUID
+    result = df.iloc[0]
     
-    # Process the DataFrame rows to add HTML links and format owner info
-    for i in range(len(df_display)):
-        # Format app name links only (not guid)
-        if 'dashboard_url' in df_display.columns and not pd.isna(df_display.loc[i, 'dashboard_url']) and df_display.loc[i, 'dashboard_url']:
-            url = df_display.loc[i, 'dashboard_url']
-            app_name = df_display.loc[i, 'name']
-            app_guid = df_display.loc[i, 'guid']
+    # Format app name with link if dashboard_url is available
+    app_name = result.get('name', 'Unknown')
+    dashboard_url = result.get('dashboard_url', '')
+    if dashboard_url:
+        app_name_display = f"<a href='{dashboard_url}' target='_blank'>{app_name}</a>"
+    else:
+        app_name_display = app_name
+    
+    # Get GUID
+    app_guid = result.get('guid', '')
+    
+    # Format status with appropriate color
+    status = result.get('status', '')
+    if status == "PASS":
+        status_color = "#28a745"  # Green for PASS
+        status_icon = "✅"
+    else:
+        status_color = "#dc3545"  # Red for FAIL
+        status_icon = "❌"
+    
+    # Get HTTP Code
+    http_code = result.get('http_code', '')
+    
+    # Format logs link if available
+    logs_url = result.get('logs_url', '')
+    if logs_url:
+        logs_display = f"<a href='{logs_url}' target='_blank' style='text-decoration:none;'>📋 View Logs</a>"
+    else:
+        logs_display = "No logs available (only available to owner and collaborators)"
+    
+    # Format owner information
+    owner_name = result.get('owner_name', 'Unknown')
+    owner_email = result.get('owner_email', '')
+    if owner_email:
+        owner_display = f"{owner_name} <a href='mailto:{owner_email}' style='text-decoration:none;'>✉️</a>"
+    else:
+        owner_display = owner_name
+    
+    # Create last check time display
+    check_time_display = f"Last checked: {check_time}"
+    
+    # Create the report display HTML
+    status_box_color = "#e8f5e9" if status == "PASS" else "#ffebee"  # Light green or light red background
+    status_border_color = "#4caf50" if status == "PASS" else "#f44336"  # Green or red border
+    
+    display(HTML(f"""
+    <div style="border: 1px solid {status_border_color}; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: {status_box_color};">
+        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">
+            <span style="color: {status_color};">{status_icon} {status}</span> - Application Status
+        </div>
+        
+        <div style="display: grid; grid-template-columns: 150px auto; grid-gap: 8px; padding: 10px 0;">
+            <div style="font-weight: bold;">Name:</div>
+            <div>{app_name_display}</div>
             
-            # Create simple markdown link for name only
-            df_display.loc[i, 'name'] = f"<a href='{url}' target='_blank'>{app_name}</a>"
+            <div style="font-weight: bold;">Content GUID:</div>
+            <div>{app_guid}</div>
+            
+            <div style="font-weight: bold;">HTTP Code:</div>
+            <div>{http_code}</div>
+            
+            <div style="font-weight: bold;">Logs:</div>
+            <div>{logs_display}</div>
+            
+            <div style="font-weight: bold;">Owner:</div>
+            <div>{owner_display}</div>
+        </div>
         
-        # Format logs URL using markdown instead of HTML (similar to owner email)
-        if 'logs_url' in df_display.columns and df_display.loc[i, 'logs_url'] is not None and str(df_display.loc[i, 'logs_url']).strip():
-            # Use a simple icon since we can't use custom SVG in emails easily
-            logs_icon = "📋"
-            logs_url = df_display.loc[i, 'logs_url']
-            df_display.loc[i, 'logs'] = f"<a href='{logs_url}' target='_blank' style='text-decoration:none;'>{logs_icon}</a>"
-
-        else:
-            df_display.loc[i, 'logs'] = ""
-
-        # Format owner name with email icon link
-        owner_name = df_display.loc[i, 'owner_name'] if not pd.isna(df_display.loc[i, 'owner_name']) else "Unknown"
-        owner_email = df_display.loc[i, 'owner_email'] if not pd.isna(df_display.loc[i, 'owner_email']) else ""
-        
-        if owner_email:
-            # Use a simple icon since we can't use custom SVG in emails easily
-            email_icon = "✉️"
-            df_display.loc[i, 'owner_display'] = f"{owner_name} <a href='mailto:{owner_email}' style='text-decoration:none;'>{email_icon}</a>"
-        else:
-            df_display.loc[i, 'owner_display'] = owner_name
+        <div style="text-align: right; font-size: 0.8em; color: #666; padding-top: 8px; border-top: 1px solid #eaecef;">
+            {check_time_display}
+        </div>
+    </div>
+    """))
     
-    # Remove dashboard_url column since the links are embedded in the other columns
-    if 'dashboard_url' in df_display.columns:
-        df_display = df_display.drop(columns=['dashboard_url'])
-    
-    # Remove raw owner columns in favor of our formatted display column
-    if 'owner_name' in df_display.columns:
-        df_display = df_display.drop(columns=['owner_name'])
-    if 'owner_email' in df_display.columns:
-        df_display = df_display.drop(columns=['owner_email'])
-    
-    # Reorder columns to match requested layout
-    column_order = ['name', 'guid', 'status', 'http_code', 'logs', 'owner_display']
-    # Only include columns that exist in df_display
-    ordered_columns = [col for col in column_order if col in df_display.columns]
-    df_display = df_display[ordered_columns]
-    
-    # Create GT table
-    gt_tbl = GT(df_display)
-    
-    # Tell great_tables to render markdown content in these columns
-    gt_tbl = gt_tbl.fmt_markdown(columns=['name', 'owner_display', 'logs'])
-    
-    # Apply styling to columns
-    gt_tbl = (gt_tbl
-              # Status column styling - green for PASS, red for FAIL
-              .tab_style(
-                  style.fill("green"),
-                  locations=loc.body(columns="status", rows=lambda df: df["status"] == "PASS")
-              )
-              .tab_style(
-                  style.fill("red"),
-                  locations=loc.body(columns="status", rows=lambda df: df["status"] == "FAIL")
-              )
-              # Set column labels for better presentation
-              .cols_label(
-                  owner_display="Owner",
-                  name="Name",
-                  guid="Content GUID",
-                  status="Status",
-                  http_code="HTTP Code",
-                  logs="Logs"
-              )
-              # Override default column alignment for better presentation
-              .cols_align(
-                align='center', 
-                columns=["status", "http_code", "logs"]
-              )
-              .tab_options(
-                container_width="100%"
-              )
-              )
+    # Set gt_tbl to None since we're not using a table
+    gt_tbl = None
 
 elif show_error:
     # Create a callout box for API errors
@@ -399,8 +393,8 @@ if show_error:
 ```{python}
 #| echo: false
 
-# Display the table in the rendered document HTML, email is handled separately below
-gt_tbl
+# No need to display anything here since we're displaying HTML directly above
+# The gt_tbl variable is set to None in our new implementation
 ```
 
 
@@ -438,6 +432,82 @@ if show_error:
     </div>
     """))
 else:
-    gt_tbl
+    # Display the report-style format in the email
+    # We're working with a single result since we only monitor a single GUID
+    result = df.iloc[0]
+    
+    # Format app name with link if dashboard_url is available
+    app_name = result.get('name', 'Unknown')
+    dashboard_url = result.get('dashboard_url', '')
+    if dashboard_url:
+        app_name_display = f"<a href='{dashboard_url}' target='_blank'>{app_name}</a>"
+    else:
+        app_name_display = app_name
+    
+    # Get GUID
+    app_guid = result.get('guid', '')
+    
+    # Format status with appropriate color
+    status = result.get('status', '')
+    if status == "PASS":
+        status_color = "#28a745"  # Green for PASS
+        status_icon = "✅"
+    else:
+        status_color = "#dc3545"  # Red for FAIL
+        status_icon = "❌"
+    
+    # Get HTTP Code
+    http_code = result.get('http_code', '')
+    
+    # Format logs link if available
+    logs_url = result.get('logs_url', '')
+    if logs_url:
+        logs_display = f"<a href='{logs_url}' target='_blank' style='text-decoration:none;'>📋 View Logs</a>"
+    else:
+        logs_display = "No logs available"
+    
+    # Format owner information
+    owner_name = result.get('owner_name', 'Unknown')
+    owner_email = result.get('owner_email', '')
+    if owner_email:
+        owner_display = f"{owner_name} <a href='mailto:{owner_email}' style='text-decoration:none;'>✉️</a>"
+    else:
+        owner_display = owner_name
+    
+    # Create last check time display
+    check_time_display = f"Last checked: {check_time}"
+    
+    # Create the report display HTML
+    status_box_color = "#e8f5e9" if status == "PASS" else "#ffebee"  # Light green or light red background
+    status_border_color = "#4caf50" if status == "PASS" else "#f44336"  # Green or red border
+    
+    display(HTML(f"""
+    <div style="border: 1px solid {status_border_color}; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: {status_box_color};">
+        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">
+            <span style="color: {status_color};">{status_icon} {status}</span> - Application Status
+        </div>
+        
+        <div style="display: grid; grid-template-columns: 150px auto; grid-gap: 8px; padding: 10px 0;">
+            <div style="font-weight: bold;">Name:</div>
+            <div>{app_name_display}</div>
+            
+            <div style="font-weight: bold;">Content GUID:</div>
+            <div>{app_guid}</div>
+            
+            <div style="font-weight: bold;">HTTP Code:</div>
+            <div>{http_code}</div>
+            
+            <div style="font-weight: bold;">Logs:</div>
+            <div>{logs_display}</div>
+            
+            <div style="font-weight: bold;">Owner:</div>
+            <div>{owner_display}</div>
+        </div>
+        
+        <div style="text-align: right; font-size: 0.8em; color: #666; padding-top: 8px; border-top: 1px solid #eaecef;">
+            {check_time_display}
+        </div>
+    </div>
+    """))
 ```
 :::

--- a/extensions/app-canary/app-canary.qmd
+++ b/extensions/app-canary/app-canary.qmd
@@ -36,7 +36,7 @@ def get_env_var(var_name, description=""):
     value = os.environ.get(var_name, "")
     if not value:
         show_instructions = True
-        instruction = f"Please set the <b>{var_name}</b> environment variable."
+        instruction = f"Please set the <b>{var_name}</b> environment variable and re-render the report."
         if description:
             instruction += f" {description}"
         instructions.append(instruction)

--- a/extensions/app-canary/app-canary.qmd
+++ b/extensions/app-canary/app-canary.qmd
@@ -15,13 +15,11 @@ import requests
 import datetime
 import pandas as pd
 from posit import connect
-from great_tables import GT, style, loc, html
 from IPython.display import HTML, display
 
 # Used to display on-screen setup instructions if environment variables are missing
 show_instructions = False
 instructions = []
-gt_tbl = None
 
 # Used to display on-screen error messages if API errors occur
 show_error = False
@@ -320,8 +318,7 @@ if not show_instructions and not df.empty and not show_error:
     </div>
     """))
     
-    # Set gt_tbl to None since we're not using a table
-    gt_tbl = None
+    # No need for table display since we're using HTML callouts
 
 elif show_error:
     # Create a callout box for API errors
@@ -336,8 +333,7 @@ elif show_error:
     </div>
     """))
     
-    # Set gt_tbl to None since we're using HTML display instead
-    gt_tbl = None
+    # Using HTML display instead of tables
     
 elif show_instructions:
     # Create a callout box for instructions
@@ -356,8 +352,7 @@ elif show_instructions:
     </div>
     """))
     
-    # Set gt_tbl to None since we're using HTML display instead
-    gt_tbl = None
+    # Using HTML display instead of tables
 else:
     # We should only hit this catchall if the dataframe is empty (a likely error) and there are no instructions
     display(HTML(f"""
@@ -375,8 +370,7 @@ else:
     </div>
     """))
     
-    # Set gt_tbl to None since we're using HTML display instead
-    gt_tbl = None
+    # Using HTML display instead of tables
 
 # Compute if we should send an email, only send if at least one app has a failure
 if 'df' in locals() and 'status' in df.columns:
@@ -394,7 +388,6 @@ if show_error:
 #| echo: false
 
 # No need to display anything here since we're displaying HTML directly above
-# The gt_tbl variable is set to None in our new implementation
 ```
 
 

--- a/extensions/app-canary/app-canary.qmd
+++ b/extensions/app-canary/app-canary.qmd
@@ -53,6 +53,11 @@ client = connect.Client()
 #| echo: false
 #| label: data-gathering
 
+# Define status constants
+STATUS_PASS = "PASS"
+STATUS_FAIL = "FAIL"
+ERROR_PREFIX = "ERROR:"
+
 if not show_instructions:
     # Proceed to validate our monitored GUIDS
 
@@ -74,6 +79,29 @@ if not show_instructions:
     except requests.exceptions.RequestException as e:
         raise RuntimeError(f"Connect server at {connect_server} is unavailable: {str(e)}")
 
+    # Helper function to extract error messages from exceptions
+    def format_error_message(exception):
+        """Extract a clean error message from various exception types"""
+        error_message = str(exception)
+        
+        # posit-sdk will return a ClientError if there is a problem getting the guid, parse the error message
+        if isinstance(exception, connect.errors.ClientError):
+            try:
+                # ClientError from posit-connect SDK stores error as string that contains JSON
+                # Convert the string representation to a dict
+                error_data = json.loads(str(exception))
+                if isinstance(error_data, dict):
+                    # Extract the specific error message
+                    if "error_message" in error_data:
+                        error_message = error_data["error_message"]
+                    elif "error" in error_data:
+                        error_message = error_data["error"]
+            except json.JSONDecodeError:
+                # If parsing fails, keep the original error message
+                pass
+        
+        return error_message
+    
     # Function to get app details from Connect API
     def get_content(guid):
         try:
@@ -81,28 +109,12 @@ if not show_instructions:
             content = client.content.get(guid)
             return content
         except Exception as e:
-            # Initialize default error message
-            error_message = str(e)
-            
-            # posit-sdk will return a ClientError if there is a problem getting the guid, parse the error message
-            if isinstance(e, connect.errors.ClientError):
-                try:
-                    # ClientError from posit-connect SDK stores error as string that contains JSON
-                    # Convert the string representation to a dict
-                    error_data = json.loads(str(e))
-                    if isinstance(error_data, dict):
-                        # Extract the specific error message
-                        if "error_message" in error_data:
-                            error_message = error_data["error_message"]
-                        elif "error" in error_data:
-                            error_message = error_data["error"]
-                except json.JSONDecodeError:
-                    # If parsing fails, keep the original error message
-                    pass
+            # Extract error message and return error object
+            error_message = format_error_message(e)
             
             # Return content with error in title
             return {
-                "title": f"ERROR: {error_message}", 
+                "title": f"{ERROR_PREFIX} {error_message}", 
                 "guid": guid
             }
 
@@ -111,7 +123,8 @@ if not show_instructions:
             user = client.users.get(user_guid)
             return user
         except Exception as e:
-            raise RuntimeError(f"Error getting user: {str(e)}")
+            error_message = format_error_message(e)
+            raise RuntimeError(f"Error getting user: {error_message}")
 
     # Function to validate app health (simple HTTP 200 check)
     def validate_app(guid):
@@ -199,20 +212,34 @@ if not show_instructions:
                 "http_code": str(e)
             }
 
+    # Helper function to check if a result has an error
+    def has_error(result):
+        """Check if a result contains an error message in the name field"""
+        return result["name"].startswith(ERROR_PREFIX) if result and "name" in result else False
+    
+    # Helper function to extract error details from a result
+    def extract_error_details(result):
+        """Extract error message and GUID from a result"""
+        if has_error(result):
+            return {
+                "message": result["name"].replace(f"{ERROR_PREFIX} ", ""),
+                "guid": result.get("guid", "")
+            }
+        return None
+        
     # Check the app and collect result
     results = []
+    result = None
     if canary_guid:
         result = validate_app(canary_guid)
+        results.append(result)
         
         # Check if there was an error with the GUID
-        if result["name"].startswith("ERROR:"):
+        if has_error(result):
             show_error = True
-            error_message = result["name"].replace("ERROR: ", "")
-            error_guid = result["guid"]
-            # Still add to results so we have a non-empty dataframe
-            results.append(result)
-        else:
-            results.append(result)
+            error_details = extract_error_details(result)
+            error_message = error_details["message"]
+            error_guid = error_details["guid"]
 
     # Convert results to DataFrame for easy display
     df = pd.DataFrame(results)
@@ -226,32 +253,69 @@ if not show_instructions:
 #| echo: false
 #| label: display
 
+# Define CSS styling constants
+CSS_COLORS = {
+    "neutral": {
+        "border": "#ccc",
+        "background": "#f8f9fa",
+        "text": "#000"
+    },
+    "error": {
+        "border": "#cc0000",
+        "background": "#fff8f8",
+        "text": "#cc0000"
+    },
+    "warning": {
+        "border": "#f0ad4e",
+        "background": "#fcf8e3",
+        "text": "#cc0000"
+    },
+    "success": {
+        "border": "#4caf50",
+        "background": "#e8f5e9",
+        "text": "#28a745"
+    },
+    "fail": {
+        "border": "#f44336",
+        "background": "#ffebee",
+        "text": "#dc3545"
+    }
+}
+
+CSS_BOX_STYLE = "border: 1px solid {border}; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: {background};"
+CSS_HEADER_STYLE = "margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;"
+CSS_CONTENT_STYLE = "padding: 5px 0;"
+CSS_FOOTER_STYLE = "padding-top: 8px; font-size: 0.9em; border-top: 1px solid #eaecef;"
+CSS_GRID_STYLE = "display: grid; grid-template-columns: 150px auto; grid-gap: 8px; padding: 10px 0;"
+
 # Define helper functions for generating HTML components
 
 def create_about_box(about_content):
     """Creates the About callout box HTML"""
+    neutral = CSS_COLORS["neutral"]
     return f"""
-    <div style="border: 1px solid #ccc; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #f8f9fa;">
-        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">ℹ️ About</div>
-        <div style="padding: 5px 0;">{about_content}</div>
+    <div style="{CSS_BOX_STYLE.format(border=neutral['border'], background=neutral['background'])}"> 
+        <div style="{CSS_HEADER_STYLE}">ℹ️ About</div>
+        <div style="{CSS_CONTENT_STYLE}">{about_content}</div>
     </div>
     """
 
 def create_error_box(guid, error_msg):
     """Creates the Error callout box HTML"""
+    error = CSS_COLORS["error"]
     return f"""
-    <div style="border: 1px solid #cc0000; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fff8f8;">
-        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ Error Monitoring Content</div>
+    <div style="{CSS_BOX_STYLE.format(border=error['border'], background=error['background'])}"> 
+        <div style="{CSS_HEADER_STYLE}; color: {error['text']}">⚠️ Error Monitoring Content</div>
         
-        <div style="display: grid; grid-template-columns: 150px auto; grid-gap: 8px; margin-top: 10px; padding-bottom: 8px; border-bottom: 1px solid #eaecef;">
+        <div style="{CSS_GRID_STYLE}; margin-top: 10px; padding-bottom: 8px; border-bottom: 1px solid #eaecef;">
             <div style="font-weight: bold;">Content GUID:</div>
             <div>{guid}</div>
             
             <div style="font-weight: bold;">Error:</div>
-            <div style="color: #cc0000;">{error_msg}</div>
+            <div style="color: {error['text']};">{error_msg}</div>
         </div>
         
-        <div style="padding-top: 8px; font-size: 0.9em;">
+        <div style="{CSS_FOOTER_STYLE}">
             Please check that your CANARY_GUID environment variable contains a valid content identifier.
         </div>
     </div>
@@ -259,10 +323,12 @@ def create_error_box(guid, error_msg):
 
 def create_no_results_box():
     """Creates the No Results callout box HTML"""
+    warning = CSS_COLORS["warning"]
+    error_text = CSS_COLORS["error"]["text"]
     return f"""
-    <div style="border: 1px solid #f0ad4e; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fcf8e3;">
-        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ No results available</div>
-        <div style="padding: 5px 0;">
+    <div style="{CSS_BOX_STYLE.format(border=warning['border'], background=warning['background'])}"> 
+        <div style="{CSS_HEADER_STYLE}; color: {error_text};">⚠️ No results available</div>
+        <div style="{CSS_CONTENT_STYLE}">
             No monitoring results were found. This could be because:
             <ul>
                 <li>No valid GUID was provided</li>
@@ -276,11 +342,12 @@ def create_no_results_box():
 
 def create_instructions_box(instructions_html_content):
     """Creates the Setup Instructions callout box HTML"""
+    error = CSS_COLORS["error"]
     return f"""
-    <div style="border: 1px solid #cc0000; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fff8f8;">
-        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ Setup Instructions</div>
+    <div style="{CSS_BOX_STYLE.format(border=error['border'], background=error['background'])}"> 
+        <div style="{CSS_HEADER_STYLE}; color: {error['text']};">⚠️ Setup Instructions</div>
         {instructions_html_content}
-        <div style="padding-top: 8px; font-size: 0.9em; border-top: 1px solid #eaecef;">
+        <div style="{CSS_FOOTER_STYLE}">
             See Posit Connect documentation for <a href='https://docs.posit.co/connect/user/content-settings/#content-vars' target='_blank'>Vars (environment variables)</a>
         </div>
     </div>
@@ -301,12 +368,13 @@ def create_report_display(result_data, check_time_value):
     
     # Format status with appropriate color
     status = result_data.get('status', '')
-    if status == "PASS":
-        status_color = "#28a745"  # Green for PASS
-        status_icon = "✅"
+    
+    if status == STATUS_PASS:
+        status_colors = CSS_COLORS["success"]
+        status_icon = "✅"  # Checkmark
     else:
-        status_color = "#dc3545"  # Red for FAIL
-        status_icon = "❌"
+        status_colors = CSS_COLORS["fail"]
+        status_icon = "❌"  # X mark
     
     # Get HTTP Code
     http_code = result_data.get('http_code', '')
@@ -329,17 +397,13 @@ def create_report_display(result_data, check_time_value):
     # Create last check time display
     check_time_display = f"Last checked: {check_time_value}"
     
-    # Create the report display HTML
-    status_box_color = "#e8f5e9" if status == "PASS" else "#ffebee"  # Light green or light red background
-    status_border_color = "#4caf50" if status == "PASS" else "#f44336"  # Green or red border
-    
     html_output = f"""
-    <div style="border: 1px solid {status_border_color}; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: {status_box_color};">
-        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">
-            <span style="color: {status_color};">{status_icon} {status}</span> - Application Status
+    <div style="{CSS_BOX_STYLE.format(border=status_colors['border'], background=status_colors['background'])}">
+        <div style="{CSS_HEADER_STYLE}">
+            <span style="color: {status_colors['text']};">{status_icon} {status}</span> - Application Status
         </div>
         
-        <div style="display: grid; grid-template-columns: 150px auto; grid-gap: 8px; padding: 10px 0;">
+        <div style="{CSS_GRID_STYLE}">
             <div style="font-weight: bold;">Name:</div>
             <div>{app_name_display}</div>
             
@@ -356,7 +420,7 @@ def create_report_display(result_data, check_time_value):
             <div>{owner_display}</div>
         </div>
         
-        <div style="text-align: right; font-size: 0.8em; color: #666; padding-top: 8px; border-top: 1px solid #eaecef;">
+        <div style="text-align: right; font-size: 0.8em; color: #666; {CSS_FOOTER_STYLE}">
             {check_time_display}
         </div>
     </div>
@@ -405,15 +469,21 @@ else:
     
     # Using HTML display instead of tables
 
-# Compute if we should send an email, only send if at least one app has a failure
-if 'df' in locals() and 'status' in df.columns:
-    send_email = bool(not df.empty and (df['status'] == 'FAIL').any())
-else:
-    send_email = False
+# Helper function to determine if we should send an email
+def should_send_email():
+    """Determine if we should send an email notification"""
+    # Send email if we have an API error
+    if show_error:
+        return True
+    
+    # Send email if at least one app has a failure status
+    if 'df' in locals() and not df.empty and 'status' in df.columns:
+        return bool(df['status'] == STATUS_FAIL).any()
+    
+    return False
 
-# Also send email if we have an API error
-if show_error:
-    send_email = True
+# Set send_email variable for the quarto email mechanism
+send_email = should_send_email()
 ```
 
 

--- a/extensions/app-canary/app-canary.qmd
+++ b/extensions/app-canary/app-canary.qmd
@@ -24,6 +24,7 @@ instructions = []
 # Used to display on-screen error messages if API errors occur
 show_error = False
 error_message = ""
+error_guid = ""
 
 # Read CONNECT_SERVER from environment, this is automatically configured on Connect, set manually for local dev
 connect_server = os.environ.get("CONNECT_SERVER", "")
@@ -207,6 +208,7 @@ if not show_instructions:
         if result["name"].startswith("ERROR:"):
             show_error = True
             error_message = result["name"].replace("ERROR: ", "")
+            error_guid = result["guid"]
             # Still add to results so we have a non-empty dataframe
             results.append(result)
         else:
@@ -224,39 +226,21 @@ if not show_instructions:
 #| echo: false
 #| label: display
 
-about = """<div>
-This report uses the publisher's API key to monitor an application GUID, verifies that the monitored app is 
-reachable at its content URL, and reports the results. If run on a schedule, reports will be emailed when the monitored 
-application reports a failure.
-</div>"""
-
-# Always display the About callout box
-display(HTML(f"""
-<div style="border: 1px solid #ccc; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #f8f9fa;">
-    <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">ℹ️ About</div>
-    <div style="padding: 5px 0;">{about}</div>
-</div>
-"""))
-
-if not show_instructions and not df.empty and not show_error:
-    
-    # Process the results to display in a top-to-bottom report format
-    # We're working with a single result since we only monitor a single GUID
-    result = df.iloc[0]
-    
+# Define a function to create the report display for a result
+def create_report_display(result_data, check_time_value):
     # Format app name with link if dashboard_url is available
-    app_name = result.get('name', 'Unknown')
-    dashboard_url = result.get('dashboard_url', '')
+    app_name = result_data.get('name', 'Unknown')
+    dashboard_url = result_data.get('dashboard_url', '')
     if dashboard_url:
         app_name_display = f"<a href='{dashboard_url}' target='_blank'>{app_name}</a>"
     else:
         app_name_display = app_name
     
     # Get GUID
-    app_guid = result.get('guid', '')
+    app_guid = result_data.get('guid', '')
     
     # Format status with appropriate color
-    status = result.get('status', '')
+    status = result_data.get('status', '')
     if status == "PASS":
         status_color = "#28a745"  # Green for PASS
         status_icon = "✅"
@@ -265,31 +249,31 @@ if not show_instructions and not df.empty and not show_error:
         status_icon = "❌"
     
     # Get HTTP Code
-    http_code = result.get('http_code', '')
+    http_code = result_data.get('http_code', '')
     
     # Format logs link if available
-    logs_url = result.get('logs_url', '')
+    logs_url = result_data.get('logs_url', '')
     if logs_url:
         logs_display = f"<a href='{logs_url}' target='_blank' style='text-decoration:none;'>📋 View Logs</a>"
     else:
         logs_display = "No logs available (only available to owner and collaborators)"
     
     # Format owner information
-    owner_name = result.get('owner_name', 'Unknown')
-    owner_email = result.get('owner_email', '')
+    owner_name = result_data.get('owner_name', 'Unknown')
+    owner_email = result_data.get('owner_email', '')
     if owner_email:
         owner_display = f"{owner_name} <a href='mailto:{owner_email}' style='text-decoration:none;'>✉️</a>"
     else:
         owner_display = owner_name
     
     # Create last check time display
-    check_time_display = f"Last checked: {check_time}"
+    check_time_display = f"Last checked: {check_time_value}"
     
     # Create the report display HTML
     status_box_color = "#e8f5e9" if status == "PASS" else "#ffebee"  # Light green or light red background
     status_border_color = "#4caf50" if status == "PASS" else "#f44336"  # Green or red border
     
-    display(HTML(f"""
+    html_output = f"""
     <div style="border: 1px solid {status_border_color}; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: {status_box_color};">
         <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">
             <span style="color: {status_color};">{status_icon} {status}</span> - Application Status
@@ -316,7 +300,31 @@ if not show_instructions and not df.empty and not show_error:
             {check_time_display}
         </div>
     </div>
-    """))
+    """
+    
+    return html_output
+
+about = """<div>
+This report uses the publisher's API key to monitor an application GUID, verifies that the monitored app is 
+reachable at its content URL, and reports the results. If run on a schedule, reports will be emailed when the monitored 
+application reports a failure.
+</div>"""
+
+# Always display the About callout box
+display(HTML(f"""
+<div style="border: 1px solid #ccc; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #f8f9fa;">
+    <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">ℹ️ About</div>
+    <div style="padding: 5px 0;">{about}</div>
+</div>
+"""))
+
+if not show_instructions and 'df' in locals() and not df.empty and not show_error:
+    # We're working with a single result since we only monitor a single GUID
+    result_data = df.iloc[0]
+    
+    # Use the function to create and display the report
+    report_html = create_report_display(result_data, check_time)
+    display(HTML(report_html))
     
     # No need for table display since we're using HTML callouts
 
@@ -325,8 +333,15 @@ elif show_error:
     display(HTML(f"""
     <div style="border: 1px solid #cc0000; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fff8f8;">
         <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ Error Monitoring Content</div>
-        <div style="margin-top: 10px; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold;">Error Details:</div>
-        <div style="padding: 5px 0; color: #cc0000;">{error_message}</div>
+        
+        <div style="display: grid; grid-template-columns: 150px auto; grid-gap: 8px; margin-top: 10px; padding-bottom: 8px; border-bottom: 1px solid #eaecef;">
+            <div style="font-weight: bold;">Content GUID:</div>
+            <div>{error_guid}</div>
+            
+            <div style="font-weight: bold;">Error:</div>
+            <div style="color: #cc0000;">{error_message}</div>
+        </div>
+        
         <div style="padding-top: 8px; font-size: 0.9em;">
             Please check that your CANARY_GUID environment variable contains a valid content identifier.
         </div>
@@ -417,88 +432,35 @@ if show_error:
     display(HTML(f"""
     <div style="border: 1px solid #cc0000; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fff8f8;">
         <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ Error Monitoring Content</div>
-        <div style="margin-top: 10px; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold;">Error Details:</div>
-        <div style="padding: 5px 0; color: #cc0000;">{error_message}</div>
+        
+        <div style="display: grid; grid-template-columns: 150px auto; grid-gap: 8px; margin-top: 10px; padding-bottom: 8px; border-bottom: 1px solid #eaecef;">
+            <div style="font-weight: bold;">Content GUID:</div>
+            <div>{error_guid}</div>
+            
+            <div style="font-weight: bold;">Error:</div>
+            <div style="color: #cc0000;">{error_message}</div>
+        </div>
+        
         <div style="padding-top: 8px; font-size: 0.9em;">
             Please check that your CANARY_GUID environment variable contains a valid content identifier.
         </div>
     </div>
     """))
-else:
+elif 'df' in locals() and not df.empty:
     # Display the report-style format in the email
     # We're working with a single result since we only monitor a single GUID
-    result = df.iloc[0]
+    result_data = df.iloc[0]
     
-    # Format app name with link if dashboard_url is available
-    app_name = result.get('name', 'Unknown')
-    dashboard_url = result.get('dashboard_url', '')
-    if dashboard_url:
-        app_name_display = f"<a href='{dashboard_url}' target='_blank'>{app_name}</a>"
-    else:
-        app_name_display = app_name
-    
-    # Get GUID
-    app_guid = result.get('guid', '')
-    
-    # Format status with appropriate color
-    status = result.get('status', '')
-    if status == "PASS":
-        status_color = "#28a745"  # Green for PASS
-        status_icon = "✅"
-    else:
-        status_color = "#dc3545"  # Red for FAIL
-        status_icon = "❌"
-    
-    # Get HTTP Code
-    http_code = result.get('http_code', '')
-    
-    # Format logs link if available
-    logs_url = result.get('logs_url', '')
-    if logs_url:
-        logs_display = f"<a href='{logs_url}' target='_blank' style='text-decoration:none;'>📋 View Logs</a>"
-    else:
-        logs_display = "No logs available"
-    
-    # Format owner information
-    owner_name = result.get('owner_name', 'Unknown')
-    owner_email = result.get('owner_email', '')
-    if owner_email:
-        owner_display = f"{owner_name} <a href='mailto:{owner_email}' style='text-decoration:none;'>✉️</a>"
-    else:
-        owner_display = owner_name
-    
-    # Create last check time display
-    check_time_display = f"Last checked: {check_time}"
-    
-    # Create the report display HTML
-    status_box_color = "#e8f5e9" if status == "PASS" else "#ffebee"  # Light green or light red background
-    status_border_color = "#4caf50" if status == "PASS" else "#f44336"  # Green or red border
-    
+    # Use the function to create and display the report
+    report_html = create_report_display(result_data, check_time)
+    display(HTML(report_html))
+else:
+    # Display a message if neither error nor data is available
     display(HTML(f"""
-    <div style="border: 1px solid {status_border_color}; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: {status_box_color};">
-        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; font-weight: bold; font-size: 1.2em;">
-            <span style="color: {status_color};">{status_icon} {status}</span> - Application Status
-        </div>
-        
-        <div style="display: grid; grid-template-columns: 150px auto; grid-gap: 8px; padding: 10px 0;">
-            <div style="font-weight: bold;">Name:</div>
-            <div>{app_name_display}</div>
-            
-            <div style="font-weight: bold;">Content GUID:</div>
-            <div>{app_guid}</div>
-            
-            <div style="font-weight: bold;">HTTP Code:</div>
-            <div>{http_code}</div>
-            
-            <div style="font-weight: bold;">Logs:</div>
-            <div>{logs_display}</div>
-            
-            <div style="font-weight: bold;">Owner:</div>
-            <div>{owner_display}</div>
-        </div>
-        
-        <div style="text-align: right; font-size: 0.8em; color: #666; padding-top: 8px; border-top: 1px solid #eaecef;">
-            {check_time_display}
+    <div style="border: 1px solid #f0ad4e; border-radius: 8px; padding: 10px; margin-bottom: 15px; background-color: #fcf8e3;">
+        <div style="margin-top: 0; padding-bottom: 8px; border-bottom: 1px solid #eaecef; color: #cc0000; font-weight: bold; font-size: 1.2em;">⚠️ No results available</div>
+        <div style="padding: 5px 0;">
+            No monitoring results were found. Please check your configuration.
         </div>
     </div>
     """))


### PR DESCRIPTION
Refactor includes:

- Only monitoring a single GUID
- Removing pandas since we no longer need to store a dataset of multiple content results
- Displaying monitoring results in a callout instead of a table since we are no longer collecting multiple content results
- Displaying any errors in a callout instead of shoving them into the results (previously directly into the results table). This makes the error much more consumable and functions as providing feedback about malformed/invalid GUID, or GUID you don't have access to for whatever reason
- Improved output when you don't have permissions to view the logs for the monitored content, which should only happen if you are a viewer
- Significant refactoring of the overall code to reduce duplication and complexity

This is deployed on our internal Connect server: https://dogfood.team.pct.posit.it/connect/#/apps/54e4557b-812d-4f70-afc6-9f2e5022a179/environment

Fixes https://github.com/posit-dev/connect/issues/32394
Fixes https://github.com/posit-dev/connect/issues/32404

## Tests

- [x] No CANARY_GUID env var set
    - [x] If scheduled, DOES NOT send an email
- [x] Invalid GUID
    - [x] If scheduled, sends an email
- [x] Valid GUID for content you are a owner of
- [x] Valid GUID for content you are a collaborator of
- [x] Valid GUID for content you are a viewer of
- [x] Valid GUID for content you do not have access to (not in ACL, etc.)
    - [x] In the above setup, where the monitored content passing validation, if scheduled, DOES NOT send an email
- [x] Valid GUID, content is published but fails validation
    - [x] If scheduled, sends an email

Required env var not set.
<img width="1978" height="1167" alt="Screenshot 2025-07-11 at 1 11 56 PM" src="https://github.com/user-attachments/assets/8191e179-83a9-4ac5-b817-69af66637c65" />

Invalid GUID set
<img width="1978" height="1167" alt="Screenshot 2025-07-11 at 1 12 43 PM" src="https://github.com/user-attachments/assets/2de61c50-4600-41c5-8c37-3aa5476ba27e" />

<img width="1072" height="843" alt="image" src="https://github.com/user-attachments/assets/78007434-351a-4336-b8ea-a52f8d22e509" />


Valid GUID, owner of content, content passes validation
<img width="1978" height="1167" alt="Screenshot 2025-07-11 at 1 13 35 PM" src="https://github.com/user-attachments/assets/ea396921-971a-4dc9-96bf-ad00a45192d4" />

Valid GUID, collaborator of content, content passes validation
<img width="1978" height="1167" alt="image" src="https://github.com/user-attachments/assets/6706d1c0-97e4-46a8-9547-dce57409f5d5" />


Valid GUID, viewer of content, content passes validation
<img width="1978" height="1167" alt="Screenshot 2025-07-11 at 1 28 12 PM" src="https://github.com/user-attachments/assets/50cdfe65-0512-4b27-8e30-b5cd0f007989" />


Vaid GUID, no permission to content
<img width="1978" height="1167" alt="image" src="https://github.com/user-attachments/assets/317090e2-3e92-4f16-90f5-a74afcfaeaba" />

<img width="1072" height="941" alt="image" src="https://github.com/user-attachments/assets/cbbadd44-0da3-40eb-b98e-deb24a3298b5" />


Valid GUID, owner of content, content fails validation
<img width="1978" height="1167" alt="Screenshot 2025-07-11 at 1 22 34 PM" src="https://github.com/user-attachments/assets/6f2dcb78-cb80-44a2-b12c-9446495683d2" />

<img width="1072" height="941" alt="image" src="https://github.com/user-attachments/assets/aed46b77-2c4b-401f-9d8c-f84bbbe89a1e" />


