### PR TITLE
fix: prevent concurrent update-extension-list push failures

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -286,6 +286,9 @@ jobs:
   # all extensions that were released in this workflow using the `fetch-releases`
   # job output
   update-extension-list:
+    concurrency:
+      group: update-extension-list
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     needs: [fetch-releases]
     # Only runs if there are releases to update the extension list with
@@ -332,4 +335,5 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add extensions.json
           git commit -m "Update extension list"
+          git pull --rebase
           git push


### PR DESCRIPTION
## Summary
- Adds a job-level `concurrency` group to the `update-extension-list` job so only one instance runs at a time (others queue instead of cancelling)
- Adds `git pull --rebase` before `git push` as a safety net in case local main is behind remote

Fixes the race condition where merging multiple extension PRs in quick succession causes the second workflow run's push to be rejected (e.g. [this run](https://github.com/posit-dev/connect-extensions/actions/runs/24465973727/attempts/1)).