### PR TITLE
Simplify release-check pipeline and expand PR comment

### DIFF
--- a/.github/actions/release-extension/action.yml
+++ b/.github/actions/release-extension/action.yml
@@ -46,18 +46,9 @@ runs:
         echo "# Extension: ${{ inputs.extension-name }}" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
-        # Helper to write release check artifact
-        write_release_check() {
-          echo "{\"name\": \"${{ inputs.extension-name }}\", \"manifestVersion\": \"$MANIFEST_VERSION\", \"latestVersion\": \"$LATEST_VERSION\", \"wouldRelease\": $1}" \
-            > would-release-${{ inputs.extension-name }}.json
-        }
-
         if [ "$MANIFEST_VERSION" = "0.0.0" ]; then
           MESSAGE="⚠️ Version 0.0.0 is reserved and will never be released."
-          echo "$MESSAGE"
-          echo "$MESSAGE" >> $GITHUB_STEP_SUMMARY
-          echo "should_release=false" >> "$GITHUB_OUTPUT"
-          write_release_check false
+          SHOULD_RELEASE=false
         else
           # Normal version comparison logic
           VERSION_INFO="The manifest version is '$MANIFEST_VERSION' and the released version is '$LATEST_VERSION'"
@@ -68,18 +59,24 @@ runs:
           HIGHER_VERSION=$(semver "$MANIFEST_VERSION" "$LATEST_VERSION" | tail -n 1)
           if [ "$MANIFEST_VERSION" = "$HIGHER_VERSION" ] && [ "$MANIFEST_VERSION" != "$LATEST_VERSION" ]; then
             MESSAGE="🚀 Will release! The manifest version is greater than the released version."
-            echo "$MESSAGE"
-            echo "$MESSAGE" >> $GITHUB_STEP_SUMMARY
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-            write_release_check true
+            SHOULD_RELEASE=true
           else
             MESSAGE="😴 Holding back from release: The manifest version is not greater than the released version."
-            echo "$MESSAGE"
-            echo "$MESSAGE" >> $GITHUB_STEP_SUMMARY
-            echo "should_release=false" >> "$GITHUB_OUTPUT"
-            write_release_check false
+            SHOULD_RELEASE=false
           fi
         fi
+
+        echo "$MESSAGE"
+        echo "$MESSAGE" >> $GITHUB_STEP_SUMMARY
+        echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
+
+        jq -n \
+          --arg name "${{ inputs.extension-name }}" \
+          --arg manifest "$MANIFEST_VERSION" \
+          --arg latest "$LATEST_VERSION" \
+          --argjson would "$SHOULD_RELEASE" \
+          '{name: $name, manifestVersion: $manifest, latestVersion: $latest, wouldRelease: $would}' \
+          > would-release-${{ inputs.extension-name }}.json
       shell: bash
 
     # Here we download the packaged extension artifact to release
@@ -124,8 +121,10 @@ runs:
         path: release-${{ inputs.extension-name }}.json
         retention-days: 1
 
-    # Upload release check artifact for PR comment aggregation
+    # Upload on PRs for any non-reserved extension so the downstream comment
+    # job can summarize both will-release and won't-release extensions.
     - name: Upload release check data
+      if: github.event_name == 'pull_request' && env.MANIFEST_VERSION != '0.0.0'
       uses: actions/upload-artifact@v4
       with:
         name: would-release-${{ inputs.extension-name }}.json

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -271,42 +271,46 @@ jobs:
           path: would-release
           merge-multiple: true
 
-      - name: Aggregate release check data
-        run: |
-          # If no release checks exist, no extensions were processed
-          if [ ! -d "would-release" ] || [ -z "$(ls -A would-release 2>/dev/null)" ]; then
-            echo "[]" > no_release.json
-            exit 0
-          fi
-
-          # Filter to extensions that won't release (wouldRelease: false, excluding 0.0.0)
-          jq -s '[.[] | select(.wouldRelease == false and .manifestVersion != "0.0.0")]' \
-            would-release/*.json > no_release.json
-
       - name: Post or update PR comment
         run: |
-          MARKER="<!-- release-check-comment -->"
-          NO_RELEASE=$(cat no_release.json)
-
-          # Exit if no extensions need commenting
-          if [ "$NO_RELEASE" = "[]" ] || [ -z "$NO_RELEASE" ]; then
-            echo "All changed extensions will release - no comment needed"
+          # Artifacts are only uploaded by the release-extension action for
+          # extensions that changed (and aren't reserved 0.0.0), so an empty
+          # download directory means there's nothing to comment on.
+          if [ ! -d "would-release" ] || [ -z "$(ls -A would-release 2>/dev/null)" ]; then
+            echo "No extensions changed - no comment needed"
             exit 0
           fi
 
-          # Build the extension list
-          EXTENSION_LIST=$(echo "$NO_RELEASE" | jq -r '.[] | "- **\(.name)**: manifest version `\(.manifestVersion)` ≤ released version `\(.latestVersion)`"')
+          MARKER="<!-- release-check-comment -->"
 
-          # Build comment body
+          WILL_RELEASE=$(jq -r 'select(.wouldRelease) | "- **\(.name)**: `\(.latestVersion)` → `\(.manifestVersion)`"' would-release/*.json)
+          WONT_RELEASE=$(jq -r 'select(.wouldRelease | not) | "- **\(.name)**: manifest version `\(.manifestVersion)` ≤ released version `\(.latestVersion)`"' would-release/*.json)
+
           COMMENT_BODY="${MARKER}
-          ## 😴 Extensions changed but won't release
+          ## Extension release summary
+          "
 
-          The following extensions have code changes but the manifest version hasn't been incremented, so they won't be released when this PR merges:
+          if [ -n "$WILL_RELEASE" ]; then
+            COMMENT_BODY+="
+          ### 🚀 Will release on merge
 
-          ${EXTENSION_LIST}
+          ${WILL_RELEASE}
+          "
+          fi
+
+          if [ -n "$WONT_RELEASE" ]; then
+            COMMENT_BODY+="
+          ### 😴 Changed but won't release
+
+          The following extensions have code changes but the manifest version hasn't been incremented:
+
+          ${WONT_RELEASE}
 
           If you intended to release these changes, update the \`version\` field in each extension's \`manifest.json\`.
+          "
+          fi
 
+          COMMENT_BODY+="
           See the [contributing guide](https://github.com/posit-dev/connect-extensions/blob/main/CONTRIBUTING.md#updating-content-in-the-connect-gallery) for details."
 
           # Check for existing comment with marker


### PR DESCRIPTION
## Summary
Proposed simplifications on top of #342:
- Consolidate the `should_release` step in `release-extension/action.yml`: single message/output/JSON emission at the end of the step instead of the 3-branch `write_release_check` helper. Uses `jq -n --arg/--argjson` for safer JSON construction than hand-built string concatenation.
- Gate the release-check artifact upload at the action level (`pull_request && MANIFEST_VERSION != '0.0.0'`), so the downstream comment job doesn't need to filter.
- Merge the aggregate + comment workflow steps into one. The intermediate `no_release.json` file and duplicate empty-check are gone.
- Expand the PR comment to summarize both will-release and won't-release extensions in separate sections — so contributors can also see what *will* release on merge, not just flag the mistakes.