### PR TITLE
fix(runtime-version-scanner): parse error in content table

### DIFF
--- a/extensions/runtime-version-scanner/CHANGELOG.md
+++ b/extensions/runtime-version-scanner/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Runtime Version Scanner extension will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2026-06-23
+
+### Fixed
+
+- Fixed the content table failing to load (and the resulting `map_chr` crash) when scanning content. The content list was being parsed directly off connectapi's R6 objects, which left every column empty; it now parses via `as_tibble()`, and missing owner names fall back to an empty string. (#391)
+
+### Changed
+
+- Removed the extension's reliance on unexported connectapi internals (`connectapi:::unversioned_url()` and `connectapi:::v1_url()`), which could be renamed or removed in a future connectapi release and silently break the scanner. URL construction now uses connectapi's public client methods and base R. (#391)
+
 ## [1.0.4] - 2026-06-11
 
 ### Changed

--- a/extensions/runtime-version-scanner/R/connect_module.R
+++ b/extensions/runtime-version-scanner/R/connect_module.R
@@ -38,12 +38,10 @@ connectVisitorClient <- function(
           )
         } else if (nrow(selected_integration) == 0) {
           integration_settings_url <- publisher_client$server_url(
-            connectapi:::unversioned_url(
-              "connect",
-              "#",
-              "system",
-              "integrations"
-            )
+            "connect",
+            "#",
+            "system",
+            "integrations"
           )
           message <- paste0(
             "This content needs permission to ",
@@ -128,12 +126,14 @@ get_eligible_integrations <- function(client) {
 
 auto_add_integration <- function(client, integration_guid) {
   client$PUT(
-    connectapi:::v1_url(
+    paste(
+      "v1",
       "content",
       Sys.getenv("CONNECT_CONTENT_GUID"),
       "oauth",
       "integrations",
-      "associations"
+      "associations",
+      sep = "/"
     ),
     body = list(list(oauth_integration_guid = integration_guid))
   )

--- a/extensions/runtime-version-scanner/R/fetch_content.R
+++ b/extensions/runtime-version-scanner/R/fetch_content.R
@@ -41,11 +41,8 @@ type_query <- function(content_types) {
 }
 
 content_list_to_data_frame <- function(content_list) {
-  # `search_content()` returns a `connect_content_list` of `Content` R6
-  # objects whose fields live in `$content`. Use connectapi's exported
-  # `as_tibble()` method, which extracts `$content` from each object before
-  # parsing. Passing the R6 objects straight to the internal parser yields a
-  # table of all-empty rows (guid = NA, owner = list()), which crashes the
-  # downstream `map_chr(owner, "first_name")`. See issue #379.
+  # `search_content()` returns R6 `Content` objects whose fields live in
+  # `$content`; `as_tibble()` extracts those before parsing. Parsing the
+  # objects directly yields a table of all-empty rows.
   tibble::as_tibble(content_list)
 }

--- a/extensions/runtime-version-scanner/R/fetch_content.R
+++ b/extensions/runtime-version-scanner/R/fetch_content.R
@@ -41,8 +41,11 @@ type_query <- function(content_types) {
 }
 
 content_list_to_data_frame <- function(content_list) {
-  connectapi:::parse_connectapi_typed(
-    content_list,
-    connectapi:::connectapi_ptypes$content
-  )
+  # `search_content()` returns a `connect_content_list` of `Content` R6
+  # objects whose fields live in `$content`. Use connectapi's exported
+  # `as_tibble()` method, which extracts `$content` from each object before
+  # parsing. Passing the R6 objects straight to the internal parser yields a
+  # table of all-empty rows (guid = NA, owner = list()), which crashes the
+  # downstream `map_chr(owner, "first_name")`. See issue #379.
+  tibble::as_tibble(content_list)
 }

--- a/extensions/runtime-version-scanner/app.R
+++ b/extensions/runtime-version-scanner/app.R
@@ -263,8 +263,8 @@ server <- function(input, output, session) {
       content_df <- content_list_to_data_frame(content_list)|>
         mutate(
           owner_name = paste(
-            map_chr(owner, "first_name"),
-            map_chr(owner, "last_name")
+            map_chr(owner, "first_name", .default = ""),
+            map_chr(owner, "last_name", .default = "")
           ),
           title = coalesce(title, ifelse(name != "", name, NA))
         )

--- a/extensions/runtime-version-scanner/manifest.json
+++ b/extensions/runtime-version-scanner/manifest.json
@@ -2616,13 +2616,13 @@
   },
   "files": {
     "app.R": {
-      "checksum": "69ec0029acb50cb4bc05041bb35b88b8"
+      "checksum": "1f458d627fc174c123e24baa3a3934cf"
     },
     "R/connect_module.R": {
-      "checksum": "06b96d31139208ae8e231a4b9991e800"
+      "checksum": "b06c872e41c16ee85834394daccfc19d"
     },
     "R/fetch_content.R": {
-      "checksum": "1563f56cdbf699953ee2750fac9b560f"
+      "checksum": "a99f3e21b2612e9d889b14b8a6201d83"
     },
     "R/supported_versions.R": {
       "checksum": "ca8c4181bddf00f8e7e0797671ae01c6"

--- a/extensions/runtime-version-scanner/manifest.json
+++ b/extensions/runtime-version-scanner/manifest.json
@@ -2649,6 +2649,6 @@
     "requiredFeatures": [
       "OAuth Integrations"
     ],
-    "version": "1.0.4"
+    "version": "1.0.5"
   }
 }


### PR DESCRIPTION
fixes #379 

I started by deploying a version of this app with a diagnostic log on the content owner firstname/lastname to dogfood. That log showed that the entire parsed content ownership table was empty. 

### The actual bug:

`content_list_to_data_frame()` passed the result of `search_content()` straight into `connectapi`'s internal parser:
```
connectapi:::parse_connectapi_typed(content_list, connectapi:::connectapi_ptypes$content)
```

But `search_content()` returns a list of R6 Content objects whose fields live in `$content`. The internal parser can't read fields off R6 objects, so every column came back empty. `map_chr(owner, "first_name")` was just the first line to error on the empty owner.


`connectapi`'s own converter does the step the scanner skipped:
```
as_tibble.connect_content_list <- function(x, ...) {
    content_data <- purrr::map(x, "content")   # <-- extract $content first
    parse_connectapi_typed(content_data, connectapi_ptypes$content)
}
```
the fix is just to to rely on this method

### validation

Deployed the app with this fix:

<img width="1472" height="936" alt="Screenshot 2026-06-22 at 9 13 45 AM" src="https://github.com/user-attachments/assets/98fbfd81-e5a0-45ee-ae67-55f35b631405" />
