### PR TITLE
fix(scripts): pin Quarto render to the script entrypoint

### DIFF
--- a/extensions/script-python/_quarto.yml
+++ b/extensions/script-python/_quarto.yml
@@ -1,2 +1,7 @@
 project:
   title: "Penguin data transformations"
+  # Render only the script so it is the unambiguous primary document.
+  # Without this, Quarto also renders sibling Markdown (e.g. CHANGELOG.md)
+  # and the default served document can become that file instead.
+  render:
+    - script.py

--- a/extensions/script-python/manifest.json
+++ b/extensions/script-python/manifest.json
@@ -46,7 +46,7 @@
       "checksum": "95deb7521ff8998bee968374533e61e5"
     },
     "_quarto.yml": {
-      "checksum": "e5bfdf389c2ae3bc115d8f4add41fc2f"
+      "checksum": "4d974e712cab1ec376519adb218e3d12"
     },
     "script.py": {
       "checksum": "94e1a7707bef08a4812428cdd9b0f953"

--- a/extensions/script-r/_quarto.yml
+++ b/extensions/script-r/_quarto.yml
@@ -1,2 +1,7 @@
 project:
   title: "Penguin data transformations"
+  # Render only the script so it is the unambiguous primary document.
+  # Without this, Quarto also renders sibling Markdown (e.g. CHANGELOG.md)
+  # and the default served document can become that file instead.
+  render:
+    - script.R

--- a/extensions/script-r/manifest.json
+++ b/extensions/script-r/manifest.json
@@ -766,7 +766,7 @@
   },
   "files": {
     "_quarto.yml": {
-      "checksum": "e5bfdf389c2ae3bc115d8f4add41fc2f"
+      "checksum": "6f804dc006eb9eebf2305b37812940fd"
     },
     "script.R": {
       "checksum": "bc99a676344f7d4556bd39cece482555"


### PR DESCRIPTION
Pins each script extension's Quarto project to render only its script, so the served content is always the rendered script rather than a sibling Markdown file.

Quarto treats `CHANGELOG.md` as a render input (it ignores `README.md`, but not `CHANGELOG.md`). With `primary_html` unset, a bundle containing both rendered two HTML outputs and the default served document could resolve to `CHANGELOG.html`. Scoping `project.render` to the script removes the ambiguity.

- `extensions/script-{r,python}/_quarto.yml`: add a `project.render` list limited to `script.R` / `script.py`.
- `extensions/script-{r,python}/manifest.json`: refresh the `_quarto.yml` checksum to match.

**Verify**
```
quarto inspect extensions/script-r       # files.input -> ['script.R']
quarto inspect extensions/script-python  # files.input -> ['script.py']
```

Targets `polish-script-pair` so CI publishes a fresh `script-*.tar.gz` artifact to confirm the deployed content serves the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)