### PR TITLE
Upgrade Vite to 8.0.x in publisher-command-center

### DIFF
--- a/extensions/publisher-command-center/CONTRIBUTING.md
+++ b/extensions/publisher-command-center/CONTRIBUTING.md
@@ -47,7 +47,6 @@ Start the watcher to enable continuous rebuilds of the frontend:
 npm run watch
 ```
 
-
 ### Building for Production
 
 To build the frontend for production:

--- a/extensions/publisher-command-center/README.md
+++ b/extensions/publisher-command-center/README.md
@@ -12,4 +12,3 @@ integration.
 
 If you don't see one in the list, an administrator must enable this feature on your Connect server.
 See the [Admin Guide](https://docs.posit.co/connect/admin/integrations/oauth-integrations/connect/) for setup instructions.
-

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -27,7 +27,7 @@
     "API Publishing",
     "OAuth Integrations"
   ],
-  "version": "0.0.5"
+  "version": "0.0.6"
   },
   "files": {
     "requirements.txt": {

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -18,16 +18,13 @@
     }
   },
   "extension": {
-  "name": "publisher-command-center",
-  "title": "Publisher Command Center",
-  "description": "An app that helps publishers view and manage details about apps and dashboards deployed to Connect. View app metadata and history for all of the apps you are collaborating on as well as see and managing running process for individual apps.",
-  "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/publisher-command-center",
-  "minimumConnectVersion": "2025.04.0",
-  "requiredFeatures": [
-    "API Publishing",
-    "OAuth Integrations"
-  ],
-  "version": "0.0.6"
+    "name": "publisher-command-center",
+    "title": "Publisher Command Center",
+    "description": "An app that helps publishers view and manage details about apps and dashboards deployed to Connect. View app metadata and history for all of the apps you are collaborating on as well as see and managing running process for individual apps.",
+    "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/publisher-command-center",
+    "minimumConnectVersion": "2025.04.0",
+    "requiredFeatures": ["API Publishing", "OAuth Integrations"],
+    "version": "0.0.6"
   },
   "files": {
     "requirements.txt": {

--- a/extensions/publisher-command-center/package-lock.json
+++ b/extensions/publisher-command-center/package-lock.json
@@ -20,24 +20,41 @@
       "devDependencies": {
         "prettier": "3.4.2",
         "sass": "^1.83.4",
-        "vite": "^2.6.2"
+        "vite": "^8.0.8"
       }
     },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
-      "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
-      "cpu": [
-        "loong64"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
@@ -80,6 +97,35 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -402,6 +448,299 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/bootstrap": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
@@ -475,383 +814,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
-      "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/linux-loong64": "0.14.54",
-        "esbuild-android-64": "0.14.54",
-        "esbuild-android-arm64": "0.14.54",
-        "esbuild-darwin-64": "0.14.54",
-        "esbuild-darwin-arm64": "0.14.54",
-        "esbuild-freebsd-64": "0.14.54",
-        "esbuild-freebsd-arm64": "0.14.54",
-        "esbuild-linux-32": "0.14.54",
-        "esbuild-linux-64": "0.14.54",
-        "esbuild-linux-arm": "0.14.54",
-        "esbuild-linux-arm64": "0.14.54",
-        "esbuild-linux-mips64le": "0.14.54",
-        "esbuild-linux-ppc64le": "0.14.54",
-        "esbuild-linux-riscv64": "0.14.54",
-        "esbuild-linux-s390x": "0.14.54",
-        "esbuild-netbsd-64": "0.14.54",
-        "esbuild-openbsd-64": "0.14.54",
-        "esbuild-sunos-64": "0.14.54",
-        "esbuild-windows-32": "0.14.54",
-        "esbuild-windows-64": "0.14.54",
-        "esbuild-windows-arm64": "0.14.54"
-      }
-    },
-    "node_modules/esbuild-android-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
-      "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-android-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
-      "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-darwin-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
-      "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
-      "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
-      "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
-      "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-32": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
-      "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
-      "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-arm": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
-      "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
-      "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
-      "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
-      "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
-      "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
-      "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
-      "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
-      "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-sunos-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
-      "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-32": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
-      "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
-      "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
-      "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/filesize": {
       "version": "10.1.6",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.6.tgz",
@@ -890,51 +852,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/immutable": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
       "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -972,6 +895,289 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -994,9 +1200,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -1020,13 +1226,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1049,9 +1248,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "dev": true,
       "funding": [
         {
@@ -1069,7 +1268,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1107,41 +1306,38 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
       },
       "bin": {
-        "resolve": "bin/resolve"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/rollup": {
-      "version": "2.77.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
-      "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/sass": {
@@ -1175,17 +1371,52 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
@@ -1202,42 +1433,103 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/vite": {
-      "version": "2.9.18",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.18.tgz",
-      "integrity": "sha512-sAOqI5wNM9QvSEE70W3UGMdT8cyEn0+PmJMTFvTB8wB0YbYUWw3gUbY62AOyrXosGieF2htmeLATvNxpv/zNyQ==",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.14.27",
-        "postcss": "^8.4.13",
-        "resolve": "^1.22.0",
-        "rollup": ">=2.59.0 <2.78.0"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": ">=12.2.0"
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2"
+        "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "less": "*",
-        "sass": "*",
-        "stylus": "*"
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
         "less": {
           "optional": true
         },
         "sass": {
           "optional": true
         },
+        "sass-embedded": {
+          "optional": true
+        },
         "stylus": {
           "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     }
   }

--- a/extensions/publisher-command-center/package.json
+++ b/extensions/publisher-command-center/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "prettier": "3.4.2",
     "sass": "^1.83.4",
-    "vite": "^2.6.2"
+    "vite": "^8.0.8"
   }
 }

--- a/extensions/publisher-command-center/src/components/Collaborators.js
+++ b/extensions/publisher-command-center/src/components/Collaborators.js
@@ -5,7 +5,9 @@ import Content from "../models/Content";
 export default {
   view: function () {
     const content = Content.data;
-    const accessUrl = content?.dashboard_url ? `${content.dashboard_url}/access` : "#";
+    const accessUrl = content?.dashboard_url
+      ? `${content.dashboard_url}/access`
+      : "#";
 
     return m(".pt-3.border-top", [
       m(".", [
@@ -15,8 +17,12 @@ export default {
           m("small.text-body-secondary.align-items-center", [
             m(".fa-solid.fa-user-lock"),
             " ",
-            m("a", { href: accessUrl, target: "_blank" }, "See Collaborators and Manage Access"),
-          ])
+            m(
+              "a",
+              { href: accessUrl, target: "_blank" },
+              "See Collaborators and Manage Access",
+            ),
+          ]),
         ),
       ]),
     ]);

--- a/extensions/publisher-command-center/src/components/ContentsComponent.js
+++ b/extensions/publisher-command-center/src/components/ContentsComponent.js
@@ -18,7 +18,7 @@ const ContentsComponent = {
     }
   },
 
-  view: () => {
+  view: function () {
     if (this.error) {
       return m("div", { class: "error" }, this.error);
     }

--- a/extensions/publisher-command-center/src/components/ContentsComponent.js
+++ b/extensions/publisher-command-center/src/components/ContentsComponent.js
@@ -54,80 +54,78 @@ const ContentsComponent = {
         Contents.data.map((content) => {
           const guid = content["guid"];
           const title = content["title"];
-          return m(
-            "tr",
-            [
+          return m("tr", [
+            m(
+              "td",
+              {
+                class: "link-primary content-page-link",
+                onclick: () => m.route.set(`/contents/${guid}`),
+              },
+              title || m("i", "No Name"),
+            ),
+            m("td", m(Languages, content)),
+            m("td", content?.active_jobs?.length),
+            m("td", format(content["last_deployed_time"], "MMM do, yyyy")),
+            m("td", format(content["created_time"], "MMM do, yyyy")),
+            m(
+              "td",
               m(
-                "td",
-                  {
-                    class: "link-primary content-page-link",
-                    onclick: () => m.route.set(`/contents/${guid}`),
-                  },
-                  title || m("i", "No Name"),
-              ),
-              m(
-                "td",
-                m(Languages, content)
-              ),
-              m("td", content?.active_jobs?.length),
-              m("td", format(content["last_deployed_time"], "MMM do, yyyy")),
-              m("td", format(content["created_time"], "MMM do, yyyy")),
-              m(
-                "td",
-                m("button", {
+                "button",
+                {
                   class: "action-btn",
                   ariaLabel: `Rename ${title}`,
                   title: `Rename ${title}`,
                   "data-bs-toggle": "modal",
                   "data-bs-target": `#renameModal-${guid}`,
