### PR TITLE
Polish landing page

### DIFF
--- a/extensions/landing-page/CHANGELOG.md
+++ b/extensions/landing-page/CHANGELOG.md
@@ -16,3 +16,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the broken "contact us" link (`href="#"`). (#404)
 - Fixed invalid FAQ markup (answer paragraphs were direct children of `<ul>`). (#404)
+- Removed `maximum-scale=1.0` from the viewport meta so the page allows pinch-zoom (accessibility). (#404)

--- a/extensions/landing-page/CHANGELOG.md
+++ b/extensions/landing-page/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rewrote the title (`HTML: Landing Page`), description, and README so the example clearly explains the static organization-landing-page pattern and how to customize it. (#404)
+- Rewrote the title (`Static HTML: Landing Page`), description, and README so the example clearly explains the static organization-landing-page pattern and how to customize it. (#404)
 - Replaced the placeholder FAQ (off-topic grant-policy boilerplate) with on-topic questions about finding, accessing, and publishing content on Connect, and added "replace this" comments at each customizable spot in `index.html`. (#404)
 
 ### Fixed
 
-- Fixed the broken "contact us" link (`href="#"`) and re-pointed the onboarding link from Wikipedia to a customizable placeholder. (#404)
+- Fixed the broken "contact us" link (`href="#"`). (#404)
 - Fixed invalid FAQ markup (answer paragraphs were direct children of `<ul>`). (#404)

--- a/extensions/landing-page/CHANGELOG.md
+++ b/extensions/landing-page/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rewrote the title (`Static HTML: Landing Page`), description, and README so the example clearly explains the static organization-landing-page pattern and how to customize it. (#404)
-- Replaced the placeholder FAQ (off-topic grant-policy boilerplate) with on-topic questions about finding, accessing, and publishing content on Connect, and added "replace this" comments at each customizable spot in `index.html`. (#404)
+- Rewrote the title (`Static HTML: Landing Page`), description, and README so the example clearly explains the static organization-landing-page pattern and how to customize it. (#409)
+- Replaced the placeholder FAQ (off-topic grant-policy boilerplate) with on-topic questions about finding, accessing, and publishing content on Connect, and added "replace this" comments at each customizable spot in `index.html`. (#409)
 
 ### Fixed
 
-- Fixed the broken "contact us" link (`href="#"`). (#404)
-- Fixed invalid FAQ markup (answer paragraphs were direct children of `<ul>`). (#404)
-- Removed `maximum-scale=1.0` from the viewport meta so the page allows pinch-zoom (accessibility). (#404)
+- Fixed the broken "contact us" link (`href="#"`). (#409)
+- Fixed invalid FAQ markup (answer paragraphs were direct children of `<ul>`). (#409)
+- Removed `maximum-scale=1.0` from the viewport meta so the page allows pinch-zoom (accessibility). (#409)

--- a/extensions/landing-page/CHANGELOG.md
+++ b/extensions/landing-page/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to the Landing Page example will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1] - 2026-06-25
+
+### Changed
+
+- Rewrote the title (`HTML: Landing Page`), description, and README so the example clearly explains the static organization-landing-page pattern and how to customize it. (#404)
+- Replaced the placeholder FAQ (off-topic grant-policy boilerplate) with on-topic questions about finding, accessing, and publishing content on Connect, and added "replace this" comments at each customizable spot in `index.html`. (#404)
+
+### Fixed
+
+- Fixed the broken "contact us" link (`href="#"`) and re-pointed the onboarding link from Wikipedia to a customizable placeholder. (#404)
+- Fixed invalid FAQ markup (answer paragraphs were direct children of `<ul>`). (#404)

--- a/extensions/landing-page/README.md
+++ b/extensions/landing-page/README.md
@@ -1,8 +1,35 @@
-# Landing page
+# HTML: Landing Page
 
 ## About this example
 
-A simple static HTML web page that can be served from Connect.
+A static HTML landing page served from Posit Connect. It gives your organization
+a branded "front door" that welcomes your team, points them to key resources, and
+links out to the content you publish. It uses no Connect API and has no
+server-side code; it's just static files, which makes it the simplest way to put
+a custom page in front of your Connect deployment.
+
+## Who it's for
+
+Teams who want a friendly, branded entry point to their published reports, apps,
+and datasets, rather than sending people straight to a raw content listing.
+
+## Customize it
+
+The page is a template built around a placeholder "Example Organization." Make it
+your own by editing `index.html` (each customizable spot is flagged with an HTML
+comment):
+
+- Replace "Example Organization" throughout with your organization's name.
+- Replace `images/logo.png` with your own logo (it's set as the hero background
+  image in `css/example-landing.css`).
+- Point the "Getting Started Guide" link and the contact `mailto:` address at your
+  own onboarding doc and team email.
+- Swap the sample FAQs for the questions your users actually ask.
+
+## Deploy
+
+Publish the directory as static content with `rsconnect deploy html`, or push it
+through a git-backed deployment. There's nothing to build.
 
 ## Requirements
 

--- a/extensions/landing-page/README.md
+++ b/extensions/landing-page/README.md
@@ -1,4 +1,4 @@
-# HTML: Landing Page
+# Static HTML: Landing Page
 
 ## About this example
 
@@ -8,10 +8,9 @@ links out to the content you publish. It uses no Connect API and has no
 server-side code; it's just static files, which makes it the simplest way to put
 a custom page in front of your Connect deployment.
 
-## Who it's for
-
-Teams who want a friendly, branded entry point to their published reports, apps,
-and datasets, rather than sending people straight to a raw content listing.
+It's for teams who want a friendly, branded entry point to their published
+reports, apps, and datasets, rather than sending people straight to a raw content
+listing.
 
 ## Customize it
 
@@ -28,9 +27,10 @@ comment):
 
 ## Deploy
 
-Publish the directory as static content with `rsconnect deploy html`, or push it
-through a git-backed deployment. There's nothing to build.
+Deploy it straight from the Connect Gallery to get a copy running, then customize
+it. To publish your customized version, use `rsconnect deploy html` or a
+git-backed deployment; there's nothing to build.
 
-## Requirements
+## Learn more
 
-* None
+* [Publish static content to Posit Connect](https://docs.posit.co/connect/user/publishing-cli-html/index.html)

--- a/extensions/landing-page/README.md
+++ b/extensions/landing-page/README.md
@@ -27,8 +27,10 @@ comment):
 
 ## Deploy it
 
-Deploy it straight from the Connect Gallery to get a copy running, then customize
-it. To publish your own version, deploy the directory with
+Deploy it straight from the Connect Gallery to get a copy running and try it
+as-is. To run a customized version, get the
+[example source](https://github.com/posit-dev/connect-extensions/tree/main/extensions/landing-page),
+make your changes, and publish with
 [`rsconnect deploy html`](https://docs.posit.co/rsconnect-python/) or a
 [git-backed deployment](https://docs.posit.co/connect/user/git-backed/); there's
 nothing to build.

--- a/extensions/landing-page/README.md
+++ b/extensions/landing-page/README.md
@@ -8,9 +8,9 @@ links out to the content you publish. It uses no Connect API and has no
 server-side code; it's just static files, which makes it the simplest way to put
 a custom page in front of your Connect deployment.
 
-It's for teams who want a friendly, branded entry point to their published
-reports, apps, and datasets, rather than sending people straight to a raw content
-listing.
+A custom landing page like this is for teams who want a friendly, branded entry
+point to their published reports, apps, and datasets, rather than sending people
+straight to a raw content listing.
 
 ## Customize it
 
@@ -25,12 +25,14 @@ comment):
   own onboarding doc and team email.
 - Swap the sample FAQs for the questions your users actually ask.
 
-## Deploy
+## Deploy it
 
 Deploy it straight from the Connect Gallery to get a copy running, then customize
-it. To publish your customized version, use `rsconnect deploy html` or a
-git-backed deployment; there's nothing to build.
+it. To publish your own version, deploy the directory with
+[`rsconnect deploy html`](https://docs.posit.co/rsconnect-python/) or a
+[git-backed deployment](https://docs.posit.co/connect/user/git-backed/); there's
+nothing to build.
 
 ## Learn more
 
-* [Publish static content to Posit Connect](https://docs.posit.co/connect/user/publishing-cli-html/index.html)
+- [Publish static content to Posit Connect](https://docs.posit.co/connect/user/publishing-cli-html/index.html)

--- a/extensions/landing-page/css/example-landing.css
+++ b/extensions/landing-page/css/example-landing.css
@@ -12,6 +12,7 @@ body {
   .band.hero {
     height: 200px;
     background-color: #aaa;
+    /* Replace images/logo.png with your organization's logo. */
     background-image: url(../images/logo.png);
     background-size: 400px 200px;
     background-repeat: no-repeat;
@@ -41,5 +42,3 @@ body {
       background-position: left center; }
   .bandContent ul p {
     line-height: 20px; }
-
-/*# sourceMappingURL=example-landing.css.map */

--- a/extensions/landing-page/index.html
+++ b/extensions/landing-page/index.html
@@ -20,9 +20,9 @@
       <div class="bandContent intro">
         <p>If you're new to exploring data here at Example Organization, we recommend you start by looking at the following document:</p>
         <!-- Point this at your own onboarding doc (e.g. a report published on Connect). -->
-        <p><a class="introDoc" target="_parent" href="https://en.wikipedia.org/wiki/Data_science">Getting Started Guide</a></p>
+        <p><a class="introDoc" target="_parent" href="https://docs.posit.co/connect/user/">Getting Started Guide</a></p>
         <!-- Replace with your team's contact address. -->
-        <p>Otherwise, dive right in! And <a href="mailto:data-team@example.com">please contact us</a> if you have any issues, or there are areas of data research that you'd like us to explore for you!</p>
+        <p>Otherwise, dive right in! And <a href="mailto:data-team@example.com">please contact us</a> if you have any issues!</p>
       </div>
 
       <!-- Replace these with questions your own users commonly ask. -->

--- a/extensions/landing-page/index.html
+++ b/extensions/landing-page/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <title>Data Science at Example Organization</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <link rel='stylesheet' href='./css/example-landing.css' />
   </head>
   <body>

--- a/extensions/landing-page/index.html
+++ b/extensions/landing-page/index.html
@@ -1,37 +1,44 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <title>Example Landing Page</title>
+    <title>Data Science at Example Organization</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <link rel='stylesheet' href='./css/example-landing.css' />
   </head>
   <body>
+    <!-- Hero banner. The logo is set as a background image in css/example-landing.css
+         (.band.hero); replace images/logo.png with your organization's logo. -->
     <div class="band hero"></div>
 
     <div class="band">
 
+      <!-- Replace "Example Organization" throughout with your organization's name. -->
       <div class="bandContent">
         <h1>Welcome to Data Science at Example Organization!</h1>
       </div>
 
       <div class="bandContent intro">
         <p>If you're new to exploring data here at Example Organization, we recommend you start by looking at the following document:</p>
-        <p><a class="introDoc" target="_parent" href="https://en.wikipedia.org/wiki/Data_science">Intro Doc</a></p>
-        <p>Otherwise, dive right in! And <a href="#">please contact us</a> if you have any issues, or there are areas of data research that you'd like us to explore for you!</p>
+        <!-- Point this at your own onboarding doc (e.g. a report published on Connect). -->
+        <p><a class="introDoc" target="_parent" href="https://example.com/data-science-onboarding">Getting Started Guide</a></p>
+        <!-- Replace with your team's contact address. -->
+        <p>Otherwise, dive right in! And <a href="mailto:data-team@example.com">please contact us</a> if you have any issues, or there are areas of data research that you'd like us to explore for you!</p>
       </div>
 
+      <!-- Replace these with questions your own users commonly ask. -->
       <div class="bandContent">
         <h1>FAQs</h1>
         <ul>
-          <li>Who benefits from data sharing?</li>
-          <p>Everyone benefits, including investigators, funding agencies, the scientific community, and, most importantly, the public. Data sharing provides more effective use of NIH resources by avoiding unnecessary duplication of data collection. It also conserves research funds to support more investigators. The initial investigator benefits, because as the data are used and published more broadly, the initial investigator's reputation grows.</p>
-          <li>Is data sharing widely accepted as a good practice?</li>
-          <p>National scientific organizations have made a commitment to the sharing and archiving of data through their ethical codes (e.g., the American Sociological Association) or publication policies (e.g., the American Psychological Association). More than 15 years ago, the National Academy of Sciences described the benefits of sharing data. (See http://books.nap.edu/catalog/2033.html) For many years, the National Science Foundation (NSF) Economics Program has required data underlying an article arising from an NSF grant to be placed in a public archive. Similar expectations exist at the National Institute of Justice. Moreover, many scientific journals require that authors make available the data included in their publications. In the biological sciences, protein and DNA sequences are made available to researchers through data archives, such as GenBank. Since 1996, NIH has required data sharing in several areas, such as DNA sequences, mapping information, and crystallographic coordinates.</p>
-          <li>What kinds of data are candidates for sharing?</li>
-          <p>Potentially all kinds of data are candidates for sharing, but unique data are especially important. Some biologic sciences already have data-sharing plans in place, such as genetic mapping. But other basic science data are also amenable to sharing. Data from human subjects (e.g., surveys, clinical studies) also can be shared if the identity and privacy of research participants can be protected.</p>
-          <li>I don't want to share my data, which were generated under an NIH grant. Can I be forced to do so?</li>
-          <p>When the PI and the authorized institutional official sign the face page of an NIH application, they are assuring compliance with policies and regulations governing research awards. NIH expects grantees to follow these rules and to conduct the work described in the application. Thus, if an application describes a data sharing plan, NIH expects that plan to be enacted. In some instances, for example, NIH may make data sharing a term and condition of award.</p>
+          <li>How do I find published content?
+            <p>Browse the links on this page, or open your Connect dashboard and use search and tags to find a report, app, or dataset. The Getting Started Guide above is a good first stop.</p>
+          </li>
+          <li>How do I request access to a dataset or report?
+            <p>Access to each piece of content is managed by its owner. Email the data team (or the content's owner) and we'll grant you the right permissions.</p>
+          </li>
+          <li>Can I publish my own work here?
+            <p>Yes. If you have a publisher account on Connect, you can deploy your own reports, apps, and APIs. Reach out to the data team and we'll help you get set up.</p>
+          </li>
         </ul>
       </div>
     </div>

--- a/extensions/landing-page/index.html
+++ b/extensions/landing-page/index.html
@@ -21,7 +21,7 @@
       <div class="bandContent intro">
         <p>If you're new to exploring data here at Example Organization, we recommend you start by looking at the following document:</p>
         <!-- Point this at your own onboarding doc (e.g. a report published on Connect). -->
-        <p><a class="introDoc" target="_parent" href="https://example.com/data-science-onboarding">Getting Started Guide</a></p>
+        <p><a class="introDoc" target="_parent" href="https://en.wikipedia.org/wiki/Data_science">Getting Started Guide</a></p>
         <!-- Replace with your team's contact address. -->
         <p>Otherwise, dive right in! And <a href="mailto:data-team@example.com">please contact us</a> if you have any issues, or there are areas of data research that you'd like us to explore for you!</p>
       </div>

--- a/extensions/landing-page/index.html
+++ b/extensions/landing-page/index.html
@@ -3,7 +3,6 @@
   <head>
     <title>Data Science at Example Organization</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
-    <meta name="mobile-web-app-capable" content="yes" />
     <link rel='stylesheet' href='./css/example-landing.css' />
   </head>
   <body>

--- a/extensions/landing-page/manifest.json
+++ b/extensions/landing-page/manifest.json
@@ -30,7 +30,7 @@
       "checksum": "38472dc2c802db2abbc2ee5c7204632d"
     },
     "index.html": {
-      "checksum": "5809ce9d6bf7d8126dd145322cea8ce6"
+      "checksum": "ad9f113dcab466bfe4ea3bb966ff771d"
     },
     "README.md": {
       "checksum": "b790eaf4af774d4322c0983069d3871d"

--- a/extensions/landing-page/manifest.json
+++ b/extensions/landing-page/manifest.json
@@ -30,7 +30,7 @@
       "checksum": "38472dc2c802db2abbc2ee5c7204632d"
     },
     "index.html": {
-      "checksum": "b8faba62044b1a42b2d3922c434b21ad"
+      "checksum": "babbed6a80953c0677452108e5cce015"
     },
     "README.md": {
       "checksum": "bbff6d8bf9e2c5a2e59626fbd43b3924"

--- a/extensions/landing-page/manifest.json
+++ b/extensions/landing-page/manifest.json
@@ -12,7 +12,7 @@
   "extension": {
     "name": "landing-page",
     "title": "Static HTML: Landing Page",
-    "description": "A static HTML landing page for Connect. It gives your team a branded front door that links to the content you publish, with no app or API to build. Customize the copy, logo, and links for any organization.",
+    "description": "A static HTML landing page for your Connect server: a simple, branded front door that welcomes your team and links out to the reports, apps, and datasets you publish, instead of dropping people on a plain content list. Customize it with your own name, logo, links, and FAQs.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/landing-page",
     "category": "example",
     "minimumConnectVersion": "2025.04.0",

--- a/extensions/landing-page/manifest.json
+++ b/extensions/landing-page/manifest.json
@@ -30,7 +30,7 @@
       "checksum": "38472dc2c802db2abbc2ee5c7204632d"
     },
     "index.html": {
-      "checksum": "ad9f113dcab466bfe4ea3bb966ff771d"
+      "checksum": "da552804f5c9dd70222b2fbaa2768302"
     }
   },
   "users": null

--- a/extensions/landing-page/manifest.json
+++ b/extensions/landing-page/manifest.json
@@ -31,9 +31,6 @@
     },
     "index.html": {
       "checksum": "ad9f113dcab466bfe4ea3bb966ff771d"
-    },
-    "README.md": {
-      "checksum": "b790eaf4af774d4322c0983069d3871d"
     }
   },
   "users": null

--- a/extensions/landing-page/manifest.json
+++ b/extensions/landing-page/manifest.json
@@ -11,17 +11,17 @@
   },
   "extension": {
     "name": "landing-page",
-    "title": "Static HTML landing page",
-    "description": "A simple static HTML web page that can be served from Connect",
+    "title": "HTML: Landing Page",
+    "description": "A static HTML landing page for Connect. It gives your team a branded front door that links to the content you publish, with no app or API to build. Customize the copy, logo, and links for any organization.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/landing-page",
     "category": "example",
     "minimumConnectVersion": "2025.04.0",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "packages": null,
   "files": {
     "css/example-landing.css": {
-      "checksum": "d5ab84ce8482341785ad7798f272fcc5"
+      "checksum": "63a878ef3a179295711414cca26976da"
     },
     "images/info.png": {
       "checksum": "184edb1e9b490e26bf93081274d45928"
@@ -30,10 +30,10 @@
       "checksum": "38472dc2c802db2abbc2ee5c7204632d"
     },
     "index.html": {
-      "checksum": "5a39c2d4fea53f9e4d8870b6370facc4"
+      "checksum": "b8faba62044b1a42b2d3922c434b21ad"
     },
     "README.md": {
-      "checksum": "31098f057b98fd974710bfc93d8eeee2"
+      "checksum": "bbff6d8bf9e2c5a2e59626fbd43b3924"
     }
   },
   "users": null

--- a/extensions/landing-page/manifest.json
+++ b/extensions/landing-page/manifest.json
@@ -11,7 +11,7 @@
   },
   "extension": {
     "name": "landing-page",
-    "title": "HTML: Landing Page",
+    "title": "Static HTML: Landing Page",
     "description": "A static HTML landing page for Connect. It gives your team a branded front door that links to the content you publish, with no app or API to build. Customize the copy, logo, and links for any organization.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/landing-page",
     "category": "example",
@@ -30,10 +30,10 @@
       "checksum": "38472dc2c802db2abbc2ee5c7204632d"
     },
     "index.html": {
-      "checksum": "babbed6a80953c0677452108e5cce015"
+      "checksum": "5809ce9d6bf7d8126dd145322cea8ce6"
     },
     "README.md": {
-      "checksum": "bbff6d8bf9e2c5a2e59626fbd43b3924"
+      "checksum": "b790eaf4af774d4322c0983069d3871d"
     }
   },
   "users": null


### PR DESCRIPTION
Fixes #404 
- New title, description, README, and comments to guide/teach a user
- Update FAQs
- Fix dead "contact us" link
- Fix invalid FAQ markup and modernize a deprecated meta tag
- Drop a stale CSS sourceMappingURL line
- Add CHANGELOG.md, bump 1.0.0 to 1.0.1, refresh checksums