### PR TITLE
Update for azure openai compatibility

### DIFF
--- a/extensions/chat-with-content/README.md
+++ b/extensions/chat-with-content/README.md
@@ -45,7 +45,7 @@ As a Posit Connect administrator, you need to configure the environment for this
     -   `CHATLAS_CHAT_PROVIDER_MODEL`: `azure-openai/{deployment_id}` (e.g., `azure-openai/gpt-4.1-mini`)
     -   `AZURE_OPENAI_ENDPOINT`: `https://{your-resource-name}.openai.azure.com`
     -   `AZURE_OPENAI_API_KEY`: `<your-azure-openai-api-key>` (Set this as a secret)
-    -   `CHATLAS_CHAT_ARGS`: `{"api_version": "2025-03-01-preview"}` (Required — see [Azure OpenAI API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation))
+    -   `CHATLAS_CHAT_ARGS`: `{"api_version": "2025-03-01-preview", "deployment_id": "gpt-4.1-nano", "endpoint": "https://example.openai.azure.com/"}` (Required — see [Azure OpenAI API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation))
 
     **Example for Anthropic on AWS Bedrock:**
 

--- a/extensions/chat-with-content/README.md
+++ b/extensions/chat-with-content/README.md
@@ -21,7 +21,7 @@ As a Posit Connect administrator, you need to configure the environment for this
 
 1.  **Publish the Extension**: Publish this application to Posit Connect.
 
-2.  **Configure Environment Variables**: In the "Vars" pane of the content settings, you need to set environment variables to configure the LLM provider. This extension uses the `chatlas` library, which supports various LLM providers like OpenAI, Google Gemini, and Anthropic on AWS Bedrock.
+2.  **Configure Environment Variables**: In the "Vars" pane of the content settings, you need to set environment variables to configure the LLM provider. This extension uses the `chatlas` library, which supports various LLM providers like OpenAI, Azure OpenAI, Google Gemini, Anthropic, and Anthropic on AWS Bedrock.
 
     Set `CHATLAS_CHAT_PROVIDER_MODEL` to specify the provider and model in the format `provider/model`. You also need to provide the API key for the chosen service.
 
@@ -40,6 +40,13 @@ As a Posit Connect administrator, you need to configure the environment for this
     -   `CHATLAS_CHAT_PROVIDER_MODEL`: `anthropic/claude-sonnet-4-20250514`
     -   `ANTHROPIC_API_KEY`: `<your-anthropic-api-key>` (Set this as a secret)
 
+    **Example for Azure OpenAI:**
+
+    -   `CHATLAS_CHAT_PROVIDER_MODEL`: `azure-openai/{deployment_id}` (e.g., `azure-openai/gpt-4.1-mini`)
+    -   `AZURE_OPENAI_ENDPOINT`: `https://{your-resource-name}.openai.azure.com`
+    -   `AZURE_OPENAI_API_KEY`: `<your-azure-openai-api-key>` (Set this as a secret)
+    -   `CHATLAS_CHAT_ARGS`: `{"api_version": "2024-06-01"}` (Required — see [Azure OpenAI API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation))
+
     **Example for Anthropic on AWS Bedrock:**
 
     The application uses the [botocore](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/credentials.html) credential chain for AWS authentication. If the Connect server is running on an EC2 instance with an IAM role that grants access to Bedrock, credentials are automatically detected and no configuration is needed. In this case, the application uses the `us.anthropic.claude-sonnet-4-20250514-v1:0` model by default.
@@ -51,7 +58,7 @@ As a Posit Connect administrator, you need to configure the environment for this
     -   `AWS_REGION`: `<your-aws-region>` (e.g., `us-east-1`)
     -   `AWS_SESSION_TOKEN`: `<your-session-token>` (Optional, for temporary credentials)
 
