### PR TITLE
refactor(content-health-monitor): Add instructions for scheduling

### DIFF
--- a/extensions/content-health-monitor/content-health-monitor.qmd
+++ b/extensions/content-health-monitor/content-health-monitor.qmd
@@ -91,8 +91,10 @@ if not state.show_instructions:
 # Create the about content text
 about_content = f"""<div>
 This report uses {current_user_name}'s API key to monitor a single piece of content. It checks whether the content is 
-reachable, but does not validate its functionality. When scheduled to run regularly, it will send an email alert if the 
-content becomes unreachable.
+reachable, but does not verify that it runs without errors. When scheduled to run regularly, the report will send an email alert 
+if the content becomes unreachable.<br><br>
+To learn more about scheduling reports in Connect, see the 
+<a href="https://docs.posit.co/connect/user/scheduling/index.html" target="_blank">Scheduling documentation</a>.
 </div>"""
 
 

--- a/extensions/content-health-monitor/content-health-monitor.qmd
+++ b/extensions/content-health-monitor/content-health-monitor.qmd
@@ -91,8 +91,9 @@ if not state.show_instructions:
 # Create the about content text
 about_content = f"""<div>
 This report uses {current_user_name}'s API key to monitor a single piece of content. It checks whether the content is 
-reachable, but does not verify that it runs without errors. When scheduled to run regularly, the report will send an email alert 
-if the content becomes unreachable.<br><br>
+reachable, but does not verify that it runs without errors.<br><br>
+When scheduled to run regularly, the report will send an email alert 
+if the content becomes unreachable.
 To learn more about scheduling reports in Connect, see the 
 <a href="https://docs.posit.co/connect/user/scheduling/index.html" target="_blank">Scheduling documentation</a>.
 </div>"""

--- a/extensions/content-health-monitor/manifest.json
+++ b/extensions/content-health-monitor/manifest.json
@@ -41,7 +41,7 @@
       "checksum": "5f89d52674b219c0b0ed85f1a5785641"
     },
     "content-health-monitor.qmd": {
-      "checksum": "8dfce167badb4d889eeb93d1f4adbff8"
+      "checksum": "b9d7b54bd001f48f8af928b26be91a8f"
     },
     "content_health_utils.py": {
       "checksum": "3d599ebe8d29aa12ae630acc847e290a"


### PR DESCRIPTION
Added a link to the public Connect documentation that covers scheduling in depth.  Is it that easy?

<img width="925" height="429" alt="image" src="https://github.com/user-attachments/assets/35c2d0e4-2d37-43be-b854-a55929c7ab5a" />


Fixes: https://github.com/posit-dev/connect/issues/32798

Currently deployed on our private team Connect server here:  https://dogfood.team.pct.posit.it/connect/#/apps/2452543f-5c50-4c9f-8ccf-a222343a9d0f/7283