### PR TITLE
Allow users to filter for tidyverse/official EOL versions or “any version”

### DIFF
--- a/extensions/runtime-version-scanner/app.R
+++ b/extensions/runtime-version-scanner/app.R
@@ -124,7 +124,6 @@ ui <- page_sidebar(
       )
     ),
 
-    # h5("Filters"),
     tags$hr(),
 
     selectizeInput(
@@ -141,22 +140,16 @@ ui <- page_sidebar(
 
     div(
       class = "form-group shiny-input-container",
-      # tags$label(
-      #   "Viewed at least…",
-      #   style = "margin-bottom: 8px; display: inline-block;"
-      # ),
       div(
-        # this div is getting a height of 52.6
         style = "display: flex; align-items: baseline; gap: 6px; height: 36.5px",
         numericInput(
-          # this control has a height of 36.5
           "min_views_filter",
           label = NULL,
           value = 0,
           min = 0,
           width = "80px",
         ),
-        span("times") # this span has a height of 24
+        span("times")
       )
     ),
 


### PR DESCRIPTION
This PR allows users to select official (Python) or tidyverse (R) supported versions as their cutoff in the content filter. It also adds an option to filter for "Any version" of each runtime.

UI labels have been updated accordingly. There's quite a bit of complexity there; perhaps it's worth factoring that code out so it can be tested.

Available here (private):
- https://connect.posit.it/runtime-version-scanner/
- https://dogfood.team.pct.posit.it/runtime-version-scanner/

I don't see an *official* way to get the version support cutoff for Python or R/tidyverse from an API, so the content will need to be updated when that happens, in its current state.