### PR TITLE
detect vulns in deployed versions, not just latest

### DIFF
--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Package Vulnerability Scanner extension will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.6] - 2026-06-26
+
+### Fixed
+
+- Detect vulnerabilities in the package versions actually deployed on your content, not just each package's latest version. The scan now asks Posit Package Manager about the specific installed versions; previously it only requested packages whose latest version was vulnerable, so it missed known vulnerabilities in older deployed versions that had since been patched. (#411)
+
 ## [3.0.5] - 2026-06-15
 
 ### Fixed

--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Detect vulnerabilities in the package versions actually deployed on your content, not just each package's latest version. The scan now asks Posit Package Manager about the specific installed versions; previously it only requested packages whose latest version was vulnerable, so it missed known vulnerabilities in older deployed versions that had since been patched. (#411)
+- Stop rendering a blank line in the vulnerability details when an advisory has no summary (common for PYSEC advisories, which the change above surfaces more of). (#411)
 
 ## [3.0.5] - 2026-06-15
 

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -55,8 +55,8 @@ async def get_vulnerabilities(installed: InstalledPackages):
     results = {}
 
     async def fetch_repo_vulns(repo, specifiers):
-        # name -> {vuln id -> vuln}; a package can be installed at several
-        # versions across content, so we merge each version's vulns by id.
+        # name -> {vuln id -> vuln}; the same package may be requested at
+        # several versions, so we merge each version's vulns by id.
         merged: dict[str, dict[str, dict]] = {}
         specs = sorted(set(specifiers))
         if not specs:

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -5,10 +5,19 @@ import httpx
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from posit import connect
+from pydantic import BaseModel
 
 app = FastAPI()
 
 client = connect.Client()
+
+# The public Package Manager is always current. To scan against your own
+# instance instead, point this at "https://your-ppm/__api__/filter/packages".
+PPM_URL = "https://packagemanager.posit.co/__api__/filter/packages"
+
+# Cap how many package specifiers go in one Package Manager request so a large
+# deployment doesn't produce an unwieldy payload.
+PPM_QUERY_CHUNK = 100
 
 
 @app.get("/api/content")
@@ -31,43 +40,50 @@ async def get_packages(guid: str):
         )
 
 
-@app.get("/api/vulns")
-async def get_vulnerabilities():
-    repositories = ["pypi", "cran"]
+# The installed packages to scan, as "name==version" specifiers grouped by the
+# Package Manager repo that carries them (Python -> pypi, R -> cran).
+class InstalledPackages(BaseModel):
+    pypi: list[str] = []
+    cran: list[str] = []
+
+
+@app.post("/api/vulns")
+async def get_vulnerabilities(installed: InstalledPackages):
+    # Query the exact installed versions instead of the `has_vulns` filter,
+    # which only flags packages whose latest version is vulnerable and so misses
+    # older deployed versions that were patched later.
     results = {}
 
-    async def fetch_repo_vulns(repo):
+    async def fetch_repo_vulns(repo, specifiers):
+        # name -> {vuln id -> vuln}; a package can be installed at several
+        # versions across content, so we merge each version's vulns by id.
+        merged: dict[str, dict[str, dict]] = {}
+        specs = sorted(set(specifiers))
+        if not specs:
+            return repo, {}
         async with httpx.AsyncClient() as http:
-            # This fetches vulnerabilities from the public Posit Package Manager,
-            # which is always up to date. If customizing this to reference your
-            # own PPM instance, note that the has_vulns parameter requires
-            # PPM 2026.04 or later. Older versions may need to use the vulns
-            # parameter instead, or the legacy endpoint:
-            #
-            #     url = f"https://your-ppm-instance/__api__/repos/{repo}/vulns"
-            #     response = await http.get(url)
-            #     return repo, response.json()
-            #
-            #   tasks = [fetch_repo_vulns(repo) for repo in repositories]
-            #   for repo, data in await asyncio.gather(*tasks):
-            #     results[repo] = data
-            url = "https://packagemanager.posit.co/__api__/filter/packages"
-            payload = {
-                "repo": repo,
-                "has_vulns": True,
-                "omit_downloads": True,
-                "omit_dependencies": True,
-            }
-            response = await http.post(url, json=payload)
-            response.raise_for_status()
-            packages = [
-                json.loads(line) for line in response.text.strip().split("\n") if line
-            ]
-            return repo, packages
+            for start in range(0, len(specs), PPM_QUERY_CHUNK):
+                payload = {
+                    "repo": repo,
+                    "names": specs[start : start + PPM_QUERY_CHUNK],
+                    "omit_downloads": True,
+                    "omit_dependencies": True,
+                }
+                response = await http.post(PPM_URL, json=payload)
+                response.raise_for_status()
+                for line in response.text.strip().split("\n"):
+                    if not line:
+                        continue
+                    found = json.loads(line)
+                    for vuln in found.get("vulns") or []:
+                        merged.setdefault(found["name"], {})[vuln["id"]] = vuln
+        return repo, {name: list(v.values()) for name, v in merged.items()}
 
