### PR TITLE
Fix weekly integration failures

### DIFF
--- a/.github/workflows/weekly-integration-tests.yml
+++ b/.github/workflows/weekly-integration-tests.yml
@@ -46,6 +46,26 @@ jobs:
         with:
           extension-name: ${{ matrix.extension }}
 
+      # Frontend extensions (those with a package.json) ship a built `dist/`
+      # directory that is gitignored, so it must be built before packaging.
+      # Without this the deployed app fails at startup mounting `dist/`.
+      - name: Set up Node
+        if: ${{ hashFiles(format('extensions/{0}/package.json', matrix.extension)) != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+          cache-dependency-path: extensions/${{ matrix.extension }}/package-lock.json
+
+      - name: Build frontend
+        if: ${{ hashFiles(format('extensions/{0}/package.json', matrix.extension)) != '' }}
+        working-directory: extensions/${{ matrix.extension }}
+        run: |
+          npm ci
+          npm run build
+          # Drop build-only files so they aren't packaged into the bundle
+          rm -rf node_modules
+
       - uses: ./.github/actions/package-extension
         with:
           extension-name: ${{ matrix.extension }}

--- a/extensions/pqr/CHANGELOG.md
+++ b/extensions/pqr/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Pinned `pandas>=2.3.3` so the bundled datasets load without crashing on Connect releases that ship Python 3.14. The previous `pandas==2.3.2` had no Python 3.14 wheel and built from source, producing a broken extension that segfaulted when loading data.
+- Pinned `pandas>=2.3.3` so the bundled datasets load without crashing on Connect releases that ship Python 3.14. The previous `pandas==2.3.2` had no Python 3.14 wheel and built from source, producing a broken extension that segfaulted when loading data. (#398)
 
 ## [0.1.2] - 2026-06-15
 

--- a/extensions/pqr/CHANGELOG.md
+++ b/extensions/pqr/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Quarto Document with Python and R extension will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-06-22
+
+### Fixed
+
+- Pinned `pandas>=2.3.3` so the bundled datasets load without crashing on Connect releases that ship Python 3.14. The previous `pandas==2.3.2` had no Python 3.14 wheel and built from source, producing a broken extension that segfaulted when loading data.
+
 ## [0.1.2] - 2026-06-15
 
 ### Changed

--- a/extensions/pqr/manifest.json
+++ b/extensions/pqr/manifest.json
@@ -1274,10 +1274,10 @@
       "checksum": "962cd79e2270a9092eacb5ee04223b4b"
     },
     "requirements.in": {
-      "checksum": "a8339a5379053005e03306a5b9792ffb"
+      "checksum": "e5a63f0306f1a3d8fa54585125bab71e"
     },
     "requirements.txt": {
-      "checksum": "49b0abd857312b4b47825c38d89b5e9a"
+      "checksum": "5763a001a468a85d0608baff9ed55fb0"
     }
   },
   "users": null,
@@ -1289,6 +1289,6 @@
     "category": "example",
     "tags": ["python", "quarto", "r"],
     "minimumConnectVersion": "2025.04.0",
-    "version": "0.1.2"
+    "version": "0.1.3"
   }
 }

--- a/extensions/pqr/requirements.in
+++ b/extensions/pqr/requirements.in
@@ -1,1 +1,2 @@
 plotnine
+pandas>=2.3.3,<3

--- a/extensions/pqr/requirements.txt
+++ b/extensions/pqr/requirements.txt
@@ -26,8 +26,9 @@ packaging==25.0
     # via
     #   matplotlib
     #   statsmodels
-pandas==2.3.2
+pandas==2.3.3
     # via
+    #   -r requirements.in
     #   mizani
     #   plotnine
     #   statsmodels

