### PR TITLE
chore(content-health-monitor): ensure we always try to get the current user's full name

### DIFF
--- a/extensions/content-health-monitor/content-health-monitor.qmd
+++ b/extensions/content-health-monitor/content-health-monitor.qmd
@@ -15,8 +15,7 @@ import requests
 import datetime
 from posit import connect
 from IPython.display import HTML, display
-from content_health_utils import *
-from content_health_utils import MonitorState
+from content_health_utils import *  # Imports everything including MonitorState and DEFAULT_USER_NAME
 
 # Create state object to share between this file and utils
 state = MonitorState()
@@ -27,6 +26,9 @@ error_message = None      # Error message to display if API errors occur
 error_guid = None         # GUID that caused the error
 content_result = None     # Variable to store content monitoring result
 
+# Initialize current user name with the default value from utils
+current_user_name = DEFAULT_USER_NAME  # Will be updated if user info can be retrieved
+
 # Read environment variables
 connect_server = get_env_var("CONNECT_SERVER", state) # Automatically provided by Connect, must be set when previewing locally
 api_key = get_env_var("CONNECT_API_KEY", state) # Automatically provided by Connect, must be set when previewing locally
@@ -36,32 +38,29 @@ monitored_content_guid = get_env_var("MONITORED_CONTENT_GUID", state)
 if monitored_content_guid:
     monitored_content_guid = extract_guid(monitored_content_guid)
 
-# Only instantiate the client if we have the required environment variables
+# Check if we have the required environment variables to instantiate the client
 client = None
-if not state.show_instructions:
+has_connect_env_vars = connect_server and api_key
+
+if has_connect_env_vars:
     try:
-        # Instantiate a Connect client using posit-sdk where api_key and url are automatically read from our environment vars
+        # Instantiate a Connect client using posit-sdk
         client = connect.Client()
+        
+        # Get current user's full name - function handles errors internally
+        user_name = get_current_user_full_name(client)
+        if user_name != "Unknown":  # Only update if we got a valid name
+            current_user_name = user_name
     except ValueError as e:
-        state.show_instructions = True
-        state.instructions.append(f"<b>Error initializing Connect client:</b> {str(e)}")
+        if not state.show_instructions:
+            state.show_instructions = True
+            state.instructions.append(f"<b>Error initializing Connect client:</b> {str(e)}")
 
 
 # ------ DATA GATHERING SECTION ------ #
 # Always record the current time for reporting purposes
 check_time = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 
-# Initialize current user name with a default for display
-current_user_name = "the publisher"  # Default, used if no name is available
-
-# Get current user's full name if client is available
-if not state.show_instructions and client:
-    try:
-        user_name = get_current_user_full_name(client)
-        if user_name:  # Only update if we got a valid name
-            current_user_name = user_name
-    except Exception as e:
-        print(f"Warning: Could not get current user name: {str(e)}")
 
 # Only proceed with content validation if we have all requirements
 # (state.show_instructions=False already tells us env vars are set and client was initialized)

--- a/extensions/content-health-monitor/content_health_utils.py
+++ b/extensions/content-health-monitor/content_health_utils.py
@@ -18,6 +18,7 @@ class MonitorState:
 STATUS_PASS = "PASS"
 STATUS_FAIL = "FAIL"
 ERROR_PREFIX = "ERROR:"
