### PR TITLE
fix(content-health-monitor): emit friendly error if URL does not contain a GUID

### DIFF
--- a/extensions/content-health-monitor/content-health-monitor.qmd
+++ b/extensions/content-health-monitor/content-health-monitor.qmd
@@ -34,7 +34,11 @@ monitored_content_guid = get_env_var("MONITORED_CONTENT_GUID", state)
 
 # Extract GUID if it's a string or URL containing a GUID
 if monitored_content_guid:
-    monitored_content_guid = extract_guid(monitored_content_guid)
+    monitored_content_guid, guid_error_message = extract_guid(monitored_content_guid)
+    # Handle URL with no GUID error
+    if guid_error_message:
+        state.show_instructions = True
+        state.instructions.append(guid_error_message)
 
 # Only instantiate the client if we have the required environment variables
 client = None

--- a/extensions/content-health-monitor/content_health_utils.py
+++ b/extensions/content-health-monitor/content_health_utils.py
@@ -131,17 +131,36 @@ def extract_guid(input_string):
         input_string: String that may contain a GUID
         
     Returns:
-        str: Extracted GUID or original string if no GUID found
+        tuple: (extracted_guid, error_message)
+            - extracted_guid: The extracted GUID or original string if no GUID found
+            - error_message: Error message if the input doesn't contain a valid GUID, None otherwise
     """
     # Match UUIDs in various formats that might appear in URLs
     guid_pattern = re.compile(r'[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}')
     
     match = guid_pattern.search(input_string)
     if match:
-        return match.group(0)
+        return match.group(0), None
     
-    # Return original string if no GUID found
-    return input_string
+    # Check if the input looks like a URL but doesn't contain a GUID
+    url_pattern = re.compile(r'^https?://', re.IGNORECASE)
+    if url_pattern.match(input_string):
+        error_message = (
+            f"The URL provided in <code>MONITORED_CONTENT_GUID</code> does not contain a valid GUID. "
+            f"The URL should contain a GUID like: <code>1d97c1ff-e56c-4074-906f-cb3557685b75</code><br><br>"
+            f"The URL provided is: <a href=\"{input_string}\" target=\"_blank\" rel=\"noopener noreferrer\">{input_string}</a><br><br>"
+            f"Please update your environment variable with a valid GUID or a URL containing a GUID."
+        )
+        return input_string, error_message
+    
+    # Handle non-URL strings that don't match GUID format
+    error_message = (
+        f"The value provided in <code>MONITORED_CONTENT_GUID</code> is not a valid GUID. "
+        f"A valid GUID looks like: <code>1d97c1ff-e56c-4074-906f-cb3557685b75</code><br><br>"
+        f"The provided value was: <code>{input_string}</code><br><br>"
+        f"Please update your environment variable with a valid GUID or a URL containing a GUID."
+    )
+    return input_string, error_message
 
 # Function to get content details from Connect API
 def get_content(client, guid):

--- a/extensions/content-health-monitor/content_health_utils.py
+++ b/extensions/content-health-monitor/content_health_utils.py
@@ -259,7 +259,8 @@ def validate(client, guid, connect_server, api_key):
     try:
         # Use the content_url if available
         if not content_url:
-            content_url = f"{connect_server}/content/{guid}"
+            base_url = connect_server.rstrip('/')
+            content_url = f"{base_url}/content/{guid}"
             
         content_response = requests.get(
             content_url, 

--- a/extensions/content-health-monitor/manifest.json
+++ b/extensions/content-health-monitor/manifest.json
@@ -32,7 +32,7 @@
     "version": "3.11.7",
     "package_manager": {
       "name": "pip",
-      "version": "24.2",
+      "version": "25.1.1",
       "package_file": "requirements.txt"
     }
   },
@@ -44,7 +44,7 @@
       "checksum": "b9d7b54bd001f48f8af928b26be91a8f"
     },
     "content_health_utils.py": {
-      "checksum": "3d599ebe8d29aa12ae630acc847e290a"
+      "checksum": "4a645a030421b138e4280b7f17651783"
     },
     "images/refresh-report.png": {
       "checksum": "e5680e6188eb8d659e4313cb89d0be3b"

--- a/extensions/content-health-monitor/manifest.json
+++ b/extensions/content-health-monitor/manifest.json
@@ -41,10 +41,10 @@
       "checksum": "5f89d52674b219c0b0ed85f1a5785641"
     },
     "content-health-monitor.qmd": {
-      "checksum": "b9d7b54bd001f48f8af928b26be91a8f"
+      "checksum": "db9599dc24337de8c0becbcefb203371"
     },
     "content_health_utils.py": {
-      "checksum": "4a645a030421b138e4280b7f17651783"
+      "checksum": "3fc5386653742d8bf625686e486466ea"
     },
     "images/refresh-report.png": {
       "checksum": "e5680e6188eb8d659e4313cb89d0be3b"

--- a/extensions/content-health-monitor/test_content_health_utils.py
+++ b/extensions/content-health-monitor/test_content_health_utils.py
@@ -21,6 +21,7 @@ STATUS_PASS = content_health_utils.STATUS_PASS
 # Functions from content_health_utils
 check_server_reachable = content_health_utils.check_server_reachable
 extract_error_details = content_health_utils.extract_error_details
+extract_guid = content_health_utils.extract_guid
 format_error_message = content_health_utils.format_error_message
 get_content = content_health_utils.get_content
 get_env_var = content_health_utils.get_env_var
@@ -248,6 +249,67 @@ class TestFormatErrorMessage:
             
             # Assert - Since the JSON is invalid, it should return the original string
             assert result == error_text
+
+
+# Tests for extract_guid function
+class TestExtractGuid:
+    
+    def test_extract_guid_with_valid_guid(self):
+        """Test extract_guid with a valid GUID string"""
+        # Setup - Valid GUID string
+        input_string = "1d97c1ff-e56c-4074-906f-cb3557685b75"
+        
+        # Execute
+        result, error_message = extract_guid(input_string)
+        
+        # Assert
+        assert result == input_string
+        assert error_message is None
+    
+    def test_extract_guid_with_valid_guid_in_url(self):
+        """Test extract_guid with a URL containing a valid GUID"""
+        # Setup - URL with GUID
+        guid = "1d97c1ff-e56c-4074-906f-cb3557685b75"
+        input_string = f"https://connect.example.com/content/{guid}/"
+        
+        # Execute
+        result, error_message = extract_guid(input_string)
+        
+        # Assert
+        assert result == guid
+        assert error_message is None
+    
+    def test_extract_guid_with_url_no_guid(self):
+        """Test extract_guid with a URL that does not contain a GUID"""
+        # Setup - URL without GUID
+        input_string = "https://connect.example.com/content/dashboard"
+        
+        # Execute
+        result, error_message = extract_guid(input_string)
+        
+        # Assert
+        assert result == input_string
+        assert error_message is not None
+        assert "The URL provided in <code>MONITORED_CONTENT_GUID</code> does not contain a valid GUID" in error_message
+        assert "The URL should contain a GUID like: <code>1d97c1ff-e56c-4074-906f-cb3557685b75</code>" in error_message
+        assert f"<a href=\"{input_string}\" target=\"_blank\" rel=\"noopener noreferrer\">" in error_message
+        assert "Please update your environment variable with a valid GUID or a URL containing a GUID" in error_message
+    
+    def test_extract_guid_with_plain_text(self):
+        """Test extract_guid with plain text that is not a URL and does not contain a GUID"""
+        # Setup - Plain text input
+        input_string = "some-content-name"
+        
+        # Execute
+        result, error_message = extract_guid(input_string)
+        
+        # Assert
+        assert result == input_string
+        assert error_message is not None
+        assert "The value provided in <code>MONITORED_CONTENT_GUID</code> is not a valid GUID" in error_message
+        assert "A valid GUID looks like: <code>1d97c1ff-e56c-4074-906f-cb3557685b75</code>" in error_message
+        assert f"The provided value was: <code>{input_string}</code>" in error_message
+        assert "Please update your environment variable with a valid GUID or a URL containing a GUID" in error_message
 
 
 # Tests for get_content and get_user functions


### PR DESCRIPTION
Fixes: https://github.com/posit-dev/connect/issues/33017

Process the env var input and display a more friendly error if the input does not contain a GUID.