--- a/extensions/stock-api-flask/CHANGELOG.md
+++ b/extensions/stock-api-flask/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated `numpy` and `pandas` to versions with Python 3.14 wheels so the content runs on Connect releases that ship Python 3.14.
+- Updated `pandas` and loosened the `numpy` pin to a range so the content installs with Python 3.14 wheels on Connect releases that ship Python 3.14, while still running on older Python versions. (#398)
 
 ## [1.0.2] - 2026-06-11
 

--- a/extensions/stock-api-flask/CHANGELOG.md
+++ b/extensions/stock-api-flask/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Stock API using Flask extension will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-06-22
+
+### Changed
+
+- Updated `numpy` and `pandas` to versions with Python 3.14 wheels so the content runs on Connect releases that ship Python 3.14.
+
 ## [1.0.2] - 2026-06-11
 
 ### Changed

--- a/extensions/stock-api-flask/manifest.json
+++ b/extensions/stock-api-flask/manifest.json
@@ -15,11 +15,11 @@
     "requiredFeatures": [
       "API Publishing"
     ],
-    "version": "1.0.2"
+    "version": "1.0.3"
   },
   "environment": {
     "python": {
-      "requires": "~=3.10"
+      "requires": "~=3.11"
     }
   },
   "python": {
@@ -32,7 +32,7 @@
   },
   "files": {
     "requirements.txt": {
-      "checksum": "1176e07be1c7afaac370e4b0b5e67823"
+      "checksum": "1c3853a90c062f67462d9d50c6cdb479"
     },
     "README.md": {
       "checksum": "aa9afd650003a1220c22340a26206ea5"

--- a/extensions/stock-api-flask/manifest.json
+++ b/extensions/stock-api-flask/manifest.json
@@ -19,7 +19,7 @@
   },
   "environment": {
     "python": {
-      "requires": "~=3.11"
+      "requires": "~=3.10"
     }
   },
   "python": {
@@ -32,7 +32,7 @@
   },
   "files": {
     "requirements.txt": {
-      "checksum": "1c3853a90c062f67462d9d50c6cdb479"
+      "checksum": "548484c00d47f3a7599c888fe49936d5"
     },
     "README.md": {
       "checksum": "aa9afd650003a1220c22340a26206ea5"

--- a/extensions/stock-api-flask/requirements.txt
+++ b/extensions/stock-api-flask/requirements.txt
@@ -1,4 +1,4 @@
 flask==3.0.2
 flask-restx==1.3.0
 pandas==2.3.3
-numpy==2.3.3
+numpy>=2.2,<3

--- a/extensions/stock-api-flask/requirements.txt
+++ b/extensions/stock-api-flask/requirements.txt
@@ -1,4 +1,4 @@
 flask==3.0.2
 flask-restx==1.3.0
-pandas==2.2.3
-numpy==2.1.2
+pandas==2.3.3
+numpy==2.3.3

--- a/extensions/stock-dashboard-python/CHANGELOG.md
+++ b/extensions/stock-dashboard-python/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated `pandas` to a version with Python 3.14 wheels so the content runs on Connect releases that ship Python 3.14.
+- Updated `pandas` to a version with Python 3.14 wheels so the content runs on Connect releases that ship Python 3.14. (#398)
 
 ## [1.0.2] - 2026-06-11
 

--- a/extensions/stock-dashboard-python/CHANGELOG.md
+++ b/extensions/stock-dashboard-python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Stock Dashboard using Python extension will be docume
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-06-22
+
+### Changed
+
+- Updated `pandas` to a version with Python 3.14 wheels so the content runs on Connect releases that ship Python 3.14.
+
 ## [1.0.2] - 2026-06-11
 
 ### Changed

--- a/extensions/stock-dashboard-python/manifest.json
+++ b/extensions/stock-dashboard-python/manifest.json
@@ -12,11 +12,11 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/stock-dashboard-python",
     "category": "example",
     "minimumConnectVersion": "2025.04.0",
-    "version": "1.0.2"
+    "version": "1.0.3"
   },
   "environment": {
     "python": {
-      "requires": "~=3.9"
+      "requires": "~=3.11"
     }
   },
   "python": {
@@ -29,7 +29,7 @@
   },
   "files": {
     "requirements.txt": {
-      "checksum": "db16a5cec00d3daca9a7359fceaf4da6"
+      "checksum": "c72a7a5ac36ed0b23fef595469246b4b"
     },
     "README.md": {
       "checksum": "04838bc8a8810526a01a2a13877e04fb"

--- a/extensions/stock-dashboard-python/manifest.json
+++ b/extensions/stock-dashboard-python/manifest.json
@@ -16,7 +16,7 @@
   },
   "environment": {
     "python": {
-      "requires": "~=3.11"
+      "requires": "~=3.9"
     }
   },
   "python": {

--- a/extensions/stock-dashboard-python/requirements.txt
+++ b/extensions/stock-dashboard-python/requirements.txt
@@ -1,4 +1,4 @@
 dash==2.16.0
 dash_bootstrap_components==1.5.0
-pandas==2.2.3
+pandas==2.3.3
 plotly==5.24.1


### PR DESCRIPTION
The [weekly run](https://github.com/posit-dev/connect-extensions/actions/runs/27939082029) failed for five extensions. This PR aims to fix them.

* `package-vulnerability-scanner` and `publisher-command-center`: both mount a built `dist/` that is gitignored, but the weekly workflow tarred the directory without building it. The workflow now runs `npm run build` for any extension with a `package.json` before packaging.
* `stock-api-flask`, `stock-dashboard-python`, `pqr`: each pinned a `numpy`/`pandas` version with no Python 3.14 wheel, so on the 3.14-only image they were built from source and broke. Bumped to versions with 3.14 wheels.