### PR TITLE
chore: update starlette dependency for package vulnerability scanner

### DIFF
--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -33,7 +33,7 @@
       "checksum": "e3063b5ce9771a34d7fa23f2234d3668"
     },
     "requirements.txt": {
-      "checksum": "3b9b57b849bc53863f92c720581ee6d8"
+      "checksum": "9fc5cc5fb559eded1f323793b73e82c5"
     }
   },
   "extension": {

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -44,6 +44,6 @@
     "category": "extension",
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": ["API Publishing"],
-    "version": "2.0.0"
+    "version": "2.0.1"
   }
 }

--- a/extensions/package-vulnerability-scanner/pyproject.toml
+++ b/extensions/package-vulnerability-scanner/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "fastapi[standard]>=0.115.12",
+    "starlette>=0.47.2",
     "httpx>=0.28.1",
     "posit-sdk>=0.10.0",
 ]

--- a/extensions/package-vulnerability-scanner/requirements.txt
+++ b/extensions/package-vulnerability-scanner/requirements.txt
@@ -1,3 +1,4 @@
 httpx
 fastapi
+starlette>=0.47.2
 posit-sdk


### PR DESCRIPTION
Fixes #264

I downloaded and extracted the tarball with the changes on this branch: https://github.com/posit-dev/connect-extensions/actions/runs/16680046741/artifacts/3668897327

Then I deployed the updated application to a local Connect server using `rsconnect deploy manifest` and verified the `starlette` vulnerability is no longer being flagged