### PR TITLE
gitignore deployment directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ uv.lock
 # Package info
 *.egg-info/
 .installed.cfg
+
+# Deployment files
+.posit/
+rsconnect/
+rsconnect-python/


### PR DESCRIPTION
When developing in this repo I often deploy extensions from my local machine to Connect to test things out. Then I end up with various deployment files appearing as untracked files in git. For this repo there's never any need to commit those, so this PR adds them to `.gitignore`.