### PR TITLE
Usage Metrics Dashboard: Enrich our usage data when exporting to CSV

### DIFF
--- a/extensions/usage-metrics-dashboard/manifest.json
+++ b/extensions/usage-metrics-dashboard/manifest.json
@@ -3069,6 +3069,6 @@
     "requiredFeatures": [
       "OAuth Integrations"
     ],
-    "version": "1.0.10"
+    "version": "1.0.11"
   }
 }


### PR DESCRIPTION
A request from a customer: to provide content title and username to the raw data export so it's easier to consume our csv exports without needing to query the API (again)


Here's what the output looks like (names + emails redacted with `...`):

```
"timestamp","content_title","content_guid","owner_username","username","full_name","email","user_guid"
2025-12-18 00:01:32.173499,"simple-mcp-server","6319ad41-4545-4dda-add9-bda55401b6dd","...","...","...","...","46cd83c3-3a02-4673-968a-d1819e49bc92"
2025-12-18 00:03:29.448596,"simple-mcp-server","6319ad41-4545-4dda-add9-bda55401b6dd","...","...","...","...","46cd83c3-3a02-4673-968a-d1819e49bc92"
2025-12-18 00:05:58.672521,"simple-mcp-server","6319ad41-4545-4dda-add9-bda55401b6dd","...","...","...","...","46cd83c3-3a02-4673-968a-d1819e49bc92"
2025-12-18 00:07:38.618918,"simple-mcp-server","6319ad41-4545-4dda-add9-bda55401b6dd","...","...","...","...","46cd83c3-3a02-4673-968a-d1819e49bc92"
2025-12-18 00:09:19.876261,"simple-mcp-server","6319ad41-4545-4dda-add9-bda55401b6dd","...","...","...","...","46cd83c3-3a02-4673-968a-d1819e49bc92"
```