### PR TITLE
refactor(content-health-monitor): include user's name in About and Log error

### DIFF
--- a/extensions/content-health-monitor/content-health-monitor.qmd
+++ b/extensions/content-health-monitor/content-health-monitor.qmd
@@ -100,7 +100,7 @@ else:
 html_components = {
     'instructions': create_instructions_box(instructions_html) if show_instructions else None,
     'error': create_error_box(error_guid, error_message) if show_error else None,
-    'report': create_report_display(content_result, check_time) if content_result and not has_error(content_result) else None,
+    'report': create_report_display(content_result, check_time, current_user_name) if content_result and not has_error(content_result) else None,
     'no_results': create_no_results_box() if not (show_instructions or show_error or 
                                               (content_result and not has_error(content_result))) else None
 }

--- a/extensions/content-health-monitor/content-health-monitor.qmd
+++ b/extensions/content-health-monitor/content-health-monitor.qmd
@@ -45,6 +45,18 @@ if not show_instructions:
 # Always record the current time for reporting purposes
 check_time = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 
+# Initialize current user name with a default for display
+current_user_name = "the publisher"  # Default, used if no name is available
+
+# Get current user's full name if client is available
+if not show_instructions and client:
+    try:
+        user_name = get_current_user_full_name(client)
+        if user_name:  # Only update if we got a valid name
+            current_user_name = user_name
+    except Exception as e:
+        print(f"Warning: Could not get current user name: {str(e)}")
+
 # Only proceed with content validation if we have all requirements
 # (show_instructions=False already tells us env vars are set and client was initialized)
 if not show_instructions:
@@ -71,11 +83,12 @@ if not show_instructions:
 
 # ------ DISPLAY SECTION ------ #
 # Create the about content text
-about_content = """<div>
-This report uses the publisher's API key to monitor a single piece of content. It checks whether the content is 
+about_content = f"""<div>
+This report uses {current_user_name}'s API key to monitor a single piece of content. It checks whether the content is 
 reachable, but does not validate its functionality. When scheduled to run regularly, it will send an email alert if the 
 content becomes unreachable.
 </div>"""
+
 
 # Prepare instructions HTML if needed
 if show_instructions:

--- a/extensions/content-health-monitor/content_health_utils.py
+++ b/extensions/content-health-monitor/content_health_utils.py
@@ -118,6 +118,38 @@ def get_user(client, user_guid):
         error_message = format_error_message(e)
         raise RuntimeError(f"Error getting user: {error_message}")
 
+def get_current_user_full_name(client):
+    """
+    Get the full name of the current user from the Connect API
+    
+    Args:
+        client: The Connect client instance
+        
+    Returns:
+        str: The full name of the current user or "Unknown" if not available
+    """
+    try:
+        # Get the current user information
+        current_user = client.me
+        
+        # Extract first and last name
+        first_name = current_user.get("first_name", "")
+        last_name = current_user.get("last_name", "")
+        
+        # Combine into full name
+        full_name = f"{first_name} {last_name}".strip()
+        
+        # Return username if full name is empty
+        if not full_name:
+            return current_user.get("username", "Unknown")
+            
+        return full_name
+    except Exception as e:
+        # Handle any errors gracefully
+        error_message = format_error_message(e)
+        print(f"Warning: Could not retrieve current user: {error_message}")
+        return "Unknown"
+
 # Function to validate content health (simple HTTP 200 check)
 def validate(client, guid, connect_server, api_key):
     # Get content details

--- a/extensions/content-health-monitor/content_health_utils.py
+++ b/extensions/content-health-monitor/content_health_utils.py
@@ -345,7 +345,7 @@ def create_instructions_box(instructions_html_content):
     """
 
 # Function to create the report display for a result
-def create_report_display(result_data, check_time_value):
+def create_report_display(result_data, check_time_value, current_user_name=None):
     if result_data is None:
         return None
         
@@ -378,7 +378,10 @@ def create_report_display(result_data, check_time_value):
     if logs_url:
         logs_display = f"<a href='{logs_url}' target='_blank' style='text-decoration:none;'>📋 View Logs</a>"
     else:
-        logs_display = "No logs available — only visible to the content owner and collaborators."
+        if current_user_name:
+            logs_display = f"Log access is restricted for {current_user_name}. Logs are only available to the content owner and collaborators."
+        else:
+            logs_display = "Log access is restricted. Logs are only available to the content owner and collaborators."
     
     # Format owner information
     owner_name = result_data.get('owner_name', 'Unknown')


### PR DESCRIPTION
Fixes: #32659


Display the user's full name in:
- About dialog so it is clear who's API key is being used to render the report
- Log if the user has no access to the logs