### PR TITLE
feat(stock-api-fastapi): simple otel tracing

### DIFF
--- a/extensions/stock-api-fastapi/requirements.txt
+++ b/extensions/stock-api-fastapi/requirements.txt
@@ -2,3 +2,7 @@ fastapi==0.115.3
 numpy==1.26.4
 pandas==2.2.1
 pydantic==2.10.4
+opentelemetry-api==1.28.2
+opentelemetry-sdk==1.28.2
+opentelemetry-instrumentation-fastapi==0.49b2
+opentelemetry-exporter-otlp-proto-http==1.28.2


### PR DESCRIPTION
DRAFT

For: https://github.com/posit-dev/connect/issues/34333

Shows how simple it is to set up otel tracing in a Python fastapi app. The benefit of using OTLP is that the only thing that needs to change if you want to point this at a different backend is the environment variables ingested by `OTLPSpanExporter`. 

Note:
Lost a battle to the OTEL collector and Datadog and didn't want to close the week out without having anything up. Have a number of iterations on collector config files that we can likely learn from but didn't get a finished thing that worked.
