### PR TITLE
fix stale manifests and standardize > to ~ for runtime requirements

### DIFF
--- a/extensions/audit-reports/manifest.json
+++ b/extensions/audit-reports/manifest.json
@@ -34,7 +34,7 @@
       "checksum": "2bafb90cfc5b4933ee0ef8d4d07ff5b2"
     },
     "runtime-versions.qmd": {
-      "checksum": "5fc1056d0e0e8b89721cc7508a635eff"
+      "checksum": "1fd88936f3d435918be3ef2adacbda0c"
     },
     "unpublished.qmd": {
       "checksum": "dd2d6de0ce972611a454e80776c4ed3d"

--- a/extensions/chat-with-content/CHANGELOG.md
+++ b/extensions/chat-with-content/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to the Chat with Content extension will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.7] - 2026-06-15
+
+### Changed
+
+- Constrained the Python runtime requirement to the current major version (`>=3.10.0` → `~=3.10`). (#376)
+
+### Fixed
+
+- Corrected a stale manifest checksum; no change to bundled files. (#376)
+
+## [0.0.6] - 2026-05-08
+
+### Changed
+
+- Updated for the new settings panel. (#347)
+
+## [0.0.5] - 2026-04-08
+
+### Changed
+
+- Added Azure OpenAI compatibility. (#331)
+
+## [0.0.4] - 2026-01-16
+
+### Changed
+
+- Updated chatlas usage. (#310)
+
+## [0.0.3] - 2025-12-09
+
+### Changed
+
+- Updated chatlas environment variable references. (#306)
+
+## [0.0.2] - 2025-11-10
+
+### Changed
+
+- Switched to a more minimal `requirements.txt` to avoid strict pins. (#289)
+
+## [0.0.1] - 2025-07-08
+
+### Added
+
+- Initial release. (#190)

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -27,7 +27,7 @@
     "tags": ["llm", "shiny", "chat", "python"],
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": ["OAuth Integrations"],
-    "version": "0.0.6"
+    "version": "0.0.7"
   },
   "files": {
     "requirements.txt": {

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -15,7 +15,7 @@
   },
   "environment": {
     "python": {
-      "requires": ">=3.10.0"
+      "requires": "~=3.10"
     }
   },
   "extension": {
@@ -46,7 +46,7 @@
       "checksum": "b18f4bc0072b6e47864670a3174b0cea"
     },
     "pyproject.toml": {
-      "checksum": "f296646bfcde3f0a4ad4312bc69b28fc"
+      "checksum": "604c28539dcb8abf952d7099ce2994bc"
     }
   }
 }

--- a/extensions/datadog-prometheus-metrics/manifest.json
+++ b/extensions/datadog-prometheus-metrics/manifest.json
@@ -18,7 +18,7 @@
       "checksum": "0a1dd4e0e8f73b6abdfb9a54e7bb69bf"
     },
     "app.py": {
-      "checksum": "96b60bc4e32f2b4d809207ec6d2a880d"
+      "checksum": "7b88fe85e558d6a668df690bf3878f2b"
     },
     "connect-extension.qmd": {
       "checksum": "168f0a708df0811fa9225bda634a7cb3"
@@ -37,7 +37,7 @@
   },
   "environment": {
     "python": {
-      "requires": ">=3.11"
+      "requires": "~=3.11"
     }
   }
 }

--- a/extensions/integration-session-manager/manifest.json
+++ b/extensions/integration-session-manager/manifest.json
@@ -15,7 +15,7 @@
   },
   "environment": {
     "python": {
-      "requires": ">=3.11"
+      "requires": "~=3.11"
     }
   },
   "files": {

--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Package Vulnerability Scanner extension will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.5] - 2026-06-15
+
+### Fixed
+
+- Corrected a stale manifest checksum; no change to bundled files. (#376)
+
 ## [3.0.4] - 2026-04-15
 
 ### Fixed

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -30,7 +30,7 @@
       "checksum": "61de23bbcf376913838dfc6cba2a0979"
     },
     "main.py": {
-      "checksum": "e3063b5ce9771a34d7fa23f2234d3668"
+      "checksum": "a590da1135686d5eb651d635898f19d5"
     },
     "requirements.txt": {
       "checksum": "9fc5cc5fb559eded1f323793b73e82c5"

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -44,6 +44,6 @@
     "category": "extension",
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": ["API Publishing"],
-    "version": "3.0.4"
+    "version": "3.0.5"
   }
 }

--- a/extensions/pqr/CHANGELOG.md
+++ b/extensions/pqr/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to the Quarto Document with Python and R extension will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.2] - 2026-06-15
+
+### Changed
+
+- Constrained the Python, Quarto, and R runtime requirements to their current major versions (`>=3.11` → `~=3.11`, `>=1.4` → `~=1.4`, `>=4.3` → `~=4.3`). (#376)
+
+### Fixed
+
+- Corrected a stale manifest checksum; no change to bundled files. (#376)
+
+## [0.1.1] - 2026-06-11
+
+### Changed
+
+- Switched to with-connect for integration tests. (#355)
+
+## [0.1.0] - 2025-09-12
+
+### Added
+
+- Initial release. (#274)

--- a/extensions/pqr/manifest.json
+++ b/extensions/pqr/manifest.json
@@ -11,13 +11,13 @@
   },
   "environment": {
     "python": {
-      "requires": ">=3.11"
+      "requires": "~=3.11"
     },
     "quarto": {
-      "requires": ">=1.4"
+      "requires": "~=1.4"
     },
     "r": {
-      "requires": ">=4.3"
+      "requires": "~=4.3"
     }
   },
   "quarto": {
@@ -1262,7 +1262,7 @@
   },
   "files": {
     ".Rprofile": {
-      "checksum": "e4a8469aa2429ff6deb5fe48247af0a1"
+      "checksum": "57f9047cb06fdbef821b61f49e21406e"
     },
     "index.qmd": {
       "checksum": "e3c9e1907f7e77e8d7da0492e92d9def"

--- a/extensions/pqr/manifest.json
+++ b/extensions/pqr/manifest.json
@@ -1289,6 +1289,6 @@
     "category": "example",
     "tags": ["python", "quarto", "r"],
     "minimumConnectVersion": "2025.04.0",
-    "version": "0.1.1"
+    "version": "0.1.2"
   }
 }

--- a/extensions/quarto-stock-report-python/CHANGELOG.md
+++ b/extensions/quarto-stock-report-python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Quarto Stock Report using Python extension will be do
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2026-06-15
+
+### Changed
+
+- Constrained the Python runtime requirement to the current major version (`>=3.11` → `~=3.11`). (#376)
+
 ## [1.0.4] - 2026-06-10
 
 ### Changed

--- a/extensions/quarto-stock-report-python/manifest.json
+++ b/extensions/quarto-stock-report-python/manifest.json
@@ -16,7 +16,7 @@
   },
   "environment": {
     "python": {
-      "requires": ">=3.11"
+      "requires": "~=3.11"
     },
     "quarto": {
       "requires": "~=1.4"

--- a/extensions/quarto-stock-report-python/manifest.json
+++ b/extensions/quarto-stock-report-python/manifest.json
@@ -12,7 +12,7 @@
     "minimumConnectVersion": "2025.04.0",
     "category": "example",
     "tags": ["quarto", "python"],
-    "version": "1.0.4"
+    "version": "1.0.5"
   },
   "environment": {
     "python": {

--- a/extensions/reaper/manifest.json
+++ b/extensions/reaper/manifest.json
@@ -23,7 +23,7 @@
       "checksum": "969fde50a8798a04a638e60adbae9ba7"
     },
     "app.py": {
-      "checksum": "054f42ee6f007ef74cdc232358c87428"
+      "checksum": "5120e5b37cb459f78f7e96b794e9a41d"
     },
     "connect-extension.toml": {
       "checksum": "c6e6af366dacce9c86f0a06901b931f3"

--- a/extensions/reaper/manifest.json
+++ b/extensions/reaper/manifest.json
@@ -23,7 +23,7 @@
       "checksum": "969fde50a8798a04a638e60adbae9ba7"
     },
     "app.py": {
-      "checksum": "5120e5b37cb459f78f7e96b794e9a41d"
+      "checksum": "054f42ee6f007ef74cdc232358c87428"
     },
     "connect-extension.toml": {
       "checksum": "c6e6af366dacce9c86f0a06901b931f3"

--- a/extensions/simple-mcp-server/CHANGELOG.md
+++ b/extensions/simple-mcp-server/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to the Simple MCP Server extension will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.6] - 2026-06-15
+
+### Changed
+
+- Constrained the Python runtime requirement to the current major version (`>=3.11` → `~=3.11`). (#376)
+
+## [0.0.5] - 2026-06-11
+
+### Changed
+
+- Switched to with-connect for integration tests. (#355)
+
+## [0.0.4] - 2026-05-04
+
+### Fixed
+
+- Fixed deprecation warnings. (#349)
+
+## [0.0.3] - 2026-02-03
+
+### Changed
+
+- Switched to the visitor API integration and added stateless HTTP support. (#312)
+
+## [0.0.2] - 2025-07-08
+
+### Changed
+
+- Updated setup and description text. (#229)
+
+## [0.0.1] - 2025-07-08
+
+### Added
+
+- Initial release. (#179)

--- a/extensions/simple-mcp-server/manifest.json
+++ b/extensions/simple-mcp-server/manifest.json
@@ -15,7 +15,7 @@
   },
   "environment": {
     "python": {
-      "requires": ">=3.11"
+      "requires": "~=3.11"
     }
   },
   "extension": {

--- a/extensions/simple-mcp-server/manifest.json
+++ b/extensions/simple-mcp-server/manifest.json
@@ -27,7 +27,7 @@
     "tags": ["python", "fastapi", "mcp"],
     "requiredFeatures": ["API Publishing", "OAuth Integrations"],
     "minimumConnectVersion": "2025.04.0",
-    "version": "0.0.5"
+    "version": "0.0.6"
   },
   "files": {
     "requirements.txt": {

--- a/extensions/simple-shiny-chat-with-mcp/CHANGELOG.md
+++ b/extensions/simple-shiny-chat-with-mcp/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to the Simple Shiny Chat with MCP Support extension will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.6] - 2026-06-15
+
+### Changed
+
+- Constrained the Python runtime requirement to the current major version (`>=3.10` → `~=3.10`). (#376)
+
+### Fixed
+
+- Corrected a stale manifest checksum; no change to bundled files. (#376)
+
+## [0.0.5] - 2026-05-08
+
+### Changed
+
+- Updated for the new settings panel. (#347)
+
+## [0.0.4] - 2025-12-09
+
+### Changed
+
+- Updated chatlas environment variable references. (#306)
+
+## [0.0.3] - 2025-11-10
+
+### Changed
+
+- Switched to a more minimal `requirements.txt` to avoid strict pins. (#289)
+
+## [0.0.2] - 2025-07-08
+
+### Changed
+
+- Updated setup and description text. (#229)
+
+## [0.0.1] - 2025-07-08
+
+### Added
+
+- Initial release. (#179)

--- a/extensions/simple-shiny-chat-with-mcp/manifest.json
+++ b/extensions/simple-shiny-chat-with-mcp/manifest.json
@@ -29,7 +29,7 @@
       "OAuth Integrations"
     ],
     "minimumConnectVersion": "2025.04.0",
-    "version": "0.0.5"
+    "version": "0.0.6"
   },
   "files": {
     "requirements.txt": {

--- a/extensions/simple-shiny-chat-with-mcp/manifest.json
+++ b/extensions/simple-shiny-chat-with-mcp/manifest.json
@@ -15,7 +15,7 @@
   },
   "environment": {
       "python": {
-        "requires": ">=3.10"
+        "requires": "~=3.10"
       }
     },
   "extension": {
@@ -33,7 +33,7 @@
   },
   "files": {
     "requirements.txt": {
-      "checksum": "29cc272aac150ac0aee03574874b78cf"
+      "checksum": "04704e5cc2a144ccfdd9c6bb990db570"
     },
     "README.md": {
       "checksum": "123a88ebb3df0e35fc1f45e0194504ce"

--- a/extensions/stock-report-jupyter/CHANGELOG.md
+++ b/extensions/stock-report-jupyter/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Stock Report using Jupyter extension will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-06-15
+
+### Changed
+
+- Constrained the Python runtime requirement to the current major version (`>=3.11` → `~=3.11`). (#376)
+
 ## [1.0.2] - 2026-06-10
 
 ### Changed

--- a/extensions/stock-report-jupyter/manifest.json
+++ b/extensions/stock-report-jupyter/manifest.json
@@ -17,7 +17,7 @@
   },
   "environment": {
     "python": {
-      "requires": ">=3.11"
+      "requires": "~=3.11"
     }
   },
   "python": {

--- a/extensions/stock-report-jupyter/manifest.json
+++ b/extensions/stock-report-jupyter/manifest.json
@@ -13,7 +13,7 @@
     "category": "example",
     "tags": ["python"],
     "minimumConnectVersion": "2025.04.0",
-    "version": "1.0.2"
+    "version": "1.0.3"
   },
   "environment": {
     "python": {


### PR DESCRIPTION
Fixes #366 exactly as described. In relevant manifest.json files:
- Fixes stale checksums
- Since nearly all of the extensions use ~= instead of >= for runtime requirements, I updated the few that still had >=

Neither of these affects functionality:
- The checksum fix only updates metadata to reflect files already in the repo; the file contents are untouched
- Converting >=X → ~=X only narrows the range by adding an upper bound at the next major version (e.g. >=3.11 → ~=3.11 means >=3.11, <4.0). It excludes nothing that exists today, it just stops the extension from silently claiming compatibility with a future major (Python 4, R 5, …)