### PR TITLE
refactor(content-health-monitor): automatically parse GUID from input string

### DIFF
--- a/extensions/content-health-monitor/content-health-monitor.qmd
+++ b/extensions/content-health-monitor/content-health-monitor.qmd
@@ -30,6 +30,10 @@ connect_server = get_env_var("CONNECT_SERVER") # Automatically provided by Conne
 api_key = get_env_var("CONNECT_API_KEY") # Automatically provided by Connect, must be set when previewing locally
 monitored_content_guid = get_env_var("MONITORED_CONTENT_GUID")
 
+# Extract GUID if it's a string or URL containing a GUID
+if monitored_content_guid:
+    monitored_content_guid = extract_guid(monitored_content_guid)
+
 # Only instantiate the client if we have the required environment variables
 client = None
 if not show_instructions:

--- a/extensions/content-health-monitor/content_health_utils.py
+++ b/extensions/content-health-monitor/content_health_utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import requests
 from posit import connect
 
@@ -93,6 +94,27 @@ def format_error_message(exception):
             pass
     
     return error_message
+
+# Function to extract GUID string or URL
+def extract_guid(input_string):
+    """
+    Extract GUID from a string or URL.
+    
+    Args:
+        input_string: String that may contain a GUID
+        
+    Returns:
+        str: Extracted GUID or original string if no GUID found
+    """
+    # Match UUIDs in various formats that might appear in URLs
+    guid_pattern = re.compile(r'[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}')
+    
+    match = guid_pattern.search(input_string)
+    if match:
+        return match.group(0)
+    
+    # Return original string if no GUID found
+    return input_string
 
 # Function to get content details from Connect API
 def get_content(client, guid):


### PR DESCRIPTION
Fixes: https://github.com/posit-dev/connect/issues/32799

Deployed on our private team Connect server here: https://dogfood.team.pct.posit.it/connect/#/apps/1d97c1ff-e56c-4074-906f-cb3557685b75/access/7281

Attempts to automatically parse the GUID from value stored in MONITORED_CONTENT_GUID  

This solves the previous behavior where inputting a URL would simply error.

<img width="1985" height="1167" alt="Screenshot 2025-07-31 at 12 09 07 PM" src="https://github.com/user-attachments/assets/bae648ee-d34b-476f-9056-e9c07ac55f89" />

Now automatically extracts the GUID and renders a usable report.

<img width="1984" height="1167" alt="Screenshot 2025-07-31 at 1 25 35 PM" src="https://github.com/user-attachments/assets/f2119915-9c2c-42d2-b143-5756704401d8" />

If no GUID is found it uses the raw input which will ensure the user sees their raw input when it errors fetching the content. See this example where I fed it a Vanity URL.

<img width="1984" height="1167" alt="Screenshot 2025-07-31 at 1 16 04 PM" src="https://github.com/user-attachments/assets/50e0f4f9-6124-4e48-a6f1-0a22a69451bc" />

