### PR TITLE
Polish quarto presentation

### DIFF
--- a/extensions/quarto-presentation/.gitignore
+++ b/extensions/quarto-presentation/.gitignore
@@ -1,3 +1,4 @@
 /.quarto/
 index.html
 index_files
+**/*.quarto_ipynb

--- a/extensions/quarto-presentation/CHANGELOG.md
+++ b/extensions/quarto-presentation/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Retitled to `Quarto: Presentation` and rewrote the description and README around the reveal.js slide-deck pattern.
-- Reworked the deck into a teaching showcase of what a Quarto slide can hold: an overview with doc links, a syntax-highlighted code block, a Mermaid diagram, an interactive Observable JS chart, a multi-column and incremental-reveal slide, and a publish-to-Connect slide. The sample content carries a light business flavor (a quarterly revenue readout). (#405)
-- Loaded the chart from a small bundled `data.csv` you can swap out, instead of Observable's external `olympians` sample dataset. (#405)
-- Pinned the Quarto project to render only `index.qmd` so the changelog is not rendered as a stray page, and added explanatory comments. (#405)
+- Retitled to `Quarto: Presentation` and rewrote the description and README around the reveal.js slide-deck pattern. (#410)
+- Reworked the deck into a teaching showcase of what a Quarto slide can hold: an overview with doc links, a syntax-highlighted code block, a Mermaid diagram, an interactive Observable JS chart, a multi-column and incremental-reveal slide, and a publish-to-Connect slide. The sample content carries a light business flavor (a quarterly revenue readout). (#410)
+- Loaded the chart from a small bundled `data.csv` that can be swapped out, instead of Observable's external `olympians` sample dataset. (#410)
+- Pinned the Quarto project to render only `index.qmd` so the changelog is not rendered as a stray page, and added explanatory comments. (#410)

--- a/extensions/quarto-presentation/CHANGELOG.md
+++ b/extensions/quarto-presentation/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to the Quarto Presentation example will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1] - 2026-06-25
+
+### Changed
+
+- Retitled to `Quarto: Presentation` and rewrote the description and README around the reveal.js slide-deck pattern.
+- Reworked the deck into a teaching showcase of what a Quarto slide can hold: an overview with doc links, a syntax-highlighted code block, a Mermaid diagram, an interactive Observable JS chart, a multi-column and incremental-reveal slide, and a publish-to-Connect slide. The sample content carries a light business flavor (a quarterly revenue readout). (#405)
+- Loaded the chart from a small bundled `data.csv` you can swap out, instead of Observable's external `olympians` sample dataset. (#405)
+- Pinned the Quarto project to render only `index.qmd` so the changelog is not rendered as a stray page, and added explanatory comments. (#405)

--- a/extensions/quarto-presentation/README.md
+++ b/extensions/quarto-presentation/README.md
@@ -1,12 +1,38 @@
-# Quarto Presentation
+# Quarto: Presentation
 
 ## About this example
 
-This presentation is generated using Quarto and reveal.js. It demonstrates
-how you might use code to highlight your work.
+A reveal.js slide deck built with Quarto that showcases what you can put on a
+slide and publish to Connect: formatted prose, syntax-highlighted code,
+diagrams, interactive charts, and multi-column or incremental layouts. Use it as
+a starting point for any presentation. The sample content carries a light
+business flavor (a quarterly revenue readout) that you can swap for your own.
 
+## Who it's for
+
+Anyone who wants presentation slides that are version-controlled and
+reproducible, and served from Connect alongside their other content.
+
+## What's inside
+
+The deck (`index.qmd`) is roughly one slide per capability, each linking to its
+Quarto docs:
+
+- **What goes on a slide**: an overview of the features, with links.
+- **Show your work with code**: a syntax-highlighted code block (Quarto can also
+  execute R, Python, and Julia and embed the output).
+- **Diagrams**: a Mermaid diagram drawn from text.
+- **Interactive charts**: an Observable JS chart with a segment filter, loaded
+  from a bundled `data.csv` you can swap out.
+- **Layout and reveals**: a multi-column slide with an incremental list.
+- **Publish to Connect**: how to render and publish.
+
+## Render and publish
+
+Preview locally with `quarto preview`, render with `quarto render`, then publish
+the directory to Connect, where it deploys as static content.
 
 ## Learn more
 
-* [Quarto](https://quarto.org)
-* [reveal.js](https://revealjs.com)
+* [Quarto presentations](https://quarto.org/docs/presentations/)
+* [reveal.js presentations](https://quarto.org/docs/presentations/revealjs/)

--- a/extensions/quarto-presentation/README.md
+++ b/extensions/quarto-presentation/README.md
@@ -29,14 +29,15 @@ Edit `index.qmd` to change the slides, swap the chart's `data.csv` for your own
 figures, and replace the placeholder title, author, and footer. Preview your
 changes with `quarto preview`.
 
-## Deploy
+## Deploy it
 
 Deploy it straight from the Connect Gallery to get a copy running. To publish
-your customized version, deploy the directory with `rsconnect deploy quarto` or a
-git-backed deployment; Connect serves it as static content. Rendering requires
-Quarto 1.6 or newer.
+your own version, deploy the directory with
+[`quarto publish connect`](https://quarto.org/docs/publishing/rstudio-connect.html)
+or a [git-backed deployment](https://docs.posit.co/connect/user/git-backed/);
+Connect serves it as static content. Rendering requires Quarto 1.6 or newer.
 
 ## Learn more
 
-* [Quarto presentations](https://quarto.org/docs/presentations/)
-* [reveal.js presentations](https://quarto.org/docs/presentations/revealjs/)
+- [Quarto presentations](https://quarto.org/docs/presentations/)
+- [reveal.js presentations](https://quarto.org/docs/presentations/revealjs/)

--- a/extensions/quarto-presentation/README.md
+++ b/extensions/quarto-presentation/README.md
@@ -3,17 +3,13 @@
 ## About this example
 
 A reveal.js slide deck built with Quarto that showcases what you can put on a
-slide and publish to Connect: formatted prose, syntax-highlighted code,
-diagrams, interactive charts, and multi-column or incremental layouts. Use it as
-a starting point for any presentation. The sample content carries a light
+slide and publish to Connect: formatted prose, syntax-highlighted code, diagrams,
+interactive charts, and multi-column or incremental layouts. It's for anyone who
+wants presentation slides that are version-controlled and reproducible, served
+from Connect alongside their other content. The sample content carries a light
 business flavor (a quarterly revenue readout) that you can swap for your own.
 
-## Who it's for
-
-Anyone who wants presentation slides that are version-controlled and
-reproducible, and served from Connect alongside their other content.
-
-## What's inside
+## How it works
 
 The deck (`index.qmd`) is roughly one slide per capability, each linking to its
 Quarto docs:
@@ -27,10 +23,18 @@ Quarto docs:
 - **Layout and reveals**: a multi-column slide with an incremental list.
 - **Publish to Connect**: how to render and publish.
 
-## Render and publish
+## Customize it
 
-Preview locally with `quarto preview`, render with `quarto render`, then publish
-the directory to Connect, where it deploys as static content.
+Edit `index.qmd` to change the slides, swap the chart's `data.csv` for your own
+figures, and replace the placeholder title, author, and footer. Preview your
+changes with `quarto preview`.
+
+## Deploy
+
+Deploy it straight from the Connect Gallery to get a copy running. To publish
+your customized version, deploy the directory with `rsconnect deploy quarto` or a
+git-backed deployment; Connect serves it as static content. Rendering requires
+Quarto 1.6 or newer.
 
 ## Learn more
 

--- a/extensions/quarto-presentation/_quarto.yml
+++ b/extensions/quarto-presentation/_quarto.yml
@@ -1,2 +1,5 @@
 project:
-  title: Quarto Presentation
+  # Render only the deck so sibling Markdown (e.g. CHANGELOG.md) is not
+  # rendered into the output as a stray page.
+  render:
+    - index.qmd

--- a/extensions/quarto-presentation/data.csv
+++ b/extensions/quarto-presentation/data.csv
@@ -1,0 +1,9 @@
+quarter,segment,revenue
+Q1,Enterprise,420
+Q1,SMB,180
+Q2,Enterprise,470
+Q2,SMB,210
+Q3,Enterprise,520
+Q3,SMB,250
+Q4,Enterprise,580
+Q4,SMB,300

--- a/extensions/quarto-presentation/index.qmd
+++ b/extensions/quarto-presentation/index.qmd
@@ -13,7 +13,7 @@ format:
 
 ## What goes on a slide
 
-Quarto turns plain text into [reveal.js](https://quarto.org/docs/presentations/revealjs/) slides. A single deck can combine:
+Quarto turns plain text into [reveal.js](https://quarto.org/docs/presentations/revealjs/) slides. A deck can combine:
 
 *   Formatted prose, lists, and math
 *   [Highlighted code blocks](https://quarto.org/docs/presentations/revealjs/#code-blocks) in any language, executable in R, Python, or Julia

--- a/extensions/quarto-presentation/index.qmd
+++ b/extensions/quarto-presentation/index.qmd
@@ -13,7 +13,7 @@ format:
 
 ## What goes on a slide
 
-Quarto turns plain text into [reveal.js](https://quarto.org/docs/presentations/revealjs/) slides. A deck can combine:
+Quarto turns plain text into [reveal.js](https://quarto.org/docs/presentations/revealjs/) slides. A deck can have:
 
 *   Formatted prose, lists, and math
 *   [Highlighted code blocks](https://quarto.org/docs/presentations/revealjs/#code-blocks) in any language, executable in R, Python, or Julia

--- a/extensions/quarto-presentation/index.qmd
+++ b/extensions/quarto-presentation/index.qmd
@@ -41,7 +41,7 @@ Beyond highlighted code blocks, Quarto can also run R, Python, and Julia directl
 ## Diagrams
 
 ::: aside
-This is drawn from text with a [Mermaid diagram](https://quarto.org/docs/authoring/diagrams.html).
+[Mermaid](https://quarto.org/docs/authoring/diagrams.html) turns a plain-text description into this diagram.
 :::
 
 ```{mermaid}
@@ -107,7 +107,7 @@ Next steps:
 ## Publish to Connect
 
 *   Preview your deck locally with `quarto preview`, then render it with `quarto render`.
-*   Publish the directory to Connect, where it serves as static content.
+*   Publish the directory to Connect with [`quarto publish connect`](https://quarto.org/docs/publishing/rstudio-connect.html), where it serves as static content.
 *   Control who can view it and share a link, all from Connect.
 
 Learn more: [Quarto presentations](https://quarto.org/docs/presentations/) and [reveal.js](https://quarto.org/docs/presentations/revealjs/).

--- a/extensions/quarto-presentation/index.qmd
+++ b/extensions/quarto-presentation/index.qmd
@@ -1,60 +1,113 @@
 ---
-title: Quarto Presentation
-author: Tidy Writer
+# A reveal.js slide deck. `format: revealjs` is what makes this Quarto
+# document render as slides instead of a page. Replace the title, author,
+# and footer below with your own.
+title: "Presentations with Quarto"
+subtitle: "Mix prose, code, diagrams, and interactivity in one deck, then publish it to Connect."
+author: "Example Organization"
 date: today
 format:
   revealjs:
-    footer: "Example Footer"
+    footer: "Example Organization"
 ---
 
-## Overview
+## What goes on a slide
 
-*   Quarto supports a number of [presentation
-    formats](https://quarto.org/docs/presentations/).
+Quarto turns plain text into [reveal.js](https://quarto.org/docs/presentations/revealjs/) slides. A single deck can combine:
 
-     *   This presentation uses
-         [reveal.js](https://quarto.org/docs/presentations/revealjs/).
+*   Formatted prose, lists, and math
+*   [Highlighted code blocks](https://quarto.org/docs/presentations/revealjs/#code-blocks) in any language, executable in R, Python, or Julia
+*   [Diagrams](https://quarto.org/docs/authoring/diagrams.html)
+*   [Interactive widgets](https://quarto.org/docs/interactive/ojs/)
+*   [Multi-column layouts](https://quarto.org/docs/presentations/revealjs/#multiple-columns) and [incremental reveals](https://quarto.org/docs/presentations/revealjs/#incremental-lists)
 
-*   Quarto presentations can include
-    [diagrams](https://quarto.org/docs/authoring/diagrams.html).
+You can then publish the whole deck to Connect as a single piece of content.
 
-*   Quarto presentations can include [interactive
-    elements](https://quarto.org/docs/interactive/).
+## Show your work with code
 
-## Workflow
+Show the code behind your analysis right on the slide, with syntax highlighting:
+
+```python
+import pandas as pd
+
+revenue = pd.read_csv("data.csv")
+by_segment = revenue.groupby("segment")["revenue"].sum()
+```
 
 ::: aside
-A diagram created using
-[Mermaid](https://quarto.org/docs/authoring/diagrams.html).
+Beyond highlighted code blocks, Quarto can also run R, Python, and Julia directly and embed the output.
+:::
+
+## Diagrams
+
+::: aside
+This is drawn from text with a [Mermaid diagram](https://quarto.org/docs/authoring/diagrams.html).
 :::
 
 ```{mermaid}
-stateDiagram-v2
-  [*] --> tidy
-  tidy --> analyze
-  analyze --> tidy
-  analyze --> write
-  write --> review
-  review --> write: feedback
-  review --> accepted
-  accepted --> [*]
+flowchart LR
+  A[Collect quarterly data] --> B[Analyze by segment]
+  B --> C{On track to target?}
+  C -->|Yes| D[Reinvest in what works]
+  C -->|No| E[Adjust the plan]
+  D --> F[Report to stakeholders]
+  E --> F
 ```
 
-## Height of Olympians
+## Interactive charts
 
 ::: aside
-An interactive element created with [Observable
-JS](https://quarto.org/docs/interactive/ojs/).
+This is built with [Observable JS](https://quarto.org/docs/interactive/ojs/). Select a segment to filter the chart.
 :::
 
 ```{ojs}
-// https://observablehq.com/@observablehq/sample-datasets
+// Plot is Observable Plot, bundled by Quarto for ojs cells.
+// Loads the bundled data.csv; replace it with your own figures.
+data = FileAttachment("data.csv").csv({typed: true})
+
+// The input makes the chart interactive: choosing a segment updates the bars.
+viewof segment = Inputs.select(["All segments", "Enterprise", "SMB"])
+
+shown = segment === "All segments" ? data : data.filter(d => d.segment === segment)
+
 Plot.plot({
+  marginLeft: 60,
+  x: {label: "Quarter"},
+  y: {label: "Revenue ($K)", grid: true},
+  color: {legend: true},
   marks: [
-    Plot.rectY(olympians, Plot.binX({y: "count"}, {x: "height"})),
+    Plot.barY(shown, {x: "quarter", y: "revenue", fill: "segment"}),
     Plot.ruleY([0])
-  ],
-  x: { label: "Height (m)" },
+  ]
 })
 ```
 
+## Layout and reveals
+
+::: aside
+This is a [two-column layout](https://quarto.org/docs/presentations/revealjs/#multiple-columns) with an [incremental list](https://quarto.org/docs/presentations/revealjs/#incremental-lists).
+:::
+
+:::: columns
+::: {.column width="55%"}
+Both segments grew every quarter, with Enterprise leading on revenue and SMB climbing steadily behind it.
+:::
+
+::: {.column width="45%"}
+Next steps:
+
+::: incremental
+*   Keep investing in Enterprise
+*   Sustain SMB's steady growth
+*   Set Q1 targets from the trend
+:::
+:::
+::::
+
+## Publish to Connect
+
+*   Preview your deck locally with `quarto preview`, then render it with `quarto render`.
+*   Publish the directory to Connect, where it serves as static content.
+*   Control who can view it and share a link, all from Connect.
+
+Learn more: [Quarto presentations](https://quarto.org/docs/presentations/) and [reveal.js](https://quarto.org/docs/presentations/revealjs/).

--- a/extensions/quarto-presentation/manifest.json
+++ b/extensions/quarto-presentation/manifest.json
@@ -38,7 +38,7 @@
       "checksum": "712bd86d94db9fd94d99b59670d02db5"
     },
     "index.qmd": {
-      "checksum": "77e7b2ff7fb6e8e32a0fbf211315c478"
+      "checksum": "7bc6a6c7efb2d20c1908d5ad1ce45396"
     }
   },
   "users": null

--- a/extensions/quarto-presentation/manifest.json
+++ b/extensions/quarto-presentation/manifest.json
@@ -11,12 +11,12 @@
   },
   "extension": {
     "name": "quarto-presentation",
-    "title": "Quarto Presentation",
-    "description": "This presentation is generated using Quarto and reveal.js. It demonstrates how you might use code to highlight your work.",
+    "title": "Quarto: Presentation",
+    "description": "A reveal.js slide deck built with Quarto that showcases what you can put on a slide and publish to Connect: prose, syntax-highlighted code, diagrams, interactive charts, and multi-column or incremental layouts. A starting point for any presentation.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-presentation",
     "category": "example",
     "minimumConnectVersion": "2025.04.0",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "environment": {
     "quarto": {
@@ -32,13 +32,16 @@
   "packages": null,
   "files": {
     "_quarto.yml": {
-      "checksum": "80f9dca03266ef4fbfef85e1f8be2699"
+      "checksum": "c750d2a852965b82c4e9c03ee5789d2f"
+    },
+    "data.csv": {
+      "checksum": "712bd86d94db9fd94d99b59670d02db5"
     },
     "index.qmd": {
-      "checksum": "fb7df1cb7f52c2d0502281e9bc0e31ee"
+      "checksum": "64c6b5834c85d1f4c696320dc74c63f5"
     },
     "README.md": {
-      "checksum": "725f7b7c6d298b276d7e9261d0ec8a61"
+      "checksum": "f0561db3eb74967e769b7bcf3152346a"
     }
   },
   "users": null

--- a/extensions/quarto-presentation/manifest.json
+++ b/extensions/quarto-presentation/manifest.json
@@ -39,9 +39,6 @@
     },
     "index.qmd": {
       "checksum": "77e7b2ff7fb6e8e32a0fbf211315c478"
-    },
-    "README.md": {
-      "checksum": "bdbc03ae7cf96131caccb0e9fa37f957"
     }
   },
   "users": null

--- a/extensions/quarto-presentation/manifest.json
+++ b/extensions/quarto-presentation/manifest.json
@@ -12,7 +12,7 @@
   "extension": {
     "name": "quarto-presentation",
     "title": "Quarto: Presentation",
-    "description": "A reveal.js slide deck built with Quarto that showcases what you can put on a slide and publish to Connect: prose, syntax-highlighted code, diagrams, interactive charts, and multi-column or incremental layouts. A starting point for any presentation.",
+    "description": "A slide deck built with Quarto and reveal.js that you publish to Connect, showing how a single document can combine formatted text, syntax-highlighted code, diagrams, interactive charts, and multi-column or step-by-step reveals. A starting point for any presentation.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-presentation",
     "category": "example",
     "minimumConnectVersion": "2025.04.0",

--- a/extensions/quarto-presentation/manifest.json
+++ b/extensions/quarto-presentation/manifest.json
@@ -38,10 +38,10 @@
       "checksum": "712bd86d94db9fd94d99b59670d02db5"
     },
     "index.qmd": {
-      "checksum": "64c6b5834c85d1f4c696320dc74c63f5"
+      "checksum": "77e7b2ff7fb6e8e32a0fbf211315c478"
     },
     "README.md": {
-      "checksum": "f0561db3eb74967e769b7bcf3152346a"
+      "checksum": "bdbc03ae7cf96131caccb0e9fa37f957"
     }
   },
   "users": null


### PR DESCRIPTION
Fixes #405 

- Rework the slides into a teaching showcase of Quarto presentation capabilities: an overview with doc links, a highlighted code block, a Mermaid flowchart, an interactive Observable JS chart, and a columns + incremental-reveal slide.
- Make the chart load a bundled data.csv (swappable) with a segment filter, instead of Observable's external olympians sample dataset.
- Retitle to "Quarto: Presentation"; rewrite the description and README.
- Pin project.render to index.qmd so the changelog isn't rendered as a stray page.
- Ignore *.quarto_ipynb build artifacts.
- Add CHANGELOG.md, bump 1.0.0 → 1.0.1, refresh checksums.