### PR TITLE
Ensure email subject reflects pass/fail state

### DIFF
--- a/extensions/content-health-monitor/content-health-monitor.qmd
+++ b/extensions/content-health-monitor/content-health-monitor.qmd
@@ -139,7 +139,7 @@ send_email = utils.should_send_email(show_error, content_result)
 :::
 
 ::: {.subject}
-`{python} f"❌ Content Health Monitor - \"{content_result.get('name', 'Unknown Content') if content_result else 'Unknown Content'}\" has failed monitoring"`
+`{python} f"{('❌' if content_result and content_result.get('status') == 'FAIL' else '✅')} Content Health Monitor - \"{content_result.get('name', 'Unknown Content') if content_result else 'Unknown Content'}\" {('has failed monitoring' if content_result and content_result.get('status') == 'FAIL' else 'is healthy')}"`
 :::
 
 ```{python}


### PR DESCRIPTION
Fixes: https://github.com/posit-dev/connect/issues/33020

Email subject will now correctly reflect the pass/fail status in the report.

<img width="1072" height="941" alt="image" src="https://github.com/user-attachments/assets/1e10180f-de29-4ff8-964c-3be7f892c510" />

<img width="1072" height="941" alt="image" src="https://github.com/user-attachments/assets/51ca1537-c9ca-498f-8aa8-908169d3c195" />