+DEFAULT_USER_NAME = "the publisher"  # Default name used if user info cannot be retrieved
 
 # Define CSS styling constants
 CSS_COLORS = {
@@ -194,9 +195,8 @@ def get_current_user_full_name(client):
             
         return full_name
     except Exception as e:
-        # Handle any errors gracefully
-        error_message = format_error_message(e)
-        print(f"Warning: Could not retrieve current user: {error_message}")
+        # Handle any errors gracefully without printing
+        # This prevents errors from appearing at the top of reports
         return "Unknown"
 
 # Function to validate content health (simple HTTP 200 check)
@@ -245,9 +245,10 @@ def validate(client, guid, connect_server, api_key):
             owner_full_name = f"{owner_first_name} {owner_last_name}".strip()
             if not owner_full_name:  # Handle case where both names are empty
                 owner_full_name = "Unknown"
-    except Exception as e:
-        # If there's an error getting the owner, keep the defaults
-        print(f"Warning: Could not retrieve owner for {guid}: {str(e)}")
+    except Exception:
+        # If there's an error getting the owner, silently keep the defaults
+        # No print statement to avoid errors at the top of reports
+        pass
     
     # Compose URL to logs if we have a dashboard URL, only owner/editor have access
     if dashboard_url and content.get("app_role") != "viewer":

--- a/extensions/content-health-monitor/test_integration.py
+++ b/extensions/content-health-monitor/test_integration.py
@@ -1,8 +1,10 @@
 import os
 import pytest
+import posit.connect
+from unittest.mock import MagicMock, patch
 
 import content_health_utils
-from content_health_utils import MonitorState
+from content_health_utils import MonitorState, DEFAULT_USER_NAME
 
 # Define fixtures to prepare the test environment
 
@@ -97,3 +99,167 @@ def test_env_var_exists(clean_environment, state):
     assert value == "test_value"
     assert state.show_instructions is False
     assert state.instructions == []
+
+def test_user_name_with_instructions(clean_environment, state):
+    """
+    Test that the user's name is retrieved even when show_instructions is True.
+    This test verifies the fix for the issue where publisher's name wasn't 
+    showing in the About box when setup instructions were displayed.
+    """
+    # Set state to show instructions
+    state.show_instructions = True
+    
+    # Create a mock client
+    mock_client = MagicMock()
+    mock_client.me = {
+        "first_name": "Test",
+        "last_name": "User",
+        "username": "testuser"
+    }
+    
+    # Get the user name
+    user_name = content_health_utils.get_current_user_full_name(mock_client)
+    
+    # Verify user name is retrieved correctly
+    assert user_name == "Test User"
+    # Instructions state should still be True
+    assert state.show_instructions is True
+
+def test_client_initialization_with_env_vars(clean_environment):
+    """
+    Test the scenario where environment variables are present and client can be initialized.
+    This tests our fix that attempts to get the user name when env vars are available,
+    even if showing instructions for other reasons.
+    """
+    # Set required environment variables
+    os.environ['CONNECT_SERVER'] = 'https://connect.example.com'
+    os.environ['CONNECT_API_KEY'] = 'test_api_key'
+    
+    # Create state and other required variables
+    state = MonitorState()
+    state.show_instructions = True  # Set to True for other reasons (e.g., missing MONITORED_CONTENT_GUID)
+    current_user_name = DEFAULT_USER_NAME  # Default
+    
+    # Mock the client and get_current_user_full_name function
+    mock_client = MagicMock()
+    
+    with patch('posit.connect.Client', return_value=mock_client):
+        with patch('content_health_utils.get_current_user_full_name', return_value="Test User"):
+            # This simulates the client initialization code in content-health-monitor.qmd
+            client = None
+            has_connect_env_vars = os.environ.get('CONNECT_SERVER') and os.environ.get('CONNECT_API_KEY')
+            
+            if has_connect_env_vars:
+                try:
+                    # Instantiate client
+                    client = posit.connect.Client()
+                    
+                    # Try to get user name
+                    try:
+                        user_name = content_health_utils.get_current_user_full_name(client)
+                        if user_name:
+                            current_user_name = user_name
+                    except Exception:
+                        pass
+                except ValueError:
+                    pass
+            
+            # Assert that client was created and user name was updated
+            assert client is not None
+            assert current_user_name == "Test User"
+            # Instructions state should still be True
+            assert state.show_instructions is True
+
+def test_client_initialization_without_env_vars(clean_environment):
+    """
+    Test the scenario where environment variables are missing and client cannot be initialized.
+    This verifies that we don't attempt to create the client in this case,
+    and the default publisher name is preserved.
+    """
+    # Make sure environment variables are not set
+    if 'CONNECT_SERVER' in os.environ:
+        del os.environ['CONNECT_SERVER']
+    if 'CONNECT_API_KEY' in os.environ:
+        del os.environ['CONNECT_API_KEY']
+    
+    # Create state and other required variables
+    state = MonitorState()
+    state.show_instructions = True
+    current_user_name = DEFAULT_USER_NAME  # Default
+    
+    # Mock client creation to ensure it's never called
+    mock_client_init = MagicMock(side_effect=ValueError("Should not be called"))
+    
+    with patch('posit.connect.Client', mock_client_init):
+        # This simulates the client initialization code in content-health-monitor.qmd
+        client = None
+        connect_server = os.environ.get('CONNECT_SERVER', '')
+        api_key = os.environ.get('CONNECT_API_KEY', '')
+        has_connect_env_vars = connect_server and api_key
+        
+        if has_connect_env_vars:
+            try:
+                # Instantiate client
+                client = posit.connect.Client()
+                
+                # Try to get user name
+                try:
+                    user_name = content_health_utils.get_current_user_full_name(client)
+                    if user_name:
+                        current_user_name = user_name
+                except Exception:
+                    pass
+            except ValueError:
+                pass
+        
+        # Assert that client was not created and default name is preserved
+        assert client is None
+        assert current_user_name == DEFAULT_USER_NAME
+        assert not has_connect_env_vars  # Verify that we correctly detected missing env vars (empty string is falsy)
+        
+        # Verify that Client constructor was never called
+        mock_client_init.assert_not_called()
+
+def test_connection_error_handling(clean_environment):
+    """
+    Test that connection errors are properly handled and don't show up at the top of the report.
+    The get_current_user_full_name function should handle errors internally and return "Unknown".
+    """
+    # Set required environment variables
+    os.environ['CONNECT_SERVER'] = 'http://localhost:3939'
+    os.environ['CONNECT_API_KEY'] = 'test_api_key'
+    
+    # Create state and other required variables
+    state = MonitorState()
+    
+    # Create a test scenario where get_current_user_full_name will return "Unknown" for connection issues
+    with patch('content_health_utils.get_current_user_full_name', return_value="Unknown"):
+        # Mock the client
+        mock_client = MagicMock()
+        
+        with patch('posit.connect.Client', return_value=mock_client):
+            # This simulates the code in content-health-monitor.qmd
+            client = None
+            current_user_name = DEFAULT_USER_NAME  # Default
+            connect_server = os.environ.get('CONNECT_SERVER', '')
+            api_key = os.environ.get('CONNECT_API_KEY', '')
+            has_connect_env_vars = connect_server and api_key
+            
+            if has_connect_env_vars:
+                try:
+                    # Instantiate client
+                    client = posit.connect.Client()
+                    
+                    # Get current user's full name - function handles errors internally
+                    user_name = content_health_utils.get_current_user_full_name(client)
+                    if user_name != "Unknown":  # Only update if we got a valid name
+                        current_user_name = user_name
+                        
+                except ValueError as e:
+                    if not state.show_instructions:
+                        state.show_instructions = True
+                        state.instructions.append(f"<b>Error initializing Connect client:</b> {str(e)}")
+            
+            # Assert that client was created but user name was not updated due to error
+            assert client is not None  # Client creation succeeds
+            assert current_user_name == DEFAULT_USER_NAME  # Name should remain the default since user_name is "Unknown"


### PR DESCRIPTION
Observed that during setup we were not initializing the client and trying to fetch the user's full name.

- Assuming the required Connect env vars are availbale init the client and fetch the user's full name
- Modify some var init logic related to the default user name
- Tidy up some imports
- Have Claude help with adding some tests to cover our changed behaviors