### PR TITLE
Release Package Vulnerability Scanner `2.0`

### DIFF
--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Package Vulnerability Scanner extension will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2025-07-11
 
 ### Added
 

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -44,6 +44,6 @@
     "category": "extension",
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": ["API Publishing"],
-    "version": "1.0.0"
+    "version": "2.0.0"
   }
 }

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -23,11 +23,11 @@
     "dist/assets/index-5vgyaG_a.css": {
       "checksum": "aa4504cc8edb049bfe5c2e6ec66e0f25"
     },
-    "dist/assets/index-BGxDsx_N.js": {
-      "checksum": "9b90c1b9d81627c0eaee37703068aa59"
+    "dist/assets/index-BMwEkJ9e.js": {
+      "checksum": "ef3d700fd8f521afadc82cfa2385377b"
     },
     "dist/index.html": {
-      "checksum": "f705c76bb93b87070f4492ea50ed8cf1"
+      "checksum": "61de23bbcf376913838dfc6cba2a0979"
     },
     "main.py": {
       "checksum": "e3063b5ce9771a34d7fa23f2234d3668"


### PR DESCRIPTION
Bumps the Package Vulnerability Scanner to version 2 following the work done for several issues:
- #203 
- #204 
- #205 
- #206 
- #207
- #208 
- #210 
- #211 
- #213 
- #214 
- #215 
- #216 
- #220 

This content is deployed [on our internal Dogfood server here](https://dogfood.team.pct.posit.it/connect/#/apps/b6fd7c18-4819-44dd-a47e-40be0d4a1ab0).