### PR TITLE
Fix bugs in quarto-stock-report-python and quarto-stock-report-r

### DIFF
--- a/extensions/quarto-stock-report-python/CHANGELOG.md
+++ b/extensions/quarto-stock-report-python/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to the Quarto Stock Report using Python extension will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.2] - 2026-06-04
+
+### Fixed
+
+- Flipped the price-change indexing so a price increase is no longer reported as "down". (#362)
+- Used `tail()` instead of `head()` to show the latest stock prices. (#362)
+
+## [1.0.1] - 2025-05-08
+
+### Added
+
+- Added Quarto version constraints. (#95)
+
+## [1.0.0] - 2025-04-14
+
+### Added
+
+- Initial release.

--- a/extensions/quarto-stock-report-python/index.qmd
+++ b/extensions/quarto-stock-report-python/index.qmd
@@ -105,7 +105,7 @@ information.
 #| output: asis
 
 closes = prices_90d['Close']
-change = closes[-2] - closes[-1]
+change = closes.iloc[-1] - closes.iloc[-2]
 abschange = abs(change)
 updown = "up"
 if change < 0:
@@ -126,7 +126,7 @@ print(f"Here are the latest stock prices for **GSPC** as of {datetime.date.today
 ```{python}
 #| echo: false
 
-prices_90d.head(5)[['Open', 'Close', 'Change', 'Volume']]
+prices_90d.tail(5)[['Open', 'Close', 'Change', 'Volume']]
 ```
 
 The historical trend is shown below:

--- a/extensions/quarto-stock-report-python/manifest.json
+++ b/extensions/quarto-stock-report-python/manifest.json
@@ -11,7 +11,7 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-stock-report-python",
     "minimumConnectVersion": "2025.04.0",
     "category": "example",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "environment": {
     "python": {
@@ -40,7 +40,7 @@
       "checksum": "35b4c4c58cce875b126683c525ad40f4"
     },
     "index.qmd": {
-      "checksum": "6fb0db80d26eab1544afdcbc91df228b"
+      "checksum": "bed5d3e06485c3a6d395bda9a2697441"
     },
     "gspc.csv": {
       "checksum": "f74c93cd12f334a4923d6fa4d81cdd1e"

--- a/extensions/quarto-stock-report-r/CHANGELOG.md
+++ b/extensions/quarto-stock-report-r/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to the Quarto Stock Report using R extension will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1] - 2026-06-04
+
+### Fixed
+
+- Rendered the email subject by removing a stray `#` that commented it out. (#362)
+- Updated the stale "Tesla" chart label to GSPC. (#362)
+
+## [1.0.0] - 2025-05-23
+
+### Added
+
+- Initial release.

--- a/extensions/quarto-stock-report-r/index.qmd
+++ b/extensions/quarto-stock-report-r/index.qmd
@@ -82,7 +82,7 @@ subplot(
 ) %>%
   layout(
     hovermode = "x", margin = list(t = 80),
-    title = paste("Tesla from", min(prices_df$Date), "to", max(prices_df$Date)),
+    title = paste("GSPC from", min(prices_df$Date), "to", max(prices_df$Date)),
     xaxis = list(
       rangeselector = list(
         x = 0, y = 1, xanchor = 'left', yanchor = "top",
@@ -149,7 +149,7 @@ subject <- sprintf("GSPC is %s today by $%g!",
 ```
 
 ::: {.subject}
-`r#subject`
+`r subject`
 :::
 
 # Stock Update

--- a/extensions/quarto-stock-report-r/manifest.json
+++ b/extensions/quarto-stock-report-r/manifest.json
@@ -16,7 +16,7 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-stock-report-r",
     "category": "example",
     "minimumConnectVersion": "2025.04.0",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "environment": {
     "quarto": {
@@ -2820,7 +2820,7 @@
       "checksum": "c924c5aa9469cc2a4bcf26cd7f0b2a2e"
     },
     "index.qmd": {
-      "checksum": "48ad54981fe058027c52c2721dfb639e"
+      "checksum": "e8005d283fb5c674a4268fcb8f233806"
     },
     "README.md": {
       "checksum": "5f3ead5d4e8d9802e28ae65dc0ba9cee"


### PR DESCRIPTION
Fixes #362:

`quarto-stock-report-python`:
- flipped indexing to match intent (a price increase was marked as down)
- similarly, changed from head() to tail() for "latest" stock prices

`quarto-stock-report-r`:
- fixed small typo, removing # to render email subject
- removed old label referencing Tesla (update to GSPC)