### PR TITLE
chore(simple-mcp): fix deprecation warnings

### DIFF
--- a/extensions/simple-mcp-server/main.py
+++ b/extensions/simple-mcp-server/main.py
@@ -31,7 +31,6 @@ def get_visitor_client(token: str | None) -> connect.Client:
 mcp = FastMCP(
     name="Simple MCP Server",
     instructions="MCP server for dataset operations and Connect 'whoami' via FastAPI.",
-    stateless_http=True,
 )
 
 # --- Datasets ---
@@ -133,7 +132,7 @@ async def lifespan(app: FastAPI):
         yield
 
 
-mcp_app = mcp.http_app(path="/mcp")
+mcp_app = mcp.http_app(path="/mcp", stateless_http=True)
 app = FastAPI(title="Simple MCP Server with FastAPI", lifespan=mcp_app.lifespan)
 templates = Jinja2Templates(directory=".")
 
@@ -144,9 +143,9 @@ async def get_index_page(request: Request):
     tools = get_tools_info()
     endpoint = urllib.parse.urljoin(request.url._url, "mcp")
     return templates.TemplateResponse(
+        request,
         "index.html.jinja",
         {
-            "request": request,
             "server_name": mcp.name,
             "endpoint": endpoint,
             "tools": tools,

--- a/extensions/simple-mcp-server/manifest.json
+++ b/extensions/simple-mcp-server/manifest.json
@@ -25,12 +25,9 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/simple-mcp-server",
     "category": "example",
     "tags": ["python", "fastapi", "mcp"],
-    "requiredFeatures": [
-      "API Publishing",
-      "OAuth Integrations"
-    ],
+    "requiredFeatures": ["API Publishing", "OAuth Integrations"],
     "minimumConnectVersion": "2025.04.0",
-    "version": "0.0.3"
+    "version": "0.0.4"
   },
   "files": {
     "requirements.txt": {


### PR DESCRIPTION
fixes #348 

deploy locally and observe no warning logs:

```
2026/05/04 11:04:47 AM: INFO:     192.168.65.1:0 - "GET /content/398575db-7049-49c9-a3d6-34c144733471/ HTTP/1.1" 200 OK
2026/05/04 11:04:47 AM: INFO:     127.0.0.1:46858 - "GET / HTTP/1.1" 403 Forbidden
2026/05/04 11:04:47 AM: INFO:     Uvicorn running on http://127.0.0.1:45103 (Press CTRL+C to quit)
2026/05/04 11:04:47 AM: INFO:     Application startup complete.
2026/05/04 11:04:47 AM: StreamableHTTP session manager started
2026/05/04 11:04:47 AM: INFO:     Waiting for application startup.
2026/05/04 11:04:47 AM: INFO:     Started server process [648]
2026/05/04 11:04:47 AM: Starting server on 127.0.0.1:45103...
2026/05/04 11:04:47 AM: App type is "FastAPI"
2026/05/04 11:04:45 AM: Loading code from "main.py"
```