-    tasks = [fetch_repo_vulns(repo) for repo in repositories]
-    for repo, packages in await asyncio.gather(*tasks):
-        results[repo] = {pkg["name"]: pkg["vulns"] for pkg in packages}
+    for repo, data in await asyncio.gather(
+        fetch_repo_vulns("pypi", installed.pypi),
+        fetch_repo_vulns("cran", installed.cran),
+    ):
+        results[repo] = data
 
     return results
 

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -23,11 +23,11 @@
     "dist/assets/index-CGfl-rCQ.css": {
       "checksum": "b4dadccacaa63c585d549a30e09ed801"
     },
-    "dist/assets/index-C2Wddtfm.js": {
-      "checksum": "8daf4d7a1274c4cc8d9f657955b2798e"
+    "dist/assets/index-CeYS13rN.js": {
+      "checksum": "56ec18d03f7bb86e3399fd22d1f9dcb2"
     },
     "dist/index.html": {
-      "checksum": "0e87888a6179ce43bee970a61f555cdc"
+      "checksum": "5e24f6d79483d59d6a36bcb428f12910"
     },
     "main.py": {
       "checksum": "b4d98ffdae1449709c3bc679f49262d6"

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -23,11 +23,11 @@
     "dist/assets/index-CGfl-rCQ.css": {
       "checksum": "b4dadccacaa63c585d549a30e09ed801"
     },
-    "dist/assets/index-CeYS13rN.js": {
-      "checksum": "56ec18d03f7bb86e3399fd22d1f9dcb2"
+    "dist/assets/index-B8aNyp2W.js": {
+      "checksum": "f464a4bc802b89c167439c82979af2d0"
     },
     "dist/index.html": {
-      "checksum": "5e24f6d79483d59d6a36bcb428f12910"
+      "checksum": "07435c1b16a3ab78d62c07501cc2e32d"
     },
     "main.py": {
       "checksum": "b4d98ffdae1449709c3bc679f49262d6"

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -20,17 +20,17 @@
   },
   "packages": {},
   "files": {
-    "dist/assets/index-5vgyaG_a.css": {
-      "checksum": "aa4504cc8edb049bfe5c2e6ec66e0f25"
+    "dist/assets/index-CGfl-rCQ.css": {
+      "checksum": "b4dadccacaa63c585d549a30e09ed801"
     },
-    "dist/assets/index-BMwEkJ9e.js": {
-      "checksum": "ef3d700fd8f521afadc82cfa2385377b"
+    "dist/assets/index-C2Wddtfm.js": {
+      "checksum": "8daf4d7a1274c4cc8d9f657955b2798e"
     },
     "dist/index.html": {
-      "checksum": "61de23bbcf376913838dfc6cba2a0979"
+      "checksum": "0e87888a6179ce43bee970a61f555cdc"
     },
     "main.py": {
-      "checksum": "a590da1135686d5eb651d635898f19d5"
+      "checksum": "6039bf4d34b97e70886c65cc4a5b48b5"
     },
     "requirements.txt": {
       "checksum": "9fc5cc5fb559eded1f323793b73e82c5"
@@ -44,6 +44,6 @@
     "category": "extension",
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": ["API Publishing"],
-    "version": "3.0.5"
+    "version": "3.0.6"
   }
 }

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -30,7 +30,7 @@
       "checksum": "0e87888a6179ce43bee970a61f555cdc"
     },
     "main.py": {
-      "checksum": "6039bf4d34b97e70886c65cc4a5b48b5"
+      "checksum": "b4d98ffdae1449709c3bc679f49262d6"
     },
     "requirements.txt": {
       "checksum": "9fc5cc5fb559eded1f323793b73e82c5"

--- a/extensions/package-vulnerability-scanner/src/App.vue
+++ b/extensions/package-vulnerability-scanner/src/App.vue
@@ -2,28 +2,26 @@
 import VulnerabilityChecker from "./components/VulnerabilityChecker.vue";
 import ContentList from "./components/ContentList.vue";
 import PoweredByFooter from "./components/PoweredByFooter.vue";
-import { useVulnsStore } from "./stores/vulns";
 import { useContentStore } from "./stores/content";
 import { useScannerStore } from "./stores/scanner";
 import { useUserStore } from "./stores/user";
 import LoadingSpinner from "./components/ui/LoadingSpinner.vue";
 
-const vulnStore = useVulnsStore();
 const contentStore = useContentStore();
 const scannerStore = useScannerStore();
 const userStore = useUserStore();
 
+// ContentList fetches vulnerabilities after it gathers the installed packages.
 userStore.fetchCurrentUser();
-vulnStore.fetchVulns();
 contentStore.fetchContentList();
 
-const loadingMessage = "Fetching content and vulnerabilities...";
+const loadingMessage = "Fetching your content...";
 </script>
 
 <template>
   <div class="flex flex-col min-h-svh">
     <LoadingSpinner
-      v-if="vulnStore.isLoading || contentStore.isLoading || !userStore.user"
+      v-if="contentStore.isLoading || !userStore.user"
       class="grow bg-gray-100"
       :message="loadingMessage"
     />

--- a/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
@@ -50,7 +50,7 @@ function handleClick() {
       </h3>
 
       <template v-if="!content.packageFetchError">
-        <ColorBadge v-if="content.isLoadingPackages" type="neutral">
+        <ColorBadge v-if="scannerStore.scanInProgress" type="neutral">
           Loading...
         </ColorBadge>
 

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -108,7 +108,7 @@ const tabs = computed<Tab[]>(() => {
   result.push({
     name: "With Vulnerabilities",
     color: "error",
-    count: scannerStore.anyContentLoadingPackages
+    count: scannerStore.scanInProgress
       ? undefined
       : scannerStore.contentWithVulnerabilities.length,
   });
@@ -268,10 +268,7 @@ const userHeader = computed(() => {
 
       <p class="text-gray-600">
         Found {{ scannerStore.content.length }} content items with
-        <SkeletonText
-          v-if="scannerStore.anyContentLoadingPackages"
-          class="h-6 w-[2ch]"
-        />
+        <SkeletonText v-if="scannerStore.scanInProgress" class="h-6 w-[2ch]" />
         <span v-else>{{ scannerStore.totalVulnerabilities }}</span>
         vulnerabilities.
       </p>

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -87,8 +87,11 @@ function collectInstalledPackages(): InstalledPackages {
   for (const item of Object.values(packagesStore.contentItems)) {
     for (const pkg of item.packages) {
       const language = pkg.language.toLowerCase();
-      if (language === "python") pypi.add(`${pkg.name}==${pkg.version}`);
-      else if (language === "r") cran.add(`${pkg.name}==${pkg.version}`);
+      if (language === "python") {
+        pypi.add(`${pkg.name}==${pkg.version}`);
+      } else if (language === "r") {
+        cran.add(`${pkg.name}==${pkg.version}`);
+      }
     }
   }
   return { pypi: [...pypi], cran: [...cran] };

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from "vue";
 import { storeToRefs } from "pinia";
 
 import { usePackagesStore } from "../stores/packages";
+import { useVulnsStore, type InstalledPackages } from "../stores/vulns";
 import { useContentStore } from "../stores/content";
 import { useScannerStore } from "../stores/scanner";
 import { useUserStore } from "../stores/user";
@@ -23,6 +24,7 @@ const props = defineProps<{
 const userStore = useUserStore();
 
 const packagesStore = usePackagesStore();
+const vulnStore = useVulnsStore();
 const contentStore = useContentStore();
 const scannerStore = useScannerStore();
 
@@ -70,6 +72,26 @@ async function fetchPackagesInBatches(batchSize = 3) {
 
     await Promise.all(fetchPromises);
   }
+
+  // Packages are loaded; look up vulnerabilities for the exact installed
+  // versions. Skip on a plain remount where nothing new was fetched.
+  if (contentToFetch.length > 0 || !vulnStore.isFetched) {
+    await vulnStore.fetchVulns(collectInstalledPackages());
+  }
+}
+
+// Gather unique installed packages as "name==version", grouped by repo.
+function collectInstalledPackages(): InstalledPackages {
+  const pypi = new Set<string>();
+  const cran = new Set<string>();
+  for (const item of Object.values(packagesStore.contentItems)) {
+    for (const pkg of item.packages) {
+      const language = pkg.language.toLowerCase();
+      if (language === "python") pypi.add(`${pkg.name}==${pkg.version}`);
+      else if (language === "r") cran.add(`${pkg.name}==${pkg.version}`);
+    }
+  }
+  return { pypi: [...pypi], cran: [...cran] };
 }
 
 fetchPackagesInBatches();

--- a/extensions/package-vulnerability-scanner/src/components/vulnerability/VulnerabilityDetails.vue
+++ b/extensions/package-vulnerability-scanner/src/components/vulnerability/VulnerabilityDetails.vue
@@ -25,7 +25,7 @@ function getOsvUrl(vulnId: string): string {
 
 <template>
   <div class="bg-red-50 border-l-4 border-red-500 rounded-r-md p-4">
-    <p class="text-gray-800 mb-1">
+    <p v-if="summary" class="text-gray-800 mb-1">
       <strong>{{ summary }}</strong>
     </p>
 

--- a/extensions/package-vulnerability-scanner/src/stores/scanner.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/scanner.ts
@@ -73,6 +73,17 @@ export const useScannerStore = defineStore("scanner", () => {
     return content.value.some((content) => content.isLoadingPackages);
   });
 
+  // True until both the packages and their vulnerabilities have loaded, so the
+  // vulnerability counts show a loading state rather than a premature zero.
+  const scanInProgress = computed<boolean>(() => {
+    const vulnsStore = useVulnsStore();
+    return (
+      anyContentLoadingPackages.value ||
+      vulnsStore.isLoading ||
+      !vulnsStore.isFetched
+    );
+  });
+
   return {
     currentContent,
     content,
@@ -80,5 +91,6 @@ export const useScannerStore = defineStore("scanner", () => {
     hasContent,
     totalVulnerabilities,
     anyContentLoadingPackages,
+    scanInProgress,
   };
 });

--- a/extensions/package-vulnerability-scanner/src/stores/vulns.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/vulns.ts
@@ -25,6 +25,13 @@ export interface VulnerabilityMap {
   [packageName: string]: Vulnerability[];
 }
 
+// Installed packages to look up, as "name==version" grouped by Package Manager
+// repo (a latest release is often patched while older deployed ones are not).
+export interface InstalledPackages {
+  pypi: string[];
+  cran: string[];
+}
+
 export const useVulnsStore = defineStore("vulns", () => {
   // State
   const pypi = ref<VulnerabilityMap>({});
@@ -37,12 +44,17 @@ export const useVulnsStore = defineStore("vulns", () => {
   const lastFetchTime = ref<Date | null>(null);
 
   // Actions
-  async function fetchVulns() {
+  // Look up vulnerabilities for the exact installed versions the caller gathered.
+  async function fetchVulns(installed: InstalledPackages) {
     isLoading.value = true;
     error.value = null;
 
     try {
-      const response = await fetch("api/vulns");
+      const response = await fetch("api/vulns", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(installed),
+      });
 
       if (!response.ok) {
         throw new Error(`HTTP error! Status: ${response.status}`);


### PR DESCRIPTION
Fixes #411 

Probably easiest to review this one commit by commit.

Implemented option 2 from the issue (query vulnerabilities for the specific installed versions). The frontend already loads each content item's packages, so it gathers the exact `name==version` set installed across the content in view and POSTs it to `/api/vulns`, which asks Package Manager about those versions directly. Each returned vulnerability carries its full affected-version map, so the existing per-version matching is unchanged.

The backend stays a thin Package Manager proxy — it queries only the versions the frontend sends and never enumerates content itself — so the work scales with what the UI already loads rather than a separate server-side pass over all content.

I also adjusted the UI: the vulnerability counts (the total, the "With Vulnerabilities" tab, and each content card's badge) now wait for the Package Manager lookup to finish before showing a status, instead of briefly showing "no vulnerabilities" while it's still in progress.

Verified on a Connect instance: content pinned to old, since-patched packages (`urllib3==1.26.4`, `jinja2==2.11.3`, `werkzeug==2.0.0`) now reports ~30 vulnerabilities where the previous scan reported 0.