-                }, [
-                  m("i", { class: "fa-solid fa-pencil" })
-                ]),
+                },
+                [m("i", { class: "fa-solid fa-pencil" })],
               ),
+            ),
+            m(
+              "td",
+              m(LockContentButton, {
+                contentId: guid,
+                contentTitle: title,
+                isLocked: content["locked"],
+              }),
+            ),
+            m(
+              "td",
               m(
-                "td",
-                m(LockContentButton, {
-                  contentId: guid,
-                  contentTitle: title,
-                  isLocked: content["locked"],
-                }),
-              ),
-              m(
-                "td",
-                m("button", {
+                "button",
+                {
                   class: "action-btn",
                   title: `Delete ${title}`,
                   ariaLabel: `Delete ${title}`,
                   "data-bs-toggle": "modal",
                   "data-bs-target": `#deleteModal-${guid}`,
-                }, [
-                  m("i", { class: "fa-solid fa-trash" })
-                ]),
+                },
+                [m("i", { class: "fa-solid fa-trash" })],
               ),
-              m(
-                "td",
-                m("a", {
-                  class: "fa-solid fa-arrow-up-right-from-square",
-                  href: content["content_url"],
-                  ariaLabel: `Open ${title} (opens in new tab)`,
-                  title: `Open ${title}`,
-                  target: "_blank",
-                  onclick: (e) => e.stopPropagation(),
-                }),
-              ),
-              m(DeleteModal, {
-                contentId: guid,
-                contentTitle: title,
+            ),
+            m(
+              "td",
+              m("a", {
+                class: "fa-solid fa-arrow-up-right-from-square",
+                href: content["content_url"],
+                ariaLabel: `Open ${title} (opens in new tab)`,
+                title: `Open ${title}`,
+                target: "_blank",
+                onclick: (e) => e.stopPropagation(),
               }),
-              m(RenameModal, {
-                contentId: guid,
-                contentTitle: title,
-              }),
-            ],
-          );
+            ),
+            m(DeleteModal, {
+              contentId: guid,
+              contentTitle: title,
+            }),
+            m(RenameModal, {
+              contentId: guid,
+              contentTitle: title,
+            }),
+          ]);
         }),
       ),
