### PR TITLE
Bump package vulnerability scanner to version 3.0.4 

### DIFF
--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Package Vulnerability Scanner extension will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.4] - 2026-04-15
+
+### Fixed
+
+- Handle breaking change in Posit Package Manager API response format (#335)
+
 ## [3.0.3] - 2026-04-14
 
 ### Changed

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -44,6 +44,6 @@
     "category": "extension",
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": ["API Publishing"],
-    "version": "3.0.3"
+    "version": "3.0.4"
   }
 }


### PR DESCRIPTION
This will trigger a release of the extension, as changed in the #335 update.