### PR TITLE
readme and description edits in quarto-presentation

### DIFF
--- a/extensions/quarto-presentation/CHANGELOG.md
+++ b/extensions/quarto-presentation/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Quarto Presentation example will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-07-02
+
+### Changed
+
+- Noted in the description that you can swap in your own slides and figures, and reworded the README's Deploy section to link the example source for customizing. (#419)
+
 ## [1.0.1] - 2026-06-25
 
 ### Changed

--- a/extensions/quarto-presentation/README.md
+++ b/extensions/quarto-presentation/README.md
@@ -31,8 +31,10 @@ changes with `quarto preview`.
 
 ## Deploy it
 
-Deploy it straight from the Connect Gallery to get a copy running. To publish
-your own version, deploy the directory with
+Deploy it straight from the Connect Gallery to get a copy running and try it
+as-is. To run a customized version, get the
+[example source](https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-presentation),
+make your changes, and publish with
 [`quarto publish connect`](https://quarto.org/docs/publishing/rstudio-connect.html)
 or a [git-backed deployment](https://docs.posit.co/connect/user/git-backed/);
 Connect serves it as static content. Rendering requires Quarto 1.6 or newer.

--- a/extensions/quarto-presentation/manifest.json
+++ b/extensions/quarto-presentation/manifest.json
@@ -12,11 +12,11 @@
   "extension": {
     "name": "quarto-presentation",
     "title": "Quarto: Presentation",
-    "description": "A slide deck built with Quarto and reveal.js that you publish to Connect, showing how a single document can combine formatted text, syntax-highlighted code, diagrams, interactive charts, and multi-column or step-by-step reveals. A starting point for any presentation.",
+    "description": "A slide deck built with Quarto and reveal.js that you publish to Connect, showing how a single document can combine formatted text, syntax-highlighted code, diagrams, interactive charts, and multi-column or step-by-step reveals. A starting point for any presentation; swap in your own slides and figures.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-presentation",
     "category": "example",
     "minimumConnectVersion": "2025.04.0",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "environment": {
     "quarto": {


### PR DESCRIPTION
Short follow up to #405.

Here we're slightly tweaking the language in the "Deploy it" section of the README. In #412 there was a comment requesting edits to this section, and it's a parallel here. 

The section now frames the Gallery copy as something to try as-is, and links to the example source so anyone who wants to customize has a clear next step.

Also slightly clarified the description to be more explicit in naming how a user can customize/reuse the presentation.