### PR TITLE
ci: use github app instead of deploy-key in workflows

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -303,14 +303,12 @@ jobs:
         with:
           app-id: 1129585
           private-key: ${{ secrets.POSIT_CONNECT_PROJECTS_PEM }}
-          permissions: |
-            contents: write
-            pull-requests: write
+          permission-contents: write
 
       # Checkout main to commit the updated extension list
       # reduces the chance of conflicts when updating the extension list with
       # multiple running workflows
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Instead of using an ssh key to give gha read/write permissions use our github app.

follow-up:

- [ ] remove `DEPLOY_KEY` repo secret
