### PR TITLE
feat(scripts): carry imgUrl from manifest into extension list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,32 @@ For example, if your content requires the API Publishing feature your
 }
 ```
 
+#### Thumbnail
+
+The `imgUrl` field in the `extension` section of the `manifest.json` is optional.
+It sets the image shown on the content's card in the Connect Gallery; without it,
+the card falls back to a generic placeholder icon.
+
+The Connect Gallery uses `imgUrl` directly as an image source, so it must be an
+absolute, publicly reachable URL — a path relative to the repository will not
+resolve. The recommended approach is to commit the image alongside your content
+and reference its raw GitHub URL:
+
+```json
+// manifest.json
+
+{
+  ...
+  "extension": {
+    "imgUrl": "https://raw.githubusercontent.com/posit-dev/connect-extensions/main/extensions/my-content-name/thumbnail.png",
+    ...
+  }
+}
+```
+
+Use a landscape image (roughly 16:9) so it displays consistently alongside other
+cards.
+
 ### README.md
 
 In the above extension section there is a `homepage` link that we provide in the

--- a/scripts/extension-list.ts
+++ b/scripts/extension-list.ts
@@ -68,6 +68,7 @@ class ExtensionList {
       version,
       category,
       tags,
+      imgUrl,
       minimumConnectVersion,
       requiredFeatures,
     } = manifest.extension;
@@ -87,10 +88,10 @@ class ExtensionList {
     };
 
     if (this.getExtension(name)) {
-      this.updateExtensionDetails(name, title, description, homepage, tags, category);
+      this.updateExtensionDetails(name, title, description, homepage, tags, category, imgUrl);
       this.addExtensionVersion(name, newVersion);
     } else {
-      this.addNewExtension(name, title, description, homepage, newVersion, tags, category);
+      this.addNewExtension(name, title, description, homepage, newVersion, tags, category, imgUrl);
     }
   }
 
@@ -104,7 +105,8 @@ class ExtensionList {
     description: string,
     homepage: string,
     tags: string[] = [],
-    category?: string
+    category?: string,
+    imgUrl?: string
   ) {
     this.updateExtension(name, {
       ...this.getExtension(name),
@@ -113,6 +115,7 @@ class ExtensionList {
       homepage,
       tags,
       ...(category ? { category } : {}),
+      ...(imgUrl ? { imgUrl } : {}),
     });
   }
 
@@ -147,7 +150,8 @@ class ExtensionList {
     homepage: string,
     initialVersion: ExtensionVersion,
     tags: string[] = [],
-    category?: string
+    category?: string,
+    imgUrl?: string
   ) {
     if (this.getExtension(name) !== undefined) {
       throw new Error(`Extension ${name} already exists in the list`);
@@ -161,6 +165,7 @@ class ExtensionList {
       versions: [initialVersion],
       tags,
       ...(category ? { category } : {}),
+      ...(imgUrl ? { imgUrl } : {}),
     });
     this.sortExtensions();
   }

--- a/scripts/types/index.ts
+++ b/scripts/types/index.ts
@@ -25,6 +25,7 @@ export interface ExtensionManifest {
     requiredFeatures?: RequiredFeature[];
     category?: Category['id'];
     tags?: string[];
+    imgUrl?: string;
   };
   environment?: ExtensionEnvironment;
 }
@@ -53,4 +54,5 @@ export interface Extension {
   versions: ExtensionVersion[];
   tags: string[];
   category?: Category['id'];
+  imgUrl?: string;
 }


### PR DESCRIPTION
Fixes #388 

- Threads the `imgUrl` field from each extension's `manifest.json` through the listing generator so it lands in `extensions.json`. The Connect gallery UI already renders `imgUrl` as a card thumbnail with the puzzle-piece icon as a fallback (`GalleryCard.vue`); this change supplies that value, so any extension that sets `imgUrl` in its manifest will show a real thumbnail instead of the generic puzzle piece.
- Adds a new section in `CONTRIBUTING.md` specifying how a user can (and should) add a thumbnail to an extension.

Validation:
- **Type-check:** `tsc --noEmit` passes.
- **End-to-end functional test** (run the real generator via `npm run update-extension-list` against a crafted release, then reverted):
  - *With* `imgUrl` in the manifest → value appears on the extension's entry in `extensions.json`.
  - *Without* `imgUrl` → no `imgUrl` key is emitted (not `imgUrl: undefined`); the entry's keys are unchanged, confirming existing extensions are unaffected.