-    )
+    );
   },
 };
 

--- a/extensions/publisher-command-center/src/components/DeleteModal.js
+++ b/extensions/publisher-command-center/src/components/DeleteModal.js
@@ -14,7 +14,7 @@ const ConfirmDeleteButton = {
         },
       },
       "Yes",
-    )
+    );
   },
 };
 
@@ -28,36 +28,49 @@ const CancelDeleteButton = {
         "data-bs-dismiss": "modal",
       },
       "No",
-    )
+    );
   },
 };
 
 const DeleteModal = {
-  view: function(vnode) {
-    return m("div", { class: "modal", id: `deleteModal-${vnode.attrs.contentId}`, tabindex: "-1", ariaHidden: true }, [
-      m("div", { class: "modal-dialog modal-dialog-centered" }, [
-        m("div", { class: "modal-content" }, [
-          m("div", { class: "modal-header"}, [
-            m("h1", { class: "modal-title fs-6" }, "Delete Content"),
-            m("button", {
-              class: "btn-close",
-              ariaLabel: "Close modal",
-              "data-bs-dismiss": "modal"
-            }),
+  view: function (vnode) {
+    return m(
+      "div",
+      {
+        class: "modal",
+        id: `deleteModal-${vnode.attrs.contentId}`,
+        tabindex: "-1",
+        ariaHidden: true,
+      },
+      [
+        m("div", { class: "modal-dialog modal-dialog-centered" }, [
+          m("div", { class: "modal-content" }, [
+            m("div", { class: "modal-header" }, [
+              m("h1", { class: "modal-title fs-6" }, "Delete Content"),
+              m("button", {
+                class: "btn-close",
+                ariaLabel: "Close modal",
+                "data-bs-dismiss": "modal",
+              }),
+            ]),
+            m("section", { class: "modal-body" }, [
+              m(
+                "p",
+                {
+                  id: "modal-message",
+                  class: "mb-3",
+                },
+                `Are you sure you want to delete ${vnode.attrs.contentTitle}?`,
+              ),
+            ]),
+            m("div", { class: "modal-footer" }, [
+              m(CancelDeleteButton),
+              m(ConfirmDeleteButton, { contentId: vnode.attrs.contentId }),
+            ]),
           ]),
-          m("section", { class: "modal-body" }, [
-            m("p", {
-              id: "modal-message",
-              class: "mb-3",
-            }, `Are you sure you want to delete ${vnode.attrs.contentTitle}?`)
-          ]),
-          m("div", { class: "modal-footer" }, [
-            m(CancelDeleteButton),
-            m(ConfirmDeleteButton, { contentId: vnode.attrs.contentId }),
-          ]), 
         ]),
-      ]),
-    ])
+      ],
+    );
   },
 };
 

--- a/extensions/publisher-command-center/src/components/Languages.js
+++ b/extensions/publisher-command-center/src/components/Languages.js
@@ -38,16 +38,16 @@ const getLanguages = (content) => {
 
   switch (content?.content_category) {
     case "plot":
-      languages.add("Static")
+      languages.add("Static");
       languages.add("Plot");
       break;
     case "pin":
       languages.add("Static");
-      languages.add("Pin")
+      languages.add("Pin");
       break;
     case "rmd-static":
-      languages.add("Static")
-      languages.add("Site")
+      languages.add("Static");
+      languages.add("Site");
       break;
     default:
       break;

--- a/extensions/publisher-command-center/src/components/LockContentButton.js
+++ b/extensions/publisher-command-center/src/components/LockContentButton.js
@@ -6,10 +6,10 @@ const LockedContentButton = {
     this.isLoading = false;
   },
 
-  view: function(vnode) {
-    const labelMessage = vnode.attrs.isLocked ?
-       `Unlock ${vnode.attrs.contentTitle}` :
-       `Lock Content ${vnode.attrs.contentTitle}`;
+  view: function (vnode) {
+    const labelMessage = vnode.attrs.isLocked
+      ? `Unlock ${vnode.attrs.contentTitle}`
+      : `Lock Content ${vnode.attrs.contentTitle}`;
 
     const iconClassName = () => {
       if (this.isLoading) return "fa-spinner fa-spin lock-loading";
@@ -21,32 +21,36 @@ const LockedContentButton = {
       }
     };
 
-    return m("button", {
-      class: "action-btn",
-      ariaLabel: labelMessage,
-      title: labelMessage,
-      disabled: this.isLoading,
-      onclick: async () => {
-        if (this.isLoading) { return; }
+    return m(
+      "button",
+      {
+        class: "action-btn",
+        ariaLabel: labelMessage,
+        title: labelMessage,
+        disabled: this.isLoading,
+        onclick: async () => {
+          if (this.isLoading) {
+            return;
+          }
 
-        this.isLoading = true;
-        m.redraw();
-
-        try {
-          await Contents.lock(vnode.attrs.contentId)
-        } finally {
-          this.isLoading = false;
+          this.isLoading = true;
           m.redraw();
-        }
-      }
-    }, [
-      m("i", {
-        class: `fa-solid ${iconClassName()}`,
 
-        }
-      )
-    ])
-  }
+          try {
+            await Contents.lock(vnode.attrs.contentId);
+          } finally {
+            this.isLoading = false;
+            m.redraw();
+          }
+        },
+      },
+      [
+        m("i", {
+          class: `fa-solid ${iconClassName()}`,
+        }),
+      ],
+    );
+  },
 };
 
 export default LockedContentButton;

--- a/extensions/publisher-command-center/src/components/Metrics.js
+++ b/extensions/publisher-command-center/src/components/Metrics.js
@@ -3,47 +3,49 @@ import Metrics from "../models/Metrics";
 
 const TimeseriesChart = {
   oncreate: function (vnode) {
-      // Initialize the chart when the component is created
-      const ctx = vnode.dom.getContext('2d');
-      const labels = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'];
-      const data = [10, 20, 15, 25, 30, 20];
+    // Initialize the chart when the component is created
+    const ctx = vnode.dom.getContext("2d");
+    const labels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun"];
+    const data = [10, 20, 15, 25, 30, 20];
 
-      new Chart(ctx, {
-          type: 'line',
-          data: {
-              labels: labels,
-              datasets: [{
-                  label: 'Views',
-                  data: data,
-                  borderColor: 'rgba(75, 192, 192, 1)',
-                  backgroundColor: 'rgba(75, 192, 192, 0.2)',
-                  tension: 0.4 // Smooth line
-              }]
+    new Chart(ctx, {
+      type: "line",
+      data: {
+        labels: labels,
+        datasets: [
+          {
+            label: "Views",
+            data: data,
+            borderColor: "rgba(75, 192, 192, 1)",
+            backgroundColor: "rgba(75, 192, 192, 0.2)",
+            tension: 0.4, // Smooth line
           },
-          options: {
-              responsive: true,
-              maintainAspectRatio: false,
-              scales: {
-                  x: {
-                      title: {
-                          display: true,
-                          text: 'Month'
-                      }
-                  },
-                  y: {
-                      title: {
-                          display: true,
-                          text: 'Value'
-                      },
-                      beginAtZero: true
-                  }
-              }
-          }
-      });
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          x: {
+            title: {
+              display: true,
+              text: "Month",
+            },
+          },
+          y: {
+            title: {
+              display: true,
+              text: "Value",
+            },
+            beginAtZero: true,
+          },
+        },
+      },
+    });
   },
   view: function () {
-      return m('canvas', { style: 'width: 100%; height: 400px;' });
-  }
+    return m("canvas", { style: "width: 100%; height: 400px;" });
+  },
 };
 
 export default {
@@ -68,13 +70,12 @@ export default {
       return;
     }
 
-    const start = Math.min(...metrics.map(metric => new Date(metric?.started)))
-    const ended = Math.max(...metrics.map(metric => new Date(metric?.ended)))
-    console.log(start, ended)
+    const start = Math.min(
+      ...metrics.map((metric) => new Date(metric?.started)),
+    );
+    const ended = Math.max(...metrics.map((metric) => new Date(metric?.ended)));
+    console.log(start, ended);
 
-    return m(".pt-3.border-top", [
-      m("h5", "Metrics"),
-      m(TimeseriesChart),
-    ]);
+    return m(".pt-3.border-top", [m("h5", "Metrics"), m(TimeseriesChart)]);
   },
 };

--- a/extensions/publisher-command-center/src/components/Processes.js
+++ b/extensions/publisher-command-center/src/components/Processes.js
@@ -25,10 +25,7 @@ const StopButton = {
           m.redraw();
 
           console.log(`Stopping process ${vnode.attrs.process_id}`);
-          Processes.destroy(
-            vnode.attrs.content_id,
-            vnode.attrs.process_id
-          )
+          Processes.destroy(vnode.attrs.content_id, vnode.attrs.process_id)
             .then(() => {
               console.log(`Stopped process ${vnode.attrs.process_id}`);
               Processes.reset();
@@ -57,12 +54,11 @@ const StopButton = {
         `i.${vnode.state.isHovered ? "fa-solid" : "fa-regular"}.fa-circle-stop`,
         {
           style: "font-size: 1.2rem;",
-        }
-      )
+        },
+      ),
     );
   },
 };
-
 
 export default {
   error: null,
@@ -89,8 +85,11 @@ export default {
     if (processes === null || processes.length === 0) {
       return m(".pt-3.border-top", [
         m("h5", "Processes"),
-        m("p.text-dark", "There are no server processes running at this time...")
-      ])
+        m(
+          "p.text-dark",
+          "There are no server processes running at this time...",
+        ),
+      ]);
     }
 
     return m(".pt-3.border-top", [

--- a/extensions/publisher-command-center/src/components/RenameModal.js
+++ b/extensions/publisher-command-center/src/components/RenameModal.js
@@ -6,33 +6,42 @@ const RenameModalForm = {
   newName: "",
   guid: "",
   isValid: false,
-  onsubmit: function(e) {
+  onsubmit: function (e) {
     if (RenameModalForm.isValid) {
-      e.preventDefault();  
+      e.preventDefault();
       Contents.rename(RenameModalForm.guid, RenameModalForm.newName);
 
-      const modalEl = document.getElementById(`renameModal-${RenameModalForm.guid}`);
+      const modalEl = document.getElementById(
+        `renameModal-${RenameModalForm.guid}`,
+      );
       const modal = Modal.getInstance(modalEl);
       modal.hide();
 
       RenameModalForm.newName = "";
     }
   },
-  view: function(vnode) {
-    return m("form", {
-        onsubmit: (e) => { this.onsubmit(e); }
+  view: function (vnode) {
+    return m(
+      "form",
+      {
+        onsubmit: (e) => {
+          this.onsubmit(e);
+        },
       },
       [
         m("section", { class: "modal-body" }, [
           m("div", { class: "form-group" }, [
-            m("label", {
-              for: "rename-content-input",
-              class: "mb-3",
-            }, "Enter new name for ", [
-              m("span", { class: "fw-bold" }, `${vnode.attrs.contentTitle}`)
-            ]),
+            m(
+              "label",
+              {
+                for: "rename-content-input",
+                class: "mb-3",
+              },
+              "Enter new name for ",
+              [m("span", { class: "fw-bold" }, `${vnode.attrs.contentTitle}`)],
+            ),
             m("input", {
-              oninput: function(e) {
+              oninput: function (e) {
                 RenameModalForm.isValid = e.target.validity.valid;
                 RenameModalForm.guid = vnode.attrs.contentId;
                 RenameModalForm.newName = e.target.value;
@@ -45,48 +54,53 @@ const RenameModalForm = {
               maxlength: 1024,
               value: RenameModalForm.newName,
             }),
-          ])
+          ]),
         ]),
-      m("div", { class: "modal-footer" }, [
-        m(
-          "button",
-          {
-            type: "submit",
-            class: "btn btn-primary",
-            ariaLabel: "Rename Content",
-          },
-          "Rename Content",
-        ),
-      ]), 
-    ])
+        m("div", { class: "modal-footer" }, [
+          m(
+            "button",
+            {
+              type: "submit",
+              class: "btn btn-primary",
+              ariaLabel: "Rename Content",
+            },
+            "Rename Content",
+          ),
+        ]),
+      ],
+    );
   },
-}
+};
 
 const RenameModal = {
-  view: function(vnode) {
-    return m("div", {
+  view: function (vnode) {
+    return m(
+      "div",
+      {
         class: "modal",
         id: `renameModal-${vnode.attrs.contentId}`,
         tabindex: "-1",
-        ariaHidden: true
-      }, [
-      m("div", { class: "modal-dialog modal-dialog-centered" }, [
-        m("div", { class: "modal-content" }, [
-          m("div", { class: "modal-header"}, [
-            m("h1", { class: "modal-title fs-6" }, "Rename Content"),
-            m("button", {
-              class: "btn-close",
-              ariaLabel: "Close modal",
-              "data-bs-dismiss": "modal"
+        ariaHidden: true,
+      },
+      [
+        m("div", { class: "modal-dialog modal-dialog-centered" }, [
+          m("div", { class: "modal-content" }, [
+            m("div", { class: "modal-header" }, [
+              m("h1", { class: "modal-title fs-6" }, "Rename Content"),
+              m("button", {
+                class: "btn-close",
+                ariaLabel: "Close modal",
+                "data-bs-dismiss": "modal",
+              }),
+            ]),
+            m(RenameModalForm, {
+              contentTitle: vnode.attrs.contentTitle,
+              contentId: vnode.attrs.contentId,
             }),
           ]),
-          m(RenameModalForm, {
-            contentTitle: vnode.attrs.contentTitle,
-            contentId: vnode.attrs.contentId,
-          })
         ]),
-      ]),
-    ])
+      ],
+    );
   },
 };
 

--- a/extensions/publisher-command-center/src/components/UnauthorizedView.js
+++ b/extensions/publisher-command-center/src/components/UnauthorizedView.js
@@ -7,12 +7,12 @@ const UnauthorizedView = {
 
     // Check for available integration
     m.request({ method: "GET", url: "api/integrations" })
-      .then(response => {
+      .then((response) => {
         vnode.state.integration = response;
         vnode.state.loading = false;
         m.redraw();
       })
-      .catch(err => {
+      .catch((err) => {
         console.error("Failed to fetch integrations", err);
         vnode.state.loading = false;
         m.redraw();
@@ -25,13 +25,13 @@ const UnauthorizedView = {
     m.request({
       method: "PUT",
       url: "api/visitor-auth",
-      body: { integration_guid: vnode.state.integration.guid }
+      body: { integration_guid: vnode.state.integration.guid },
     })
       .then(() => {
         // Reload the top-most window to check authorization again
         window.top.location.reload();
       })
-      .catch(err => {
+      .catch((err) => {
         console.error("Failed to add integration", err);
       });
   },
@@ -39,92 +39,130 @@ const UnauthorizedView = {
   view: function (vnode) {
     // Show loading state
     if (vnode.state.loading) {
-      return m("div.d-flex.justify-content-center", { style: { margin: "3rem" } }, [
-        m("div.spinner-border.text-primary", { role: "status" },
-          m("span.visually-hidden", "Loading...")
-        )
-      ]);
+      return m(
+        "div.d-flex.justify-content-center",
+        { style: { margin: "3rem" } },
+        [
+          m(
+            "div.spinner-border.text-primary",
+            { role: "status" },
+            m("span.visually-hidden", "Loading..."),
+          ),
+        ],
+      );
     }
 
     // We have an integration ready to add
     if (vnode.state.integration) {
-      return m("div.alert.alert-info", {
-        style: {
-          margin: "1rem auto",
-          maxWidth: "640px",
-          width: "calc(100% - 2rem)"
-        }
-      }, [
-        m("div", { style: { marginBottom: "1rem" } }, [
-          m("p", [
-            "This content uses a ",
-            m("strong", "Visitor API Key"),
-            " integration to show users the content they have access to.",
-            " A compatible integration is already available; use it below."
+      return m(
+        "div.alert.alert-info",
+        {
+          style: {
+            margin: "1rem auto",
+            maxWidth: "640px",
+            width: "calc(100% - 2rem)",
+          },
+        },
+        [
+          m("div", { style: { marginBottom: "1rem" } }, [
+            m("p", [
+              "This content uses a ",
+              m("strong", "Visitor API Key"),
+              " integration to show users the content they have access to.",
+              " A compatible integration is already available; use it below.",
+            ]),
+            m("p", [
+              "For more information, see ",
+              m(
+                "a",
+                {
+                  href: "https://docs.posit.co/connect/user/oauth-integrations/#obtaining-a-visitor-api-key",
+                  target: "_blank",
+                },
+                "documentation on Visitor API Key integrations",
+              ),
+            ]),
           ]),
-          m("p", [
-            "For more information, see ",
-            m("a", {
-              href: "https://docs.posit.co/connect/user/oauth-integrations/#obtaining-a-visitor-api-key",
-              target: "_blank"
-            }, "documentation on Visitor API Key integrations")
-          ])
-        ]),
-        m("button.btn.btn-primary", {
-          onclick: () => this.addIntegration(vnode)
-        }, [
-          m("i.fas.fa-plus.me-2"),
-          "Use the ",
-          m("strong", vnode.state.integration.title || vnode.state.integration.name || "Connect API"),
-          " Integration"
-        ])
-      ]);
+          m(
+            "button.btn.btn-primary",
+            {
+              onclick: () => this.addIntegration(vnode),
+            },
+            [
+              m("i.fas.fa-plus.me-2"),
+              "Use the ",
+              m(
+                "strong",
+                vnode.state.integration.title ||
+                  vnode.state.integration.name ||
+                  "Connect API",
+              ),
+              " Integration",
+            ],
+          ),
+        ],
+      );
     }
 
     // No integration available
     const baseUrl = window.location.origin;
     const integrationSettingsUrl = `${baseUrl}/connect/#/system/integrations`;
 
-    return m("div.alert.alert-warning", {
-      style: {
-        margin: "1rem auto",
-        maxWidth: "640px",
-        width: "calc(100% - 2rem)"
-      }
-    }, [
-      m("div", { style: { marginBottom: "1rem" } }, [
-        m("p", "This content needs permission to show users the content they have access to."),
-        m("p", [
-          "To allow this, an Administrator must configure a ",
-          m("strong", "Connect API"),
-          " integration on the ",
-          m("strong", [
-            m("a", { href: integrationSettingsUrl, target: "_blank" }, "Integration Settings")
+    return m(
+      "div.alert.alert-warning",
+      {
+        style: {
+          margin: "1rem auto",
+          maxWidth: "640px",
+          width: "calc(100% - 2rem)",
+        },
+      },
+      [
+        m("div", { style: { marginBottom: "1rem" } }, [
+          m(
+            "p",
+            "This content needs permission to show users the content they have access to.",
+          ),
+          m("p", [
+            "To allow this, an Administrator must configure a ",
+            m("strong", "Connect API"),
+            " integration on the ",
+            m("strong", [
+              m(
+                "a",
+                { href: integrationSettingsUrl, target: "_blank" },
+                "Integration Settings",
+              ),
+            ]),
+            " page.",
           ]),
-          " page."
+          m("p", [
+            "On that page, select ",
+            m("strong", "+ Add Integration"),
+            ". In the 'Select Integration' dropdown, choose ",
+            m("strong", "Connect API"),
+            ". The 'Max Role' field must be set to ",
+            m("strong", "Administrator"),
+            " or ",
+            m("strong", "Publisher"),
+            "; 'Viewer' will not work.",
+          ]),
+          m("p", [
+            "See the ",
+            m(
+              "a",
+              {
+                href: "https://docs.posit.co/connect/admin/integrations/oauth-integrations/connect/",
+                target: "_blank",
+              },
+              "Connect API section of the Admin Guide",
+            ),
+            " for more detailed setup instructions.",
+          ]),
         ]),
-        m("p", [
-          "On that page, select ",
-          m("strong", "+ Add Integration"),
-          ". In the 'Select Integration' dropdown, choose ",
-          m("strong", "Connect API"),
-          ". The 'Max Role' field must be set to ",
-          m("strong", "Administrator"),
-          " or ",
-          m("strong", "Publisher"),
-          "; 'Viewer' will not work."
-        ]),
-        m("p", [
-          "See the ",
-          m("a", {
-            href: "https://docs.posit.co/connect/admin/integrations/oauth-integrations/connect/",
-            target: "_blank"
-          }, "Connect API section of the Admin Guide"),
-          " for more detailed setup instructions."
-        ])
-      ])
-    ]);
-  }
+      ],
+    );
+  },
 };
 
 export default UnauthorizedView;

--- a/extensions/publisher-command-center/src/index.js
+++ b/extensions/publisher-command-center/src/index.js
@@ -5,11 +5,10 @@ import "@fortawesome/fontawesome-free/css/all.min.css";
 
 import "../scss/index.scss";
 
-
 import Home from "./views/Home";
 import Edit from "./views/Edit";
-import Layout from './views/Layout';
-import UnauthorizedView from './components/UnauthorizedView';
+import Layout from "./views/Layout";
+import UnauthorizedView from "./components/UnauthorizedView";
 
 const root = document.getElementById("app");
 

--- a/extensions/publisher-command-center/src/models/Contents.js
+++ b/extensions/publisher-command-center/src/models/Contents.js
@@ -35,26 +35,30 @@ export default {
   },
 
   lock: async function (guid) {
-    await m.request({
-      method: "PATCH",
-      url: `api/content/${guid}/lock`,
-    }).then((response) => {
-      const targetContent = this.data.find((c) => c.guid === guid);
-      Object.assign(targetContent, response);
-    });
+    await m
+      .request({
+        method: "PATCH",
+        url: `api/content/${guid}/lock`,
+      })
+      .then((response) => {
+        const targetContent = this.data.find((c) => c.guid === guid);
+        Object.assign(targetContent, response);
+      });
   },
 
   rename: async function (guid, newName) {
-    await m.request({
-      method: "PATCH",
-      url: `api/content/${guid}/rename`,
-      body: {
-        title: newName,
-      },
-    }).then((response) => {
-      const targetContent = this.data.find((c) => c.guid === guid);
-      Object.assign(targetContent, response);
-    });
+    await m
+      .request({
+        method: "PATCH",
+        url: `api/content/${guid}/rename`,
+        body: {
+          title: newName,
+        },
+      })
+      .then((response) => {
+        const targetContent = this.data.find((c) => c.guid === guid);
+        Object.assign(targetContent, response);
+      });
   },
 
   reset: function () {

--- a/extensions/publisher-command-center/src/views/Edit.js
+++ b/extensions/publisher-command-center/src/views/Edit.js
@@ -41,7 +41,7 @@ const Edit = {
           m(
             "a.btn.btn-md.btn-outline-primary.d-flex.align-items-center.justify-content-center.gap-2",
             {
-              onclick: () => m.route.set("/contents")
+              onclick: () => m.route.set("/contents"),
             },
             [m("i.fa-solid.fa-arrow-left"), "Back"],
           ),
@@ -52,7 +52,7 @@ const Edit = {
           {
             href: content?.dashboard_url,
             target: "_blank",
-            ariaLabel: "Open in a new tab"
+            ariaLabel: "Open in a new tab",
           },
           ["Open", m("i.fa-solid.fa-arrow-up-right-from-square")],
         ),

--- a/extensions/publisher-command-center/vite.config.js
+++ b/extensions/publisher-command-center/vite.config.js
@@ -1,10 +1,32 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  esbuild: {
-    jsx: "transform",
-    jsxFactory: "m",
-    jsxFragment: "'['",
+  css: {
+    preprocessorOptions: {
+      scss: {
+        silenceDeprecations: [
+          "import",
+          "mixed-decls",
+          "color-functions",
+          "global-builtin",
+        ],
+      },
+    },
+  },
+  oxc: {
+    jsx: {
+      runtime: "classic",
+      pragma: "m",
+      pragmaFrag: "'['",
+    },
+  },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+    },
   },
   preview: {
     proxy: {


### PR DESCRIPTION
## Summary

- Upgrades Vite from 2.6.x to 8.0.x, resolving 13 Dependabot security alerts
- Migrates esbuild JSX config to oxc equivalent for Vite 8
- Adds dev server proxy for `/api` routes (previously only configured for preview)
- Silences Bootstrap Sass deprecation warnings per [Bootstrap's official recommendation](https://getbootstrap.com/docs/5.3/getting-started/vite/#configure-vite)
- Fixes pre-existing bug in ContentsComponent where an arrow function prevented Mithril from binding `this` to component state (masked by Vite 2's non-strict bundling)
- Bumps extension version to 0.0.6

## Test plan

Ran it locally to ensure it was working. I re-ran `npx prettier --write .` some of the diff changes are related to that. You can isolate those by reviewing per-commit.

I also deployed the artifact to Connect to verify that it loads there.