### PR TITLE
feat: support Node.js content in the gallery release pipeline

### DIFF
--- a/.github/actions/connect-integration-test/action.yml
+++ b/.github/actions/connect-integration-test/action.yml
@@ -91,6 +91,9 @@ runs:
         # Connect so it loads Node. Connect checks that the configured Node
         # executable exists when it starts, so Node must be in place before the
         # restart.
+        # Pin a current Node.js release. It satisfies the open-ended `>=` ranges
+        # the gallery recommends for engines.node (see CONTRIBUTING), so it works
+        # for any compliant Node.js extension.
         NODE_VERSION=24.14.0
         CID="${{ steps.connect.outputs.CONTAINER_ID }}"
         # Download and unpack Node on the CI runner, then copy it into the container,

--- a/.github/actions/connect-integration-test/action.yml
+++ b/.github/actions/connect-integration-test/action.yml
@@ -76,6 +76,49 @@ runs:
           CONNECT_SERVER_EMAILPROVIDER=None
           CONNECT_APPLICATIONS_PACKAGEAUDITINGENABLED=true
 
+    - name: Provision Node.js runtime (nodejs extensions only)
+      shell: bash
+      run: |
+        APPMODE=$(jq -r '.metadata.appmode // ""' extensions/${{ inputs.extension-name }}/manifest.json)
+        if [ "$APPMODE" != "nodejs" ]; then
+          echo "Not a Node.js extension; skipping Node provisioning."
+          exit 0
+        fi
+        # Published Connect images do not include a Node.js runtime, so Connect
+        # cannot run Node.js content until one is installed. The previous step
+        # already started Connect (without Node) in a container; install Node into
+        # that running container, turn Node on in Connect's config, and restart
+        # Connect so it loads Node. Connect checks that the configured Node
+        # executable exists when it starts, so Node must be in place before the
+        # restart.
+        NODE_VERSION=24.14.0
+        CID="${{ steps.connect.outputs.CONTAINER_ID }}"
+        # Download and unpack Node on the CI runner, then copy it into the container,
+        # instead of downloading inside the container: the Connect images do not
+        # reliably include curl/tar/xz, and what they include changes between versions.
+        curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" -o /tmp/node.tar.xz
+        mkdir -p /tmp/node/${NODE_VERSION}
+        tar -xJf /tmp/node.tar.xz -C /tmp/node/${NODE_VERSION} --strip-components=1
+        docker exec "$CID" mkdir -p /opt/node
+        docker cp /tmp/node/${NODE_VERSION} "$CID:/opt/node/${NODE_VERSION}"
+        # Turn Node on and point Connect at the executable we just installed. This
+        # appends to the Connect config file passed to with-connect above
+        # (config-file:), which is mounted into the container, so it applies on restart.
+        printf '\n[NodeJs]\nEnabled = true\nExecutable = /opt/node/%s/bin/node\n' "$NODE_VERSION" \
+          >> ${{ github.workspace }}/.github/connect-runtime.gcfg
+        docker restart "$CID"
+        echo "Waiting for Connect to restart with Node enabled..."
+        for i in $(seq 1 45); do
+          if curl -fsS "${{ steps.connect.outputs.CONNECT_SERVER }}/__api__/server_settings" >/dev/null 2>&1; then
+            echo "Connect is back up with Node enabled."
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "Connect did not come back up after restart:"
+        docker logs "$CID" 2>&1 | tail -60
+        exit 1
+
     - name: Set bootstrap admin email
       shell: bash
       working-directory: ./integration

--- a/.github/actions/lint-extension/action.yml
+++ b/.github/actions/lint-extension/action.yml
@@ -128,3 +128,25 @@ runs:
       run: |
         semver -c $(jq -c -r '.extension.version' < ./extensions/${{ inputs.extension-name }}/manifest.json)
       shell: bash
