### PR TITLE
Update quarto stock reports to reflect cached data update

### DIFF
--- a/extensions/quarto-stock-report-python/CHANGELOG.md
+++ b/extensions/quarto-stock-report-python/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Quarto Stock Report using Python extension will be do
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-06-08
+
+### Changed
+
+- Reported the daily change as a day-over-day move so the email subject and table agree. (#368)
+
+### Fixed
+
+- Updated report and email text and formatting to reflect a market index rather than a share price (e.g., index points instead of dollars). (#368)
+- Keyed the email's date off the latest date in the data rather than today's date. (#368)
+- Renamed the summary table's "Avg Volume" column to "Volume" so the most recent day's volume is no longer mislabeled as an average. (#368)
+
 ## [1.0.2] - 2026-06-04
 
 ### Fixed

--- a/extensions/quarto-stock-report-python/README.md
+++ b/extensions/quarto-stock-report-python/README.md
@@ -3,8 +3,9 @@
 ## About this example
 
 This stock report is generated using Quarto and Python. It is an example
-of how you might automate regular updates using a data source. The report
-also generates a custom email, sharing the results directly to
+of how you might automate regular updates using a data source. It reads
+cached data by default, which can be refreshed from a live source. The
+report also generates a custom email, sharing the results directly to
 stakeholders.
 
 

--- a/extensions/quarto-stock-report-python/index.qmd
+++ b/extensions/quarto-stock-report-python/index.qmd
@@ -16,13 +16,14 @@ email-preview: true
 #| echo: true
 
 import pandas as pd
-import datetime
 ```
 
 ```{python}
 #| eval: false
 #| echo: false
-# set eval: true to fetch updated data
+# Cached data (gspc.csv) is used by default. To refresh it, set the `eval`
+# option above to true to pull fresh data from Yahoo Finance, render once,
+# then set it back to false.
 import yfinance as yf
 spx = yf.Ticker("^GSPC")
 hist = spx.history("5y")
@@ -31,7 +32,7 @@ hist.to_csv("gspc.csv")
 
 ```{python}
 hist = pd.read_csv("gspc.csv", parse_dates=[0], index_col=0)
-hist['Change'] = hist['Close'] - hist['Open']
+hist['Change'] = hist['Close'].diff()
 
 latest = hist.last_valid_index()
 days_90 = latest - pd.to_timedelta("90d")
@@ -55,12 +56,14 @@ data=[
 
 df = pd.DataFrame(
     data,
-    columns=['High', 'Low', 'Avg Volume'],
+    columns=['High', 'Low', 'Volume'],
     index=['Most Recent Trading Day', '52-Week'])
 df
 ```
 
 ### Price History
+
+The price history is read from a cached `gspc.csv` file, which can be refreshed from Yahoo Finance.
 
 ```{python}
 #| echo: false
@@ -78,10 +81,9 @@ _ = hist['Close'].plot(grid=True)
 hist
 ```
 
-## Legacy Information
+## Downloadable Data
 
-This report also produces a CSV file containing recent price data, which may
-be used in other analysis.
+This report also writes the recent data to a CSV file and includes it as a downloadable attachment, so stakeholders can grab the underlying numbers.
 
 ```{python}
 #| echo: false
@@ -110,7 +112,7 @@ abschange = abs(change)
 updown = "up"
 if change < 0:
     updown = "down"
-print(f"GSPC is {updown} today by ${abschange:.2f}")
+print(f"GSPC is {updown} by {abschange:.2f} points ({latest:%B %d, %Y})")
 ```
 :::
 
@@ -120,7 +122,7 @@ Hello Team,
 #| echo: false
 #| output: asis
 
-print(f"Here are the latest stock prices for **GSPC** as of {datetime.date.today()}:")
+print(f"Here are the latest **GSPC** index levels as of {latest:%B %d, %Y}:")
 ```
 
 ```{python}

--- a/extensions/quarto-stock-report-python/manifest.json
+++ b/extensions/quarto-stock-report-python/manifest.json
@@ -7,11 +7,12 @@
   "extension": {
     "name": "quarto-stock-report-python",
     "title": "Quarto Stock Report using Python",
-    "description": "An example of how you might automate regular updates using a data source",
+    "description": "This stock report is generated using Quarto and Python. It is an example of how you might automate regular updates using a data source. It reads cached data by default, which can be refreshed from a live source. The report also generates a custom email, sharing the results directly to stakeholders.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-stock-report-python",
     "minimumConnectVersion": "2025.04.0",
     "category": "example",
-    "version": "1.0.2"
+    "tags": ["quarto", "python"],
+    "version": "1.0.3"
   },
   "environment": {
     "python": {
@@ -40,13 +41,13 @@
       "checksum": "35b4c4c58cce875b126683c525ad40f4"
     },
     "index.qmd": {
-      "checksum": "bed5d3e06485c3a6d395bda9a2697441"
+      "checksum": "6380d64184dcf8446da3d1b94f01e999"
     },
     "gspc.csv": {
       "checksum": "f74c93cd12f334a4923d6fa4d81cdd1e"
     },
     "requirements.txt": {
-      "checksum": "1b9e705f62a822cffaa4dc0e988101b4"
+      "checksum": "96da5a6249931f87334fbc303f3a9678"
     }
   }
 }

--- a/extensions/quarto-stock-report-r/CHANGELOG.md
+++ b/extensions/quarto-stock-report-r/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Quarto Stock Report using R extension will be documen
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-06-08
+
+### Changed
+
+- Reported the index direction as a day-over-day change so the summary, email subject, and email table all agree. (#368)
+
+### Fixed
+
+- Updated report and email text and number formatting to reflect a market index rather than a share price (e.g., index points instead of currency, cached data instead of a live API). (#368)
+- Keyed the report's dates off the latest date in the data rather than the render date. (#368)
+
 ## [1.0.1] - 2026-06-04
 
 ### Fixed

--- a/extensions/quarto-stock-report-r/README.md
+++ b/extensions/quarto-stock-report-r/README.md
@@ -2,7 +2,7 @@
 
 ## About this example
 
-This stock report is generated using Quarto and R. It is an example of how you might automate regular updates using a data source. The report also generates a custom email, sharing the results directly to stakeholders.
+This stock report is generated using Quarto and R. It is an example of how you might automate regular updates using a data source. It reads cached data by default, which can be refreshed from a live source. The report also generates a custom email, sharing the results directly to stakeholders.
 
 
 ## Learn more

--- a/extensions/quarto-stock-report-r/index.qmd
+++ b/extensions/quarto-stock-report-r/index.qmd
@@ -9,7 +9,7 @@ attachments:
 email-preview: true
 ---
 
-## Report for `^GSPC`
+## Report for GSPC
 
 ```{r, echo=TRUE, message=FALSE}
 library(DT)
@@ -19,7 +19,6 @@ library(quantmod)
 library(dplyr)
 library(plotly)
 library(xts)
-library(dotty)
 ```
 
 
@@ -27,7 +26,9 @@ library(dotty)
 #| eval: false
 #| echo: false
 
-# set eval: TRUE  fetch updated data
+# Cached data (gspc.csv) is used by default. To refresh it, set the `eval`
+# option above to true to pull fresh data from Yahoo Finance, render once,
+# then set it back to false.
 
 prices <- round(getSymbols("^GSPC", auto.assign = FALSE, src = "yahoo"), 2)
 close <- Cl(xts::last(prices))
@@ -47,15 +48,18 @@ readr::write_csv(prices_df, "gspc.csv")
 ```{r}
 prices_df <- readr::read_csv("gspc.csv")
 recent <- slice_max(prices_df, order_by = Date, n = 90)
-yest <- prices_df |> slice_max(order_by = Date, n = 1) |> select(close = GSPC.Close, open = GSPC.Open)
-.[close, open] <- yest
+latest_date <- max(prices_df$Date)
+
+last_two <- prices_df |> slice_max(order_by = Date, n = 2) |> arrange(Date)
+close <- last_two$GSPC.Close[2]
+change <- round(close - last_two$GSPC.Close[1], 2)
 ```
 
-The stock closed `r ifelse(close>open,'up','down')` at `r close` dollars per share yesterday.
+The index closed `r ifelse(change > 0, "up", "down")` at `r close` points.
 
 ### Price History
 
-The chart below is made with the `quantmod` and `plotly` R packages. An API returns all of the price history based on the stock tick symbol "GSPC.".
+The chart below is made with the `quantmod` and `plotly` R packages. The price history is read from a cached `gspc.csv` file, which can be refreshed from Yahoo Finance.
 
 
 ```{r build_plot, echo=TRUE, warning=FALSE, message=FALSE}
@@ -104,21 +108,20 @@ subplot(
 
 ### Raw Data
 
-The table below displays the daily price data for the stock. A concise, interactive table is created with the `DT` package.
+The table below displays the daily price data for the index, with volume shown in millions. A concise, interactive table is created with the `DT` package.
 
 
 ```{r show_data, echo=TRUE}
 recent %>%
   mutate(GSPC.Volume = GSPC.Volume / 1000000) %>%
   datatable() %>%
-  formatCurrency(c("GSPC.Open", "GSPC.High", "GSPC.Low", "GSPC.Close"), digits = 2) %>%
+  formatRound(c("GSPC.Open", "GSPC.High", "GSPC.Low", "GSPC.Close"), digits = 2) %>%
   formatRound("GSPC.Volume", digits = 0)
 ```
 
-## Legacy Information
+## Downloadable Data
 
-This report also produces a CSV file containing recent price data, which may
-be used in other analysis.
+This report also writes the recent data to a CSV file and includes it as a downloadable attachment, so stakeholders can grab the underlying numbers.
 
 ```{r write_csv, echo = FALSE, include = FALSE}
 write.csv(recent, file = "data.csv")
@@ -134,18 +137,10 @@ information.
 ::: {.email}
 
 ```{r compute_subject, warning = FALSE, message = FALSE, echo = FALSE}
-# Calculate the total change
-
-diff <- prices_df |>
-  slice_max(order_by = Date, n = 2) |>
-  mutate(chg = GSPC.Close - lag(GSPC.Close, order_by = Date)) |>
-  pull(chg)
-subject <- sprintf("GSPC is %s today by $%g!",
-        ifelse(diff[1] > 0,"up", "down"),
-        abs(diff[1]))
-
-# ideally, we would always compute the email content but
-# suppress its scheduled sending only when (abs(diff) > 0.5)
+subject <- sprintf("GSPC is %s by %g points (%s)",
+        ifelse(change > 0, "up", "down"),
+        abs(change),
+        format(latest_date, "%B %d, %Y"))
 ```
 
 ::: {.subject}
@@ -156,15 +151,16 @@ subject <- sprintf("GSPC is %s today by $%g!",
 
 Hello Team,
 
-Here are the latest stock prices for **GSPC** as of `r Sys.Date()`:
+Here are the latest **GSPC** index levels as of `r format(latest_date, "%B %d, %Y")`:
 
 ```{r, echo = FALSE}
 price_new <- prices_df |>
+  arrange(Date) |>
+  mutate(change = GSPC.Close - lag(GSPC.Close)) |>
   slice_tail(n = 10) |>
-  select(Date, open = GSPC.Open, close = GSPC.Close) |>
-  mutate(change = close - open)
+  select(Date, open = GSPC.Open, close = GSPC.Close, change)
 
-# include a table with the stock prices
+# include a table with the index levels
 format_table(
     x = as.data.frame(tail(price_new)),
     list(
@@ -187,7 +183,7 @@ ggplot(recent) +
   geom_smooth() +
   theme_fivethirtyeight() +
   labs(
-    title = sprintf("%s Price Adjusted", "GSPC")
+    title = sprintf("%s Adjusted Close", "GSPC")
   )
 ```
 

--- a/extensions/quarto-stock-report-r/manifest.json
+++ b/extensions/quarto-stock-report-r/manifest.json
@@ -12,11 +12,12 @@
   "extension": {
     "name": "quarto-stock-report-r",
     "title": "Quarto Stock Report using R",
-    "description": "This stock report is generated using Quarto and R. It is an example of how you might automate regular updates using a data source. The report also generates a custom email, sharing the results directly to stakeholders.",
+    "description": "This stock report is generated using Quarto and R. It is an example of how you might automate regular updates using a data source. It reads cached data by default, which can be refreshed from a live source. The report also generates a custom email, sharing the results directly to stakeholders.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-stock-report-r",
     "category": "example",
     "minimumConnectVersion": "2025.04.0",
-    "version": "1.0.1"
+    "tags": ["quarto", "r"],
+    "version": "1.0.2"
   },
   "environment": {
     "quarto": {
@@ -2820,10 +2821,10 @@
       "checksum": "c924c5aa9469cc2a4bcf26cd7f0b2a2e"
     },
     "index.qmd": {
-      "checksum": "e8005d283fb5c674a4268fcb8f233806"
+      "checksum": "08453b92ddeed8746fb787f776af55ef"
     },
     "README.md": {
-      "checksum": "5f3ead5d4e8d9802e28ae65dc0ba9cee"
+      "checksum": "efd3d1462609ec79abf79f2f4eaac7c7"
     }
   },
   "users": null


### PR DESCRIPTION
Fixes #368 by changing calculations to day-over-day-change, keying dates off the latest data, and updating text to align with market index (instead of individual stock) and cached data (instead of API).