### PR TITLE
chore: Clean up old connect-extension tomls

### DIFF
--- a/extensions/audit-api/connect-extension.toml
+++ b/extensions/audit-api/connect-extension.toml
@@ -1,4 +1,0 @@
-name="audit-log-api"
-title="audit log api"
-access_type="acl"
-description="an api publishers can call for audit logs."

--- a/extensions/audit-reports/connect-extension.toml
+++ b/extensions/audit-reports/connect-extension.toml
@@ -1,4 +1,0 @@
-name="audit-reports"
-title="audit reports"
-access_type="acl"
-description="a quarto site of audit reports"

--- a/extensions/datadog-prometheus-metrics/connect-extension.toml
+++ b/extensions/datadog-prometheus-metrics/connect-extension.toml
@@ -1,4 +1,0 @@
-name = "datadog-prometheus-metrics"
-title = "Plotting Connect Prometheus Metrics from Datadog"
-description = "Allows users to query Datadog for a selected Connect Prometheus metric over a given timeframe and view a plot of the results."
-access_type = "acl"

--- a/extensions/integration-session-manager/connect-extension.toml
+++ b/extensions/integration-session-manager/connect-extension.toml
@@ -1,4 +1,0 @@
-name = "connect-integration-session-manager"
-title = "Connect OAuth Integration Session Manager"
-description = "Allows Connect admins to view and manage OAuth integration sessions."
-access_type = "logged_in"

--- a/extensions/notifier/connect-extension.toml
+++ b/extensions/notifier/connect-extension.toml
@@ -1,4 +1,0 @@
-name="notifier"
-title="notifier"
-access_type="acl"
-description="send an HTTP request to an external service based on Connect's audit log"

--- a/extensions/oauth-integration-debug/connect-extension.toml
+++ b/extensions/oauth-integration-debug/connect-extension.toml
@@ -1,4 +1,0 @@
-name = "oauth-integration-debug"
-title = "Connect OAuth Integration Debugger"
-description = "Allows Connect content viewers to debug user session tokens and credential exchange."
-access_type = "logged_in"

--- a/extensions/oauth-integration-validator/connect-extension.toml
+++ b/extensions/oauth-integration-validator/connect-extension.toml
@@ -1,4 +1,0 @@
-name = "oauth-integration-validator"
-title = "Connect OAuth Integration Validator"
-description = "Test an OAuth integration by performing a GET request to a specified endpoint using the access token obtained by Connect."
-access_type = "logged_in"

--- a/extensions/prototype-content-with-issues-table/connect-extension.toml
+++ b/extensions/prototype-content-with-issues-table/connect-extension.toml
@@ -1,4 +1,0 @@
-name = "prototype-content-with-issues-interactive-table"
-title = "Content With Issues (interactive table)"
-description = "R Shiny prototype extension that displays an interactive table of all failed content jobs for items deployed within the last year."
-access_type = "acl"


### PR DESCRIPTION
We had some lingering `connect-extension.toml` files which are no longer used as part of the bundle or deploy process. Cleaning these up 🧹 