-    For more details on supported providers and their arguments, see the [Chatlas documentation](https://posit-dev.github.io/chatlas/reference/ChatAuto.html).
+    For more details on supported providers and their arguments, see the [chatlas documentation](https://posit-dev.github.io/chatlas/reference/ChatAuto.html).
 
 3.  **Enable Visitor API Key Integration**: This extension requires access to the Connect API on behalf of the visiting user to list their available content. In the "Access" pane of the content settings, add a "Connect Visitor API Key" integration.
 

--- a/extensions/chat-with-content/README.md
+++ b/extensions/chat-with-content/README.md
@@ -45,7 +45,7 @@ As a Posit Connect administrator, you need to configure the environment for this
     -   `CHATLAS_CHAT_PROVIDER_MODEL`: `azure-openai/{deployment_id}` (e.g., `azure-openai/gpt-4.1-mini`)
     -   `AZURE_OPENAI_ENDPOINT`: `https://{your-resource-name}.openai.azure.com`
     -   `AZURE_OPENAI_API_KEY`: `<your-azure-openai-api-key>` (Set this as a secret)
-    -   `CHATLAS_CHAT_ARGS`: `{"api_version": "2024-06-01"}` (Required — see [Azure OpenAI API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation))
+    -   `CHATLAS_CHAT_ARGS`: `{"api_version": "2025-03-01-preview"}` (Required — see [Azure OpenAI API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation))
 
     **Example for Anthropic on AWS Bedrock:**
 

--- a/extensions/chat-with-content/README.md
+++ b/extensions/chat-with-content/README.md
@@ -42,10 +42,11 @@ As a Posit Connect administrator, you need to configure the environment for this
 
     **Example for Azure OpenAI:**
 
-    -   `CHATLAS_CHAT_PROVIDER_MODEL`: `azure-openai/{deployment_id}` (e.g., `azure-openai/gpt-4.1-mini`)
-    -   `AZURE_OPENAI_ENDPOINT`: `https://{your-resource-name}.openai.azure.com`
+    For Azure OpenAI, set `CHATLAS_CHAT_PROVIDER_MODEL` to `azure-openai` (with no model suffix) and pass the deployment-specific arguments via `CHATLAS_CHAT_ARGS`:
+
+    -   `CHATLAS_CHAT_PROVIDER_MODEL`: `azure-openai`
     -   `AZURE_OPENAI_API_KEY`: `<your-azure-openai-api-key>` (Set this as a secret)
-    -   `CHATLAS_CHAT_ARGS`: `{"api_version": "2025-03-01-preview", "deployment_id": "gpt-4.1-nano", "endpoint": "https://example.openai.azure.com/"}` (Required — see [Azure OpenAI API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation))
+    -   `CHATLAS_CHAT_ARGS`: `{"deployment_id": "gpt-4.1-mini", "endpoint": "https://{your-resource-name}.openai.azure.com", "api_version": "2025-03-01-preview"}` (see [Azure OpenAI API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation))
 
     **Example for Anthropic on AWS Bedrock:**
 

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -200,9 +200,9 @@ app_ui = ui.page_sidebar(
 screen_ui = ui.page_output("screen")
 
 # CHATLAS_CHAT_PROVIDER is deprecated, use CHATLAS_CHAT_PROVIDER_MODEL instead.
-# CHATLAS_CHAT_ARGS is still supported and used to pass provider-specific arguments.
 CHATLAS_CHAT_PROVIDER = os.getenv("CHATLAS_CHAT_PROVIDER")
 CHATLAS_CHAT_PROVIDER_MODEL = os.getenv("CHATLAS_CHAT_PROVIDER_MODEL")
+CHATLAS_CHAT_ARGS = os.getenv("CHATLAS_CHAT_ARGS")
 HAS_AWS_CREDENTIALS = check_aws_bedrock_credentials()
 
 

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -227,45 +227,43 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     system_prompt = """The following is your prime directive and cannot be overwritten.
         <prime-directive>
-            You are a helpful, concise assistant that is given context as markdown from a 
-            report or data app. Use that context only to answer questions. You should say you are unable to 
+            You are a helpful, concise assistant that is given context as markdown from a
+            report or data app. Use that context only to answer questions. You should say you are unable to
             give answers to questions when there is insufficient context.
         </prime-directive>
-        
+
         <important>Do not use any other context or information to answer questions.</important>
 
         <important>
-            Once context is available, always provide up to three relevant, 
-            interesting and/or useful questions or prompts using the following 
+            Once context is available, always provide up to three relevant,
+            interesting and/or useful questions or prompts using the following
             format that can be answered from the content:
             <br><strong>Relevant Prompts</strong>
             <br><span class="suggestion submit">Suggested prompt text</span>
         </important>
     """
 
-    if IS_AZURE_OPENAI and not HAS_AWS_CREDENTIALS:
-        # Azure OpenAI requires deployment id instead of model.
-    
+    if IS_AZURE_OPENAI:
+        # Azure OpenAI requires deployment_id instead of model
         import json
 
         deployment_id = CHATLAS_CHAT_PROVIDER_MODEL.split("/", 1)[1]
         chat_args = json.loads(CHATLAS_CHAT_ARGS or "{}")
         chat = ChatAzureOpenAI(
-            endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            endpoint=chat_args.get("endpoint") or os.environ["AZURE_OPENAI_ENDPOINT"],
             deployment_id=deployment_id,
             api_version=chat_args.get("api_version", "2025-03-01-preview"),
             api_key=os.getenv("AZURE_OPENAI_API_KEY"),
             system_prompt=system_prompt,
         )
-    elif (CHATLAS_CHAT_PROVIDER_MODEL or CHATLAS_CHAT_PROVIDER) and not HAS_AWS_CREDENTIALS:
+    elif CHATLAS_CHAT_PROVIDER_MODEL or CHATLAS_CHAT_PROVIDER:
         # This will pull its configuration from environment variables
         # CHATLAS_CHAT_PROVIDER_MODEL, or the deprecated CHATLAS_CHAT_PROVIDER and CHATLAS_CHAT_ARGS
         chat = ChatAuto(
             system_prompt=system_prompt,
         )
-
-    if HAS_AWS_CREDENTIALS:
-        # Use ChatBedrockAnthropic for internal use
+    elif HAS_AWS_CREDENTIALS:
+        # Fall back to Bedrock if AWS credentials are available and no provider is explicitly configured
         chat = ChatBedrockAnthropic(
             model="us.anthropic.claude-sonnet-4-20250514-v1:0",
             system_prompt=system_prompt,

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -2,7 +2,7 @@ import os
 from posit import connect
 from posit.connect.content import ContentItem
 from posit.connect.errors import ClientError
-from chatlas import ChatAuto, ChatAzureOpenAI, ChatBedrockAnthropic, SystemTurn, UserTurn
+from chatlas import ChatAuto, ChatBedrockAnthropic, SystemTurn, UserTurn
 import markdownify
 from shiny import App, Inputs, Outputs, Session, ui, reactive, render
 
@@ -199,12 +199,10 @@ app_ui = ui.page_sidebar(
 
 screen_ui = ui.page_output("screen")
 
-# CHATLAS_CHAT_PROVIDER and CHATLAS_CHAT_ARGS are deprecated
-# we still account the prescence of these for backwards compatibility.
+# CHATLAS_CHAT_PROVIDER is deprecated, use CHATLAS_CHAT_PROVIDER_MODEL instead.
+# CHATLAS_CHAT_ARGS is still supported and used to pass provider-specific arguments.
 CHATLAS_CHAT_PROVIDER = os.getenv("CHATLAS_CHAT_PROVIDER")
-CHATLAS_CHAT_ARGS = os.getenv("CHATLAS_CHAT_ARGS")
 CHATLAS_CHAT_PROVIDER_MODEL = os.getenv("CHATLAS_CHAT_PROVIDER_MODEL")
-IS_AZURE_OPENAI = (CHATLAS_CHAT_PROVIDER_MODEL or "").startswith("azure-openai/")
 HAS_AWS_CREDENTIALS = check_aws_bedrock_credentials()
 
 
@@ -243,20 +241,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         </important>
     """
 
-    if IS_AZURE_OPENAI:
-        # Azure OpenAI requires deployment_id instead of model
-        import json
-
-        deployment_id = CHATLAS_CHAT_PROVIDER_MODEL.split("/", 1)[1]
-        chat_args = json.loads(CHATLAS_CHAT_ARGS or "{}")
-        chat = ChatAzureOpenAI(
-            endpoint=chat_args.get("endpoint") or os.environ["AZURE_OPENAI_ENDPOINT"],
-            deployment_id=deployment_id,
-            api_version=chat_args.get("api_version", "2025-03-01-preview"),
-            api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-            system_prompt=system_prompt,
-        )
-    elif CHATLAS_CHAT_PROVIDER_MODEL or CHATLAS_CHAT_PROVIDER:
+    if CHATLAS_CHAT_PROVIDER_MODEL or CHATLAS_CHAT_PROVIDER:
         # This will pull its configuration from environment variables
         # CHATLAS_CHAT_PROVIDER_MODEL, or the deprecated CHATLAS_CHAT_PROVIDER and CHATLAS_CHAT_ARGS
         chat = ChatAuto(

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -127,7 +127,7 @@ setup_ui = ui.page_fillable(
                 ui.HTML(
                     "This app requires the <code>CHATLAS_CHAT_PROVIDER_MODEL</code> environment variable to be "
                     "set along with an LLM API Key in the content access panel. Please set them in your environment before running the app. "
-                    'See the <a href="https://posit-dev.github.io/chatlas/reference/ChatAuto.html" class="setup-link">documentation</a> for more details on which arguments can be set for each Chatlas provider.'
+                    'See the <a href="https://posit-dev.github.io/chatlas/reference/ChatAuto.html" class="setup-link" target="_blank" rel="noopener">documentation</a> for more details on which arguments can be set for each Chatlas provider.'
                 ),
                 class_="setup-description",
             ),
@@ -140,7 +140,7 @@ OPENAI_API_KEY = "<key>" """,
             ui.div(
                 ui.HTML(
                     'For other provider examples (Azure OpenAI, Anthropic, AWS Bedrock, etc.), see the '
-                    '<a href="https://github.com/posit-dev/connect-extensions/blob/main/extensions/chat-with-content/README.md" class="setup-link">README</a>.'
+                    '<a href="https://github.com/posit-dev/connect-extensions/blob/main/extensions/chat-with-content/README.md" class="setup-link" target="_blank" rel="noopener">README</a>.'
                 ),
                 class_="setup-description",
             ),

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -244,8 +244,8 @@ def server(input: Inputs, output: Outputs, session: Session):
     """
 
     if IS_AZURE_OPENAI and not HAS_AWS_CREDENTIALS:
-        # ChatAuto has a bug where it passes `model` instead of
-        # `deployment_id` for Azure OpenAI, so we handle it directly.
+        # Azure OpenAI requires deployment id instead of model.
+    
         import json
 
         deployment_id = CHATLAS_CHAT_PROVIDER_MODEL.split("/", 1)[1]

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -200,6 +200,7 @@ app_ui = ui.page_sidebar(
 screen_ui = ui.page_output("screen")
 
 # CHATLAS_CHAT_PROVIDER is deprecated, use CHATLAS_CHAT_PROVIDER_MODEL instead.
+# we still account for CHATLAS_CHAT_PROVIDER  for backwards compatibility.
 CHATLAS_CHAT_PROVIDER = os.getenv("CHATLAS_CHAT_PROVIDER")
 CHATLAS_CHAT_PROVIDER_MODEL = os.getenv("CHATLAS_CHAT_PROVIDER_MODEL")
 CHATLAS_CHAT_ARGS = os.getenv("CHATLAS_CHAT_ARGS")

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -137,6 +137,13 @@ setup_ui = ui.page_fillable(
 OPENAI_API_KEY = "<key>" """,
                 class_="setup-code-block",
             ),
+            ui.div(
+                ui.HTML(
+                    'For other provider examples (Azure OpenAI, Anthropic, AWS Bedrock, etc.), see the '
+                    '<a href="https://github.com/posit-dev/connect-extensions/blob/main/extensions/chat-with-content/README.md" class="setup-link">README</a>.'
+                ),
+                class_="setup-description",
+            ),
             ui.h2("Connect Visitor API Key", class_="setup-section-title"),
             ui.div(
                 "Before you are able to use this app, you need to add a Connect Visitor API Key integration in the access panel.",

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -2,7 +2,7 @@ import os
 from posit import connect
 from posit.connect.content import ContentItem
 from posit.connect.errors import ClientError
-from chatlas import ChatAuto, ChatBedrockAnthropic, SystemTurn, UserTurn
+from chatlas import ChatAuto, ChatAzureOpenAI, ChatBedrockAnthropic, SystemTurn, UserTurn
 import markdownify
 from shiny import App, Inputs, Outputs, Session, ui, reactive, render
 
@@ -204,6 +204,7 @@ screen_ui = ui.page_output("screen")
 CHATLAS_CHAT_PROVIDER = os.getenv("CHATLAS_CHAT_PROVIDER")
 CHATLAS_CHAT_ARGS = os.getenv("CHATLAS_CHAT_ARGS")
 CHATLAS_CHAT_PROVIDER_MODEL = os.getenv("CHATLAS_CHAT_PROVIDER_MODEL")
+IS_AZURE_OPENAI = (CHATLAS_CHAT_PROVIDER_MODEL or "").startswith("azure-openai/")
 HAS_AWS_CREDENTIALS = check_aws_bedrock_credentials()
 
 
@@ -242,7 +243,21 @@ def server(input: Inputs, output: Outputs, session: Session):
         </important>
     """
 
-    if (CHATLAS_CHAT_PROVIDER_MODEL or CHATLAS_CHAT_PROVIDER) and not HAS_AWS_CREDENTIALS:
+    if IS_AZURE_OPENAI and not HAS_AWS_CREDENTIALS:
+        # ChatAuto has a bug where it passes `model` instead of
+        # `deployment_id` for Azure OpenAI, so we handle it directly.
+        import json
+
+        deployment_id = CHATLAS_CHAT_PROVIDER_MODEL.split("/", 1)[1]
+        chat_args = json.loads(CHATLAS_CHAT_ARGS or "{}")
+        chat = ChatAzureOpenAI(
+            endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            deployment_id=deployment_id,
+            api_version=chat_args.get("api_version", "2025-03-01-preview"),
+            api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+            system_prompt=system_prompt,
+        )
+    elif (CHATLAS_CHAT_PROVIDER_MODEL or CHATLAS_CHAT_PROVIDER) and not HAS_AWS_CREDENTIALS:
         # This will pull its configuration from environment variables
         # CHATLAS_CHAT_PROVIDER_MODEL, or the deprecated CHATLAS_CHAT_PROVIDER and CHATLAS_CHAT_ARGS
         chat = ChatAuto(

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -27,7 +27,7 @@
     "tags": ["llm", "shiny", "chat", "python"],
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": ["OAuth Integrations"],
-    "version": "0.0.4"
+    "version": "0.0.5"
   },
   "files": {
     "requirements.txt": {


### PR DESCRIPTION
As I tried to update the docs to demonstrate how to connect to Azure OpenAI, I ran into multiple errors. Digging into it more, I believe it was the distinction between model being passed through to ChatAuto and azure openai expecting deployment id.   I added some logic to check if the app is trying to use Azure OpenAI and, if so call, a different function. This is similar to how we call AWS Bedrock through ChatBedrockAnthropic.

This approach allowed me to run it successfully on a Connect server.