### PR TITLE
fix: Update package vulnerability scanner to handle breaking PPM change

### DIFF
--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -46,6 +46,10 @@ async def get_vulnerabilities():
             #
             #   url = f"https://your-ppm-instance/__api__/repos/{repo}/vulns"
             #   response = await http.get(url)
+            #   return repo, response.json()
+            #
+            #     for repo, data in await asyncio.gather(*tasks):
+            #   results[repo] = data
             url = "https://packagemanager.posit.co/__api__/filter/packages"
             payload = {
                 "repo": repo,

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -38,6 +38,14 @@ async def get_vulnerabilities():
 
     async def fetch_repo_vulns(repo):
         async with httpx.AsyncClient() as http:
+            # This fetches vulnerabilities from the public Posit Package Manager,
+            # which is always up to date. If customizing this to reference your
+            # own PPM instance, note that the has_vulns parameter requires
+            # PPM 2026.04 or later. Older versions may need to use the vulns
+            # parameter instead, or the legacy endpoint:
+            #
+            #   url = f"https://your-ppm-instance/__api__/repos/{repo}/vulns"
+            #   response = await http.get(url)
             url = "https://packagemanager.posit.co/__api__/filter/packages"
             payload = {
                 "repo": repo,

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -1,3 +1,7 @@
+import asyncio
+import json
+
+import httpx
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from posit import connect
@@ -6,11 +10,13 @@ app = FastAPI()
 
 client = connect.Client()
 
+
 @app.get("/api/content")
 async def search_content(show_all: bool = False):
     if show_all:
         return client.content.find()
     return client.me.content.find()
+
 
 @app.get("/api/packages/{guid}")
 async def get_packages(guid: str):
@@ -19,60 +25,43 @@ async def get_packages(guid: str):
         packages = list(content.packages)
         return packages
     except Exception as e:
-        raise HTTPException(status_code=404, detail=f"Content not found or error fetching packages: {str(e)}")
-    
+        raise HTTPException(
+            status_code=404,
+            detail=f"Content not found or error fetching packages: {str(e)}",
+        )
+
+
 @app.get("/api/vulns")
 async def get_vulnerabilities():
-    import httpx
-    import asyncio
-    
     repositories = ["pypi", "cran"]
     results = {}
-    
+
     async def fetch_repo_vulns(repo):
-        import json
-        async with httpx.AsyncClient() as client:
-            # Use POST request with /filter/packages endpoint
-            url = f"https://packagemanager.posit.co/__api__/filter/packages"
+        async with httpx.AsyncClient() as http:
+            url = "https://packagemanager.posit.co/__api__/filter/packages"
             payload = {
                 "repo": repo,
                 "has_vulns": True,
                 "omit_downloads": True,
-                "omit_dependencies": True
+                "omit_dependencies": True,
             }
-            response = await client.post(url, json=payload)
+            response = await http.post(url, json=payload)
             response.raise_for_status()
-            # API returns newline-delimited JSON (NDJSON), parse each line
-            packages = []
-            for line in response.text.strip().split('\n'):
-                if line:
-                    packages.append(json.loads(line))
+            packages = [
+                json.loads(line) for line in response.text.strip().split("\n") if line
+            ]
             return repo, packages
-    
+
     tasks = [fetch_repo_vulns(repo) for repo in repositories]
-    all_results = await asyncio.gather(*tasks)
-    
-    for repo, data in all_results:
-        # Transform package results into vulnerability map
-        vuln_map = {}
-        packages = data if isinstance(data, list) else []
-
-        # Extract vulnerability data from packages
-        # Use 'project_name' as key, lowercased to match installed package names
-        # (Connect returns lowercase names like 'beaker', but API has 'Beaker')
-        for pkg in packages:
-            if isinstance(pkg, dict):
-                pkg_name = (pkg.get('project_name') or pkg.get('name', 'unknown')).lower()
-                vulns = pkg.get('vulns') or []
-                if vulns:
-                    vuln_map[pkg_name] = vulns
-
-        results[repo] = vuln_map
+    for repo, packages in await asyncio.gather(*tasks):
+        results[repo] = {pkg["name"]: pkg["vulns"] for pkg in packages}
 
     return results
+
 
 @app.get("/api/user")
 async def get_current_user():
     return client.me
+
 
 app.mount("/", StaticFiles(directory="dist", html=True), name="static")

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -48,8 +48,9 @@ async def get_vulnerabilities():
             #   response = await http.get(url)
             #   return repo, response.json()
             #
-            #     for repo, data in await asyncio.gather(*tasks):
-            #   results[repo] = data
+            #   tasks = [fetch_repo_vulns(repo) for repo in repositories]
+            #   for repo, data in await asyncio.gather(*tasks):
+            #     results[repo] = data
             url = "https://packagemanager.posit.co/__api__/filter/packages"
             payload = {
                 "repo": repo,

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -44,9 +44,9 @@ async def get_vulnerabilities():
             # PPM 2026.04 or later. Older versions may need to use the vulns
             # parameter instead, or the legacy endpoint:
             #
-            #   url = f"https://your-ppm-instance/__api__/repos/{repo}/vulns"
-            #   response = await http.get(url)
-            #   return repo, response.json()
+            #     url = f"https://your-ppm-instance/__api__/repos/{repo}/vulns"
+            #     response = await http.get(url)
+            #     return repo, response.json()
             #
             #   tasks = [fetch_repo_vulns(repo) for repo in repositories]
             #   for repo, data in await asyncio.gather(*tasks):

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -30,6 +30,7 @@ async def get_vulnerabilities():
     results = {}
     
     async def fetch_repo_vulns(repo):
+        import json
         async with httpx.AsyncClient() as client:
             # Use POST request with /filter/packages endpoint
             url = f"https://packagemanager.posit.co/__api__/filter/packages"
@@ -41,33 +42,33 @@ async def get_vulnerabilities():
             }
             response = await client.post(url, json=payload)
             response.raise_for_status()
-            return repo, response.json()
+            # API returns newline-delimited JSON (NDJSON), parse each line
+            packages = []
+            for line in response.text.strip().split('\n'):
+                if line:
+                    packages.append(json.loads(line))
+            return repo, packages
     
     tasks = [fetch_repo_vulns(repo) for repo in repositories]
     all_results = await asyncio.gather(*tasks)
     
     for repo, data in all_results:
         # Transform package results into vulnerability map
-        # The /filter/packages endpoint returns packages, each potentially with vulns array
         vuln_map = {}
-        
-        # Handle array of packages
-        if isinstance(data, list):
-            packages = data
-        # Handle object with packages nested inside
-        elif isinstance(data, dict):
-            packages = data if len(data) <= 1 and any(k in data for k in ['vulns', 'name']) else [data]
-        else:
-            packages = []
-        
+        packages = data if isinstance(data, list) else []
+
         # Extract vulnerability data from packages
+        # Use 'project_name' as key, lowercased to match installed package names
+        # (Connect returns lowercase names like 'beaker', but API has 'Beaker')
         for pkg in packages:
-            if isinstance(pkg, dict) and pkg.get('vulns'):
-                pkg_name = pkg.get('name', 'unknown')
-                vuln_map[pkg_name] = pkg['vulns']
-        
+            if isinstance(pkg, dict):
+                pkg_name = (pkg.get('project_name') or pkg.get('name', 'unknown')).lower()
+                vulns = pkg.get('vulns') or []
+                if vulns:
+                    vuln_map[pkg_name] = vulns
+
         results[repo] = vuln_map
-        
+
     return results
 
 @app.get("/api/user")

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -31,14 +31,42 @@ async def get_vulnerabilities():
     
     async def fetch_repo_vulns(repo):
         async with httpx.AsyncClient() as client:
-            url = f"https://packagemanager.posit.co/__api__/repos/{repo}/vulns"
-            response = await client.get(url)
+            # Use POST request with /filter/packages endpoint
+            url = f"https://packagemanager.posit.co/__api__/filter/packages"
+            payload = {
+                "repo": repo,
+                "has_vulns": True,
+                "omit_downloads": True,
+                "omit_dependencies": True
+            }
+            response = await client.post(url, json=payload)
             response.raise_for_status()
             return repo, response.json()
     
     tasks = [fetch_repo_vulns(repo) for repo in repositories]
-    for repo, data in await asyncio.gather(*tasks):
-        results[repo] = data
+    all_results = await asyncio.gather(*tasks)
+    
+    for repo, data in all_results:
+        # Transform package results into vulnerability map
+        # The /filter/packages endpoint returns packages, each potentially with vulns array
+        vuln_map = {}
+        
+        # Handle array of packages
+        if isinstance(data, list):
+            packages = data
+        # Handle object with packages nested inside
+        elif isinstance(data, dict):
+            packages = data if len(data) <= 1 and any(k in data for k in ['vulns', 'name']) else [data]
+        else:
+            packages = []
+        
+        # Extract vulnerability data from packages
+        for pkg in packages:
+            if isinstance(pkg, dict) and pkg.get('vulns'):
+                pkg_name = pkg.get('name', 'unknown')
+                vuln_map[pkg_name] = pkg['vulns']
+        
+        results[repo] = vuln_map
         
     return results
 

--- a/extensions/package-vulnerability-scanner/package-lock.json
+++ b/extensions/package-vulnerability-scanner/package-lock.json
@@ -1937,6 +1937,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2116,7 +2117,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -2153,6 +2155,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2179,6 +2182,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2260,6 +2264,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
       "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/compiler-sfc": "3.5.27",


### PR DESCRIPTION
We handle the new PPM endpoint in the Package vulnerability scanner after `/repos/{repo}/vulns` was removed in favor of `/filter/packages`. 

https://packagemanager.posit.co/__docs__/news/package-manager/#breaking

To test this, deploy an app that imports one of the vulnerable packages, such as [`beaker`](https://packagemanager.posit.co/client/#/repos/pypi/packages/beaker/overview). The new scanner will display the vulnerability.

(Note that when deploying with Publisher, you will need to build the frontend with `npm run build` and include `dist/` in the bundle.)

You should see: 
<img width="879" height="603" alt="image" src="https://github.com/user-attachments/assets/533ed150-eea4-4458-b0e5-d5e1be2ae413" />

closes #334 