### PR TITLE
Scan the signed-in viewer's content, not the publisher's

### DIFF
--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Scan the signed-in viewer's own content instead of the publisher's. The app now makes Connect API calls with the viewer's session token, so each person sees the content they published and their own name in the header; previously everyone saw the content and name of whoever deployed the app. Requires a Connect Visitor API Key integration. (#422)
+- Show an in-app setup message with the steps to add the required Connect Visitor API Key integration when it is missing, instead of hanging on the loading spinner. (#422)
 
 ## [3.0.6] - 2026-06-26
 

--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to the Package Vulnerability Scanner extension will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.7] - 2026-07-02
+## [3.0.7] - 2026-07-08
+
+### Changed
+
+- Fetch packages for all visible content in one batched request that the server processes in parallel, instead of one request per content item in small serial batches, so scanning a server with many items is much faster. (#422)
+- Query Package Manager for vulnerabilities in parallel across chunks, and keep already-fetched packages cached when toggling between your content and all content. (#422)
 
 ### Fixed
 

--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Package Vulnerability Scanner extension will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.7] - 2026-07-02
+
+### Fixed
+
+- Scan the signed-in viewer's own content instead of the publisher's. The app now makes Connect API calls with the viewer's session token, so each person sees the content they published and their own name in the header; previously everyone saw the content and name of whoever deployed the app. Requires a Connect Visitor API Key integration. (#NNN)
+
 ## [3.0.6] - 2026-06-26
 
 ### Fixed

--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Scan the signed-in viewer's own content instead of the publisher's. The app now makes Connect API calls with the viewer's session token, so each person sees the content they published and their own name in the header; previously everyone saw the content and name of whoever deployed the app. Requires a Connect Visitor API Key integration. (#NNN)
+- Scan the signed-in viewer's own content instead of the publisher's. The app now makes Connect API calls with the viewer's session token, so each person sees the content they published and their own name in the header; previously everyone saw the content and name of whoever deployed the app. Requires a Connect Visitor API Key integration. (#422)
 
 ## [3.0.6] - 2026-06-26
 

--- a/extensions/package-vulnerability-scanner/README.md
+++ b/extensions/package-vulnerability-scanner/README.md
@@ -2,3 +2,11 @@
 
 Shows the vulnerabilities affecting the content you have published to Posit
 Connect.
+
+## Setup
+
+The scanner reports on the content of whoever is signed in, so it calls the
+Connect API as that viewer. After deploying, open the content's **Access** tab and
+add a **Connect Visitor API Key** integration (under **Integrations**). Until it is
+added, the app shows a setup message instead of your content. See the
+[OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 
 import httpx
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.staticfiles import StaticFiles
 from posit import connect
 from pydantic import BaseModel
@@ -10,6 +10,18 @@ from pydantic import BaseModel
 app = FastAPI()
 
 client = connect.Client()
+
+
+# Build a Connect client scoped to the signed-in viewer by exchanging their
+# per-request session token, so API calls return that viewer's own content and
+# identity. Falls back to the default client when there's no token (e.g. local
+# development).
+def get_visitor_client(request: Request) -> connect.Client:
+    token = request.headers.get("posit-connect-user-session-token")
+    if token:
+        return client.with_user_session_token(token)
+    return client
+
 
 # The public Package Manager is always current. To scan against your own
 # instance instead, point this at "https://your-ppm/__api__/filter/packages".
@@ -21,16 +33,17 @@ PPM_QUERY_CHUNK = 100
 
 
 @app.get("/api/content")
-async def search_content(show_all: bool = False):
+async def search_content(request: Request, show_all: bool = False):
+    visitor = get_visitor_client(request)
     if show_all:
-        return client.content.find()
-    return client.me.content.find()
+        return visitor.content.find()
+    return visitor.me.content.find()
 
 
 @app.get("/api/packages/{guid}")
-async def get_packages(guid: str):
+async def get_packages(guid: str, request: Request):
     try:
-        content = client.content.get(guid)
+        content = get_visitor_client(request).content.get(guid)
         packages = list(content.packages)
         return packages
     except Exception as e:
@@ -89,8 +102,8 @@ async def get_vulnerabilities(installed: InstalledPackages):
 
 
 @app.get("/api/user")
-async def get_current_user():
-    return client.me
+async def get_current_user(request: Request):
+    return get_visitor_client(request).me
 
 
 app.mount("/", StaticFiles(directory="dist", html=True), name="static")

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -60,7 +60,10 @@ async def search_content(request: Request, show_all: bool = False):
 @app.get("/api/packages/{guid}")
 async def get_packages(guid: str, request: Request):
     try:
-        content = get_visitor_client(request).content.get(guid)
+        # Keep the client bound: content.packages is lazy and holds only a weak
+        # reference to it, so an unbound client would be collected before use.
+        visitor = get_visitor_client(request)
+        content = visitor.content.get(guid)
         packages = list(content.packages)
         return packages
     except Exception as e:

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -57,20 +57,35 @@ async def search_content(request: Request, show_all: bool = False):
         raise _setup_required(e)
 
 
-@app.get("/api/packages/{guid}")
-async def get_packages(guid: str, request: Request):
-    try:
-        # Keep the client bound: content.packages is lazy and holds only a weak
-        # reference to it, so an unbound client would be collected before use.
-        visitor = get_visitor_client(request)
-        content = visitor.content.get(guid)
-        packages = list(content.packages)
-        return packages
-    except Exception as e:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Content not found or error fetching packages: {str(e)}",
-        )
+class PackageScanRequest(BaseModel):
+    guids: list[str] = []
+
+
+@app.post("/api/packages")
+async def get_packages(scan: PackageScanRequest, request: Request):
+    # Keep the client bound for the whole request: content.packages is lazy and
+    # holds only a weak reference to it, so an unbound client would be collected
+    # before use.
+    visitor = get_visitor_client(request)
+
+    def fetch_one(guid: str):
+        try:
+            content = visitor.content.get(guid)
+            return guid, {"packages": list(content.packages)}
+        except Exception as e:
+            return guid, {"error": f"Content not found or error fetching packages: {e}"}
+
+    # The SDK calls are synchronous, so run them in threads and gather the results,
+    # letting a deployment with many content items scan in parallel. Bound the
+    # concurrency so a large server does not fire a burst of requests at Connect.
+    semaphore = asyncio.Semaphore(8)
+
+    async def fetch_bounded(guid: str):
+        async with semaphore:
+            return await asyncio.to_thread(fetch_one, guid)
+
+    results = await asyncio.gather(*(fetch_bounded(guid) for guid in scan.guids))
+    return dict(results)
 
 
 # The installed packages to scan, as "name==version" specifiers grouped by the
@@ -86,6 +101,9 @@ async def get_vulnerabilities(installed: InstalledPackages):
     # which only flags packages whose latest version is vulnerable and so misses
     # older deployed versions that were patched later.
     results = {}
+    # Bound how many Package Manager requests run at once so a large scan does not
+    # overload the public service.
+    ppm_semaphore = asyncio.Semaphore(5)
 
     async def fetch_repo_vulns(repo, specifiers):
         # name -> {vuln id -> vuln}; the same package may be requested at
@@ -94,22 +112,34 @@ async def get_vulnerabilities(installed: InstalledPackages):
         specs = sorted(set(specifiers))
         if not specs:
             return repo, {}
-        async with httpx.AsyncClient() as http:
-            for start in range(0, len(specs), PPM_QUERY_CHUNK):
+        chunks = [
+            specs[start : start + PPM_QUERY_CHUNK]
+            for start in range(0, len(specs), PPM_QUERY_CHUNK)
+        ]
+
+        async def fetch_chunk(http, names):
+            async with ppm_semaphore:
                 payload = {
                     "repo": repo,
-                    "names": specs[start : start + PPM_QUERY_CHUNK],
+                    "names": names,
                     "omit_downloads": True,
                     "omit_dependencies": True,
                 }
                 response = await http.post(PPM_URL, json=payload)
                 response.raise_for_status()
-                for line in response.text.strip().split("\n"):
-                    if not line:
-                        continue
-                    found = json.loads(line)
-                    for vuln in found.get("vulns") or []:
-                        merged.setdefault(found["name"], {})[vuln["id"]] = vuln
+                return response.text
+
+        # Query the chunks in parallel so a large repo doesn't pay one round-trip
+        # after another.
+        async with httpx.AsyncClient() as http:
+            texts = await asyncio.gather(*(fetch_chunk(http, chunk) for chunk in chunks))
+        for text in texts:
+            for line in text.strip().split("\n"):
+                if not line:
+                    continue
+                found = json.loads(line)
+                for vuln in found.get("vulns") or []:
+                    merged.setdefault(found["name"], {})[vuln["id"]] = vuln
         return repo, {name: list(v.values()) for name, v in merged.items()}
 
     for repo, data in await asyncio.gather(

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -5,6 +5,7 @@ import httpx
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.staticfiles import StaticFiles
 from posit import connect
+from posit.connect.errors import ClientError
 from pydantic import BaseModel
 
 app = FastAPI()
@@ -23,6 +24,19 @@ def get_visitor_client(request: Request) -> connect.Client:
     return client
 
 
+# Connect raises ClientError code 212 when the Visitor API Key integration that
+# viewer-scoped calls depend on has not been added to this content. Surface it as
+# a distinct 424 so the UI can show setup instructions.
+def _setup_required(exc: ClientError) -> HTTPException:
+    if exc.error_code == 212:
+        return HTTPException(
+            status_code=424,
+            detail="Add a Connect Visitor API Key integration on this content's "
+            "Access tab to scan your content.",
+        )
+    return HTTPException(status_code=502, detail=f"Connect API error: {exc}")
+
+
 # The public Package Manager is always current. To scan against your own
 # instance instead, point this at "https://your-ppm/__api__/filter/packages".
 PPM_URL = "https://packagemanager.posit.co/__api__/filter/packages"
@@ -34,10 +48,13 @@ PPM_QUERY_CHUNK = 100
 
 @app.get("/api/content")
 async def search_content(request: Request, show_all: bool = False):
-    visitor = get_visitor_client(request)
-    if show_all:
-        return visitor.content.find()
-    return visitor.me.content.find()
+    try:
+        visitor = get_visitor_client(request)
+        if show_all:
+            return visitor.content.find()
+        return visitor.me.content.find()
+    except ClientError as e:
+        raise _setup_required(e)
 
 
 @app.get("/api/packages/{guid}")
@@ -103,7 +120,10 @@ async def get_vulnerabilities(installed: InstalledPackages):
 
 @app.get("/api/user")
 async def get_current_user(request: Request):
-    return get_visitor_client(request).me
+    try:
+        return get_visitor_client(request).me
+    except ClientError as e:
+        raise _setup_required(e)
 
 
 app.mount("/", StaticFiles(directory="dist", html=True), name="static")

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -20,17 +20,17 @@
   },
   "packages": {},
   "files": {
-    "dist/assets/index-Bd7WoAqv.css": {
-      "checksum": "980b7708188eee5f84707dcc6cf3b01d"
+    "dist/assets/index-CKUnK_gI.css": {
+      "checksum": "910900dfbf81f7ac4caf125b844a495c"
     },
-    "dist/assets/index-D85_wxsZ.js": {
-      "checksum": "631bb2ab9551df092b560076f8b3a1d5"
+    "dist/assets/index-C9j_STO3.js": {
+      "checksum": "3489de22f98bf476c3a2e93d085e159e"
     },
     "dist/index.html": {
-      "checksum": "202fcb232f90aee6cddec9d15f76fbd3"
+      "checksum": "a740943aef8dc220e495a82a407f6d5d"
     },
     "main.py": {
-      "checksum": "802d24d736d71ea12c4f9cb92d8b8a9f"
+      "checksum": "ff3b85e2c389e4872378778600f31db5"
     },
     "requirements.txt": {
       "checksum": "9fc5cc5fb559eded1f323793b73e82c5"

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -20,17 +20,17 @@
   },
   "packages": {},
   "files": {
-    "dist/assets/index-CGfl-rCQ.css": {
-      "checksum": "b4dadccacaa63c585d549a30e09ed801"
+    "dist/assets/index-DOf96IrN.css": {
+      "checksum": "fc9c4a47bf1f820da5e0db7945a05127"
     },
-    "dist/assets/index-B8aNyp2W.js": {
-      "checksum": "f464a4bc802b89c167439c82979af2d0"
+    "dist/assets/index-1qoauOhA.js": {
+      "checksum": "f1272296a3cc5055c0b7fd8a95ca7d7e"
     },
     "dist/index.html": {
-      "checksum": "07435c1b16a3ab78d62c07501cc2e32d"
+      "checksum": "83db067997e809454627364b339e053b"
     },
     "main.py": {
-      "checksum": "1fed4df056e18136f1368484c112e8a9"
+      "checksum": "8a2016cff02402136b26bebb6ccf804f"
     },
     "requirements.txt": {
       "checksum": "9fc5cc5fb559eded1f323793b73e82c5"

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -23,11 +23,11 @@
     "dist/assets/index-Bd7WoAqv.css": {
       "checksum": "980b7708188eee5f84707dcc6cf3b01d"
     },
-    "dist/assets/index-BNNHG58C.js": {
-      "checksum": "35c6ca00519322872f239db9732395c1"
+    "dist/assets/index-D85_wxsZ.js": {
+      "checksum": "631bb2ab9551df092b560076f8b3a1d5"
     },
     "dist/index.html": {
-      "checksum": "109b859fe4c0f7dbcba87c73ba72185d"
+      "checksum": "202fcb232f90aee6cddec9d15f76fbd3"
     },
     "main.py": {
       "checksum": "802d24d736d71ea12c4f9cb92d8b8a9f"

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -30,7 +30,7 @@
       "checksum": "07435c1b16a3ab78d62c07501cc2e32d"
     },
     "main.py": {
-      "checksum": "b4d98ffdae1449709c3bc679f49262d6"
+      "checksum": "1fed4df056e18136f1368484c112e8a9"
     },
     "requirements.txt": {
       "checksum": "9fc5cc5fb559eded1f323793b73e82c5"
@@ -43,7 +43,7 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/package-vulnerability-scanner",
     "category": "extension",
     "minimumConnectVersion": "2025.04.0",
-    "requiredFeatures": ["API Publishing"],
-    "version": "3.0.6"
+    "requiredFeatures": ["API Publishing", "OAuth Integrations"],
+    "version": "3.0.7"
   }
 }

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -20,17 +20,17 @@
   },
   "packages": {},
   "files": {
-    "dist/assets/index-DOf96IrN.css": {
-      "checksum": "fc9c4a47bf1f820da5e0db7945a05127"
+    "dist/assets/index-Bd7WoAqv.css": {
+      "checksum": "980b7708188eee5f84707dcc6cf3b01d"
     },
-    "dist/assets/index-1qoauOhA.js": {
-      "checksum": "f1272296a3cc5055c0b7fd8a95ca7d7e"
+    "dist/assets/index-BNNHG58C.js": {
+      "checksum": "35c6ca00519322872f239db9732395c1"
     },
     "dist/index.html": {
-      "checksum": "83db067997e809454627364b339e053b"
+      "checksum": "109b859fe4c0f7dbcba87c73ba72185d"
     },
     "main.py": {
-      "checksum": "8a2016cff02402136b26bebb6ccf804f"
+      "checksum": "802d24d736d71ea12c4f9cb92d8b8a9f"
     },
     "requirements.txt": {
       "checksum": "9fc5cc5fb559eded1f323793b73e82c5"

--- a/extensions/package-vulnerability-scanner/src/App.vue
+++ b/extensions/package-vulnerability-scanner/src/App.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import VulnerabilityChecker from "./components/VulnerabilityChecker.vue";
 import ContentList from "./components/ContentList.vue";
 import PoweredByFooter from "./components/PoweredByFooter.vue";
+import StatusMessage from "./components/ui/StatusMessage.vue";
 import { useContentStore } from "./stores/content";
 import { useScannerStore } from "./stores/scanner";
 import { useUserStore } from "./stores/user";
@@ -13,25 +15,70 @@ const userStore = useUserStore();
 
 // ContentList fetches vulnerabilities after it gathers the installed packages.
 userStore.fetchCurrentUser();
-contentStore.fetchContentList();
+contentStore.fetchContentList().catch(() => {});
 
 const loadingMessage = "Fetching your content...";
+
+// The scan needs the viewer's identity, so a missing Visitor API Key integration
+// gates the whole UI behind a setup message (see the stores' setupRequired).
+const setupRequired = computed(
+  () => userStore.setupRequired || contentStore.setupRequired,
+);
+const isLoading = computed(
+  () => contentStore.isLoading || (!userStore.user && !userStore.error),
+);
+const errorMessage = computed(
+  () => userStore.error || contentStore.error?.message,
+);
 </script>
 
 <template>
   <div class="flex flex-col min-h-svh">
+    <div
+      v-if="setupRequired"
+      class="grow bg-gray-100 flex items-center justify-center p-4"
+    >
+      <StatusMessage
+        type="warning"
+        message="Finish setup to scan your content"
+        details="This app reads the content you have published to Connect, which requires a Connect Visitor API Key integration."
+        class="max-w-md"
+      >
+        On this content's <strong>Access</strong> tab, add a
+        <strong>Connect Visitor API Key</strong> integration under
+        <strong>Integrations</strong>, then reload. See the
+        <a
+          href="https://docs.posit.co/connect/user/oauth-integrations/"
+          class="underline"
+          target="_blank"
+          rel="noopener"
+          >OAuth Integrations documentation</a
+        >.
+      </StatusMessage>
+    </div>
     <LoadingSpinner
-      v-if="contentStore.isLoading || !userStore.user"
+      v-else-if="isLoading"
       class="grow bg-gray-100"
       :message="loadingMessage"
     />
+    <div
+      v-else-if="errorMessage"
+      class="grow bg-gray-100 flex items-center justify-center p-4"
+    >
+      <StatusMessage
+        type="error"
+        message="Something went wrong"
+        :details="errorMessage"
+        class="max-w-md"
+      />
+    </div>
     <main v-else class="flex-1 p-4 md:p-8 bg-gray-100">
       <div class="max-w-4xl mx-auto">
         <VulnerabilityChecker
           v-if="scannerStore.currentContent"
           :content="scannerStore.currentContent"
         />
-        <ContentList :user="userStore.user" v-else />
+        <ContentList v-else-if="userStore.user" :user="userStore.user" />
       </div>
     </main>
 

--- a/extensions/package-vulnerability-scanner/src/App.vue
+++ b/extensions/package-vulnerability-scanner/src/App.vue
@@ -41,20 +41,14 @@ const errorMessage = computed(
       <div
         class="max-w-md w-full bg-white rounded-lg border border-gray-200 shadow-sm p-8"
       >
-        <h1 class="text-lg font-semibold text-gray-900 text-center">
-          Finish setting up the scanner
-        </h1>
+        <h1 class="text-lg font-semibold text-gray-900 text-center">Setup</h1>
         <p class="mt-4 text-sm leading-relaxed text-gray-600">
-          To scan the content you have published, this app needs a Connect
-          Visitor API Key integration.
+          To scan the content you have published, this app needs a "Connect
+          Visitor API Key" integration.
         </p>
         <p class="mt-3 text-sm leading-relaxed text-gray-600">
-          On this content's
-          <span class="font-medium text-gray-900">Access</span> tab, add a
-          <span class="font-medium text-gray-900">Connect Visitor API Key</span>
-          integration under
-          <span class="font-medium text-gray-900">Integrations</span>, then
-          reload.
+          In the content's settings, on the "Access" tab, add a "Connect Visitor
+          API Key" integration under "Integrations".
         </p>
         <p class="mt-4 text-sm text-gray-500">
           For more information, see the

--- a/extensions/package-vulnerability-scanner/src/App.vue
+++ b/extensions/package-vulnerability-scanner/src/App.vue
@@ -38,23 +38,35 @@ const errorMessage = computed(
       v-if="setupRequired"
       class="grow bg-gray-100 flex items-center justify-center p-4"
     >
-      <StatusMessage
-        type="warning"
-        message="Finish setup to scan your content"
-        details="This app reads the content you have published to Connect, which requires a Connect Visitor API Key integration."
-        class="max-w-md"
+      <div
+        class="max-w-md w-full bg-white rounded-lg border border-gray-200 shadow-sm p-8"
       >
-        On this content's <strong>Access</strong> tab, add a
-        <strong>Connect Visitor API Key</strong> integration under
-        <strong>Integrations</strong>, then reload. See the
-        <a
-          href="https://docs.posit.co/connect/user/oauth-integrations/"
-          class="underline"
-          target="_blank"
-          rel="noopener"
-          >OAuth Integrations documentation</a
-        >.
-      </StatusMessage>
+        <h1 class="text-lg font-semibold text-gray-900 text-center">
+          Finish setting up the scanner
+        </h1>
+        <p class="mt-4 text-sm leading-relaxed text-gray-600">
+          To scan the content you have published, this app needs a Connect
+          Visitor API Key integration.
+        </p>
+        <p class="mt-3 text-sm leading-relaxed text-gray-600">
+          On this content's
+          <span class="font-medium text-gray-900">Access</span> tab, add a
+          <span class="font-medium text-gray-900">Connect Visitor API Key</span>
+          integration under
+          <span class="font-medium text-gray-900">Integrations</span>, then
+          reload.
+        </p>
+        <p class="mt-4 text-sm text-gray-500">
+          For more information, see the
+          <a
+            href="https://docs.posit.co/connect/user/oauth-integrations/"
+            class="text-indigo-600 hover:underline"
+            target="_blank"
+            rel="noopener"
+            >OAuth Integrations documentation</a
+          >.
+        </p>
+      </div>
     </div>
     <LoadingSpinner
       v-else-if="isLoading"

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -31,60 +31,58 @@ const scannerStore = useScannerStore();
 // Use store's showAllContent to persist state across remounts
 const { showAllContent } = storeToRefs(contentStore);
 
-// Watch for toggle changes and refetch content
+// Refetch the content list when the toggle changes. Packages already fetched
+// stay cached, so only newly visible content is loaded.
 watch(showAllContent, async () => {
-  packagesStore.clearAllPackages();
   await contentStore.fetchContentList(true);
-  fetchPackagesInBatches();
+  scanPackages();
 });
 
-// Fetch packages in batches to avoid overwhelming the server
-async function fetchPackagesInBatches(batchSize = 3) {
+// Load packages for the visible content in one batched request, then look up
+// vulnerabilities for the exact installed versions.
+async function scanPackages() {
   const contentToFetch = contentStore.contentList.filter(
     (content) =>
       !packagesStore.contentItems[content.guid]?.isFetched &&
       !packagesStore.contentItems[content.guid]?.isLoading,
   );
 
-  // Process in batches
-  for (let i = 0; i < contentToFetch.length; i += batchSize) {
-    const batch = contentToFetch.slice(i, i + batchSize);
-
-    // Fetch packages for this batch in parallel
-    const fetchPromises = batch.map(async (content) => {
-      if (content.bundle_id === null) {
-        packagesStore.setPackagesForContent(
-          content.guid,
-          [],
-          new Error("This content has not been fully deployed."),
-        );
-        return;
-      }
-      try {
-        return await packagesStore.fetchPackagesForContent(content.guid);
-      } catch (err) {
-        return console.error(
-          `Error fetching packages for ${content.guid}:`,
-          err,
-        );
-      }
-    });
-
-    await Promise.all(fetchPromises);
+  // Content that never finished deploying has no packages to read.
+  const guidsToFetch: string[] = [];
+  for (const content of contentToFetch) {
+    if (content.bundle_id === null) {
+      packagesStore.setPackagesForContent(
+        content.guid,
+        [],
+        new Error("This content has not been fully deployed."),
+      );
+    } else {
+      guidsToFetch.push(content.guid);
+    }
   }
 
-  // Packages are loaded; look up vulnerabilities for the exact installed
-  // versions. Skip on a plain remount where nothing new was fetched.
+  if (guidsToFetch.length > 0) {
+    try {
+      await packagesStore.fetchPackages(guidsToFetch);
+    } catch (err) {
+      console.error("Error fetching packages:", err);
+    }
+  }
+
+  // Skip the vuln lookup on a plain remount where nothing new was fetched.
   if (contentToFetch.length > 0 || !vulnStore.isFetched) {
     await vulnStore.fetchVulns(collectInstalledPackages());
   }
 }
 
-// Gather unique installed packages as "name==version", grouped by repo.
+// Gather unique installed packages as "name==version", grouped by repo, across
+// the content currently in view (cached packages for hidden content are ignored).
 function collectInstalledPackages(): InstalledPackages {
   const pypi = new Set<string>();
   const cran = new Set<string>();
-  for (const item of Object.values(packagesStore.contentItems)) {
+  for (const content of contentStore.contentList) {
+    const item = packagesStore.contentItems[content.guid];
+    if (!item) continue;
     for (const pkg of item.packages) {
       const language = pkg.language.toLowerCase();
       if (language === "python") {
@@ -97,7 +95,7 @@ function collectInstalledPackages(): InstalledPackages {
   return { pypi: [...pypi], cran: [...cran] };
 }
 
-fetchPackagesInBatches();
+scanPackages();
 
 const tabs = computed<Tab[]>(() => {
   const result: Tab[] = [];

--- a/extensions/package-vulnerability-scanner/src/stores/content.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/content.ts
@@ -20,6 +20,7 @@ export const useContentStore = defineStore("content", () => {
   const contentList = ref<ContentListItem[]>([]);
   const isLoading = ref(false);
   const error = ref<Error | null>(null);
+  const setupRequired = ref(false);
   const showAllContent = ref(false);
 
   // Track if content has been loaded for the current mode
@@ -33,6 +34,7 @@ export const useContentStore = defineStore("content", () => {
 
     isLoading.value = true;
     error.value = null;
+    setupRequired.value = false;
 
     try {
       const url = showAllContent.value
@@ -41,6 +43,8 @@ export const useContentStore = defineStore("content", () => {
       const response = await fetch(url);
 
       if (!response.ok) {
+        // 424: the Connect Visitor API Key integration this app needs is not configured.
+        if (response.status === 424) setupRequired.value = true;
         throw new Error(`HTTP error! Status: ${response.status}`);
       }
 
@@ -61,6 +65,7 @@ export const useContentStore = defineStore("content", () => {
     contentList,
     isLoading,
     error,
+    setupRequired,
     isContentLoaded,
     showAllContent,
 

--- a/extensions/package-vulnerability-scanner/src/stores/packages.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/packages.ts
@@ -23,44 +23,69 @@ export const usePackagesStore = defineStore("packages", () => {
   const isLoading = ref(false);
   const error = ref<Error | null>(null);
 
-  // Fetch packages for a specific content ID
-  async function fetchPackagesForContent(contentId: string) {
-    if (!contentItems.value[contentId]) {
-      // Initialize content item
-      contentItems.value[contentId] = {
-        guid: contentId,
-        packages: [],
-        isLoading: true,
-        error: null,
-        isFetched: false,
-        lastFetchTime: null,
-      };
-    } else {
-      // Update existing content item loading state
-      contentItems.value[contentId].isLoading = true;
-      contentItems.value[contentId].error = null;
+  // Fetch packages for many content items in one request. The backend fans the
+  // work out in parallel, so this is a single round-trip instead of one per item.
+  async function fetchPackages(guids: string[]) {
+    if (guids.length === 0) return;
+
+    for (const guid of guids) {
+      if (!contentItems.value[guid]) {
+        contentItems.value[guid] = {
+          guid,
+          packages: [],
+          isLoading: true,
+          error: null,
+          isFetched: false,
+          lastFetchTime: null,
+        };
+      } else {
+        contentItems.value[guid].isLoading = true;
+        contentItems.value[guid].error = null;
+      }
     }
 
     try {
-      const response = await fetch(`api/packages/${contentId}`);
+      const response = await fetch("api/packages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ guids }),
+      });
 
       if (!response.ok) {
         throw new Error(`HTTP error - Status: ${response.status}`);
       }
 
-      const data = await response.json();
+      const data: Record<string, { packages?: Package[]; error?: string }> =
+        await response.json();
 
-      // Update the content item with the fetched packages
-      contentItems.value[contentId].packages = data;
-      contentItems.value[contentId].isFetched = true;
-      contentItems.value[contentId].lastFetchTime = new Date();
+      for (const guid of guids) {
+        const item = contentItems.value[guid];
+        if (!item) continue;
+        const result = data[guid] ?? {};
+        if (result.error) {
+          item.packages = [];
+          item.error = new Error(result.error);
+        } else {
+          item.packages = result.packages ?? [];
+          item.error = null;
+        }
+        item.isFetched = true;
+        item.lastFetchTime = new Date();
+        item.isLoading = false;
+      }
     } catch (err) {
       console.error("Error fetching packages:", err);
-      contentItems.value[contentId].error = err as Error;
-      contentItems.value[contentId].isFetched = true;
+      // Resolve every requested item's loading state so a failed request shows an
+      // error instead of spinning forever.
+      for (const guid of guids) {
+        const item = contentItems.value[guid];
+        if (item) {
+          item.error = err as Error;
+          item.isFetched = true;
+          item.isLoading = false;
+        }
+      }
       throw err;
-    } finally {
-      contentItems.value[contentId].isLoading = false;
     }
   }
 
@@ -79,10 +104,6 @@ export const usePackagesStore = defineStore("packages", () => {
     };
   }
 
-  function clearAllPackages() {
-    contentItems.value = {};
-  }
-
   return {
     // State
     contentItems,
@@ -90,8 +111,7 @@ export const usePackagesStore = defineStore("packages", () => {
     error,
 
     // Actions
-    fetchPackagesForContent,
+    fetchPackages,
     setPackagesForContent,
-    clearAllPackages,
   };
 });

--- a/extensions/package-vulnerability-scanner/src/stores/user.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/user.ts
@@ -17,18 +17,32 @@ export interface User {
 
 export const useUserStore = defineStore("user", () => {
   const user = ref<User>();
+  const error = ref<string | null>(null);
+  const setupRequired = ref(false);
 
   const isAdmin = computed(() => user.value?.user_role === "administrator");
 
   async function fetchCurrentUser() {
-    const response = await fetch("api/user");
-    const data = await response.json();
-
-    user.value = data;
+    error.value = null;
+    setupRequired.value = false;
+    try {
+      const response = await fetch("api/user");
+      if (!response.ok) {
+        // 424: the Connect Visitor API Key integration this app needs is not configured.
+        if (response.status === 424) setupRequired.value = true;
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+      user.value = await response.json();
+    } catch (err) {
+      console.error("Error fetching current user:", err);
+      error.value = (err as Error).message;
+    }
   }
 
   return {
     user,
+    error,
+    setupRequired,
     isAdmin,
 
     fetchCurrentUser,

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -99,6 +99,7 @@ $(CONNECT_VERSIONS): %:
 	$(WITH_CONNECT) --version $* --license $(LICENSE_FILE) \
 		-e CONNECT_SERVER_EMAILPROVIDER=None \
 		-e CONNECT_APPLICATIONS_PACKAGEAUDITINGENABLED=true \
+		-e CONNECT_NODEJS_ENABLED=true \
 		-- bash -c '\
 			set -o pipefail; \
 			cd $(CURDIR) && \


### PR DESCRIPTION
Works on #415 (first of several PRs polishing the `package-vulnerability-scanner`, split up for ease of review)

**Problem**: The app authenticated to the Connect API with the deployed content's own credentials (`connect.Client()`), so every visitor saw the _publisher's_ content and name, not their own. For a tool meant to scan "your published content," each viewer should see the content they published.

**Solution**:
- Exchange the per-request `Posit-Connect-User-Session-Token` for a viewer-scoped client (`with_user_session_token`) and use it for the content, packages, and user endpoints. Falls back to the default client when there's no token (e.g. local dev). `/api/vulns` is unchanged (it only queries Package Manager).
- Add `OAuth Integrations` to `requiredFeatures`: viewer-scoped calls need a Connect Visitor API Key integration.
- Added an in-app setup screen that prompts the user to add the required Connect Visitor API Key integration. Once it's been added, move to the standard scanner page that shows vulnerabilities per content.
- Bump 3.0.6 → 3.0.7.

**Testing**:
- Manually deployed and confirmed it's working as expected.
- Sent to non-publisher viewer and confirmed they saw their own content and name in the header (instead of mine, the publisher's).
- Confirmed it still runs when no token is present (local dev falls back to the default client).

Follow-up PRs will handle performance issues, rewriting the README/description, etc.