### PR TITLE
Fix version incompatibility

### DIFF
--- a/extensions/publisher-command-center/CHANGELOG.md
+++ b/extensions/publisher-command-center/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to the Publisher Command Center extension will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.8] - 2026-06-09
+
+### Fixed
+
+- Replaced the `token: str | None` type hint with `Optional[str]` so it no longer requires Python 3.10 at runtime, matching the declared `~=3.8` minimum.

--- a/extensions/publisher-command-center/app.py
+++ b/extensions/publisher-command-center/app.py
@@ -1,5 +1,6 @@
 from http import client
 import asyncio
+from typing import Optional
 from fastapi import FastAPI, Header, Body
 from fastapi.staticfiles import StaticFiles
 from posit import connect
@@ -69,7 +70,7 @@ async def get_integrations():
 
 
 @cached(client_cache)
-def get_visitor_client(token: str | None) -> connect.Client:
+def get_visitor_client(token: Optional[str]) -> connect.Client:
     """Create and cache API client per token with 1 hour TTL"""
     if token:
         return client.with_user_session_token(token)

--- a/extensions/publisher-command-center/manifest.json
+++ b/extensions/publisher-command-center/manifest.json
@@ -24,14 +24,14 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/publisher-command-center",
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": ["API Publishing", "OAuth Integrations"],
-    "version": "0.0.7"
+    "version": "0.0.8"
   },
   "files": {
     "requirements.txt": {
       "checksum": "a162a98758867a701ce693948ffdfa67"
     },
     "app.py": {
-      "checksum": "47ca827cedf404595e9fe4c9a80424e7"
+      "checksum": "a12d8bd22d7aa7141ddbe57725bf4c74"
     },
     "dist/assets/fa-brands-400.808443ae.ttf": {
       "checksum": "15d54d142da2f2d6f2e90ed1d55121af"


### PR DESCRIPTION
Fixes #371 

Changes from `token: str | None` to `token: Optional[str]`, which is compatible with 3.8+