+
+    # Node.js content selects its runtime from `engines.node` in package.json
+    # (Connect does not read a nodejs field from manifest.json), and the Gallery
+    # reads engines.node as the nodejs requirement. So require it for nodejs content.
+    - name: Check Node.js engines
+      run: |
+        APPMODE=$(jq -r '.metadata.appmode // ""' ./extensions/${{ inputs.extension-name }}/manifest.json)
+        if [ "$APPMODE" != "nodejs" ]; then
+          exit 0
+        fi
+        PACKAGE_JSON=./extensions/${{ inputs.extension-name }}/package.json
+        if [ ! -f "$PACKAGE_JSON" ]; then
+          echo "Error: Node.js extension '${{ inputs.extension-name }}' is missing package.json."
+          exit 1
+        fi
+        ENGINES_NODE=$(jq -r '.engines.node // ""' "$PACKAGE_JSON")
+        if [ -z "$ENGINES_NODE" ]; then
+          echo "Error: Node.js extension '${{ inputs.extension-name }}' must set 'engines.node' in package.json."
+          echo "Connect selects the Node.js version from engines.node, and the Gallery reads it as the nodejs requirement."
+          exit 1
+        fi
+      shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,8 +245,11 @@ add a `nodejs` entry under `environment` in `manifest.json`.
 }
 ```
 
-`engines.node` uses npm semver ranges (for example `>=22`, `^22`, or `22.x`),
-which differ from the pep440-style `~=` ranges used for the other languages.
+`engines.node` uses npm semver ranges, which differ from the pep440-style `~=`
+ranges used for the other languages. Use an open-ended lower bound like `>=22`
+so the content installs on as many Node.js versions as possible. Avoid upper
+bounds such as `^22` or `22.x`, which pin the content to a single Node.js major
+and limit where it can run.
 
 Node.js content must also set `minimumConnectVersion` to at least `2026.06.0`, the
 release where Node.js became generally available. Older Connect UIs ignore the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,6 +226,34 @@ UI.
 `~=` is the "Compatible release" operator. `~=4.2` means "any version greater
 than or equal to 4.2 but less than 5.0".
 
+#### Node.js
+
+Node.js content is the exception: it declares its version in the `engines.node`
+field of `package.json`, not in the manifest `environment` section. Connect
+selects the Node.js version from `engines.node`, so it is the single source of
+truth, and the Gallery reads it automatically as the `nodejs` requirement. Do not
+add a `nodejs` entry under `environment` in `manifest.json`.
+
+```json
+// package.json
+
+{
+  ...
+  "engines": {
+    "node": ">=22"
+  }
+}
+```
+
+`engines.node` uses npm semver ranges (for example `>=22`, `^22`, or `22.x`),
+which differ from the pep440-style `~=` ranges used for the other languages.
+
+Node.js content must also set `minimumConnectVersion` to at least `2026.06.0`, the
+release where Node.js became generally available. Older Connect UIs ignore the
+`nodejs` requirement because they don't know it, so the minimum version check is
+what keeps the content from appearing installable on Connect versions that can't
+run it.
+
 ## Adding content to the Connect Gallery
 
 Once your content has the requirements above it is ready to be added to the

--- a/scripts/extension-list.ts
+++ b/scripts/extension-list.ts
@@ -34,9 +34,14 @@ function getManifest(extensionName: string): ExtensionManifest {
 
 // Node.js content declares its required Node version in package.json's
 // `engines.node`, which is the single source of truth Connect reads (it does not
-// read a nodejs field from manifest.json). Returns undefined for non-Node
-// extensions, which have no package.json.
-function getEnginesNode(extensionName: string): string | undefined {
+// read a nodejs field from manifest.json). Only nodejs app mode content uses it;
+// other extensions may carry a package.json for build tooling, so ignore theirs.
+// engines.node is required for nodejs content: Connect needs it to pick a
+// runtime, so a nodejs extension without it can't run.
+function getEnginesNode(extensionName: string, appmode?: string): string | undefined {
+  if (appmode !== "nodejs") {
+    return undefined;
+  }
   const packageJsonPath = path.join(
     __dirname,
     "..",
@@ -46,10 +51,16 @@ function getEnginesNode(extensionName: string): string | undefined {
     "package.json"
   );
   if (!fs.existsSync(packageJsonPath)) {
-    return undefined;
+    throw new Error(`Node.js extension ${extensionName} is missing package.json`);
   }
   const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-  return pkg.engines?.node;
+  const enginesNode = pkg.engines?.node;
+  if (!enginesNode) {
+    throw new Error(
+      `Node.js extension ${extensionName} must set engines.node in package.json`
+    );
+  }
+  return enginesNode;
 }
 
 // Sort the given extension's version in descending order
@@ -97,7 +108,7 @@ class ExtensionList {
     // R/Python/Quarto declare their version range in the manifest environment;
     // Node.js declares its in package.json's `engines.node`. Merge both so the
     // Gallery gets a nodejs requirement the same way it gets the others.
-    const enginesNode = getEnginesNode(name);
+    const enginesNode = getEnginesNode(name, manifest.metadata?.appmode);
     const requiredEnvironment: ExtensionEnvironment = {
       ...(manifest.environment ?? {}),
       ...(enginesNode ? { nodejs: { requires: enginesNode } } : {}),

--- a/scripts/extension-list.ts
+++ b/scripts/extension-list.ts
@@ -8,6 +8,7 @@ import semverRcompare from "semver/functions/rcompare";
 import {
   Category,
   Extension,
+  ExtensionEnvironment,
   ExtensionManifest,
   ExtensionVersion,
   RequiredFeature
@@ -29,6 +30,26 @@ function getManifest(extensionName: string): ExtensionManifest {
     "manifest.json"
   );
   return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+}
+
+// Node.js content declares its required Node version in package.json's
+// `engines.node`, which is the single source of truth Connect reads (it does not
+// read a nodejs field from manifest.json). Returns undefined for non-Node
+// extensions, which have no package.json.
+function getEnginesNode(extensionName: string): string | undefined {
+  const packageJsonPath = path.join(
+    __dirname,
+    "..",
+    "..",
+    "extensions",
+    extensionName,
+    "package.json"
+  );
+  if (!fs.existsSync(packageJsonPath)) {
+    return undefined;
+  }
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  return pkg.engines?.node;
 }
 
 // Sort the given extension's version in descending order
@@ -73,13 +94,24 @@ class ExtensionList {
       (asset) => asset.name === `${name}.tar.gz`
     );
 
+    // R/Python/Quarto declare their version range in the manifest environment;
+    // Node.js declares its in package.json's `engines.node`. Merge both so the
+    // Gallery gets a nodejs requirement the same way it gets the others.
+    const enginesNode = getEnginesNode(name);
+    const requiredEnvironment: ExtensionEnvironment = {
+      ...(manifest.environment ?? {}),
+      ...(enginesNode ? { nodejs: { requires: enginesNode } } : {}),
+    };
+
     const newVersion = {
       version,
       released: published_at,
       url: browser_download_url,
       minimumConnectVersion: minimumConnectVersion,
       ...(requiredFeatures ? { requiredFeatures } : {}),
-      ...(manifest.environment ? { requiredEnvironment: manifest.environment } : {}),
+      ...(Object.keys(requiredEnvironment).length > 0
+        ? { requiredEnvironment }
+        : {}),
     };
 
     if (this.getExtension(name)) {

--- a/scripts/types/index.ts
+++ b/scripts/types/index.ts
@@ -29,6 +29,9 @@ export interface ExtensionManifest {
     imgUrl?: string;
   };
   environment?: ExtensionEnvironment;
+  metadata?: {
+    appmode?: string;
+  };
 }
 
 export enum RequiredFeature {

--- a/scripts/types/index.ts
+++ b/scripts/types/index.ts
@@ -12,6 +12,7 @@ export interface ExtensionEnvironment {
   python?: LanguageRequirement;
   r?: LanguageRequirement;
   quarto?: LanguageRequirement;
+  nodejs?: LanguageRequirement;
 }
 
 export interface ExtensionManifest {


### PR DESCRIPTION
Fixes #373: Makes the release/CI pipeline understand Node.js content

## Changes (review commit by commit)
- **`extension-list.ts`**: derive `requiredEnvironment.nodejs` from `engines.node` in the extension's `package.json` (Connect's single source of truth; it doesn't read a `nodejs` field from the manifest).
- **lint**: require `engines.node` for `nodejs` app-mode extensions.
- **integration test action**: install a Node runtime into the running Connect container for `nodejs` extensions (the published Connect images ship no Node), enable it, and restart so Connect loads it.
- **CONTRIBUTING**: document the `engines.node` convention and the `minimumConnectVersion >= 2026.06.0` rule.

## Validation

This PR is infra-only: no Node.js example ships here (in-development examples live in `connect-staging-extensions`; the real one is the Express app, #374). So the Node provisioning is validated externally:

1. **In CI (this repo):** on a probe branch, a hello-world Node extension deployed successfully on `preview`, `release`, and `2026.06.0`:
https://github.com/posit-dev/connect-extensions/actions/runs/28797948148
2. **End-to-end in staging:** [connect-staging-extensions#36](https://github.com/posit-dev/connect-staging-extensions/pull/36) adopts this exact harness with a real Node.js hello-world. Its CI is green, and the example was deployed to dogfood, where it runs (`{"message":"Hello from Node.js on Posit Connect!"}`) and Connect recognizes it as Node.js content (Node.js logo). Confirms the approach works on a live Node-enabled Connect, not just in CI.