### PR TITLE
Update extension list: add `script-r` 1.0.3

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1289,12 +1289,12 @@
     {
       "name": "script-r",
       "title": "R: Scheduled Script",
-      "description": "This R script is an example of how you might run a scheduled job on Connect to automate regular imports and transformations from a data source. JSON and CSV files are exported and made available for download. Quarto is used to render the script. The script also generates a custom email, with the generated CSV files as attachments. Swap in your own data source to adapt it to any recurring data job.",
+      "description": "An R script, scheduled to run on Connect, that imports and transforms data, saves the results as downloadable JSON and CSV files, and emails them on every run. A starting point for any recurring data job; swap in your own data source.",
       "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/script-r",
       "latestVersion": {
-        "version": "1.0.2",
-        "released": "2026-06-26T03:06:27Z",
-        "url": "https://github.com/posit-dev/connect-extensions/releases/download/script-r%40v1.0.2/script-r.tar.gz",
+        "version": "1.0.3",
+        "released": "2026-07-06T17:30:46Z",
+        "url": "https://github.com/posit-dev/connect-extensions/releases/download/script-r%40v1.0.3/script-r.tar.gz",
         "minimumConnectVersion": "2025.04.0",
         "requiredEnvironment": {
           "quarto": {
@@ -1306,6 +1306,20 @@
         }
       },
       "versions": [
+        {
+          "version": "1.0.3",
+          "released": "2026-07-06T17:30:46Z",
+          "url": "https://github.com/posit-dev/connect-extensions/releases/download/script-r%40v1.0.3/script-r.tar.gz",
+          "minimumConnectVersion": "2025.04.0",
+          "requiredEnvironment": {
+            "quarto": {
+              "requires": "~=1.4"
+            },
+            "r": {
+              "requires": "~=4.4"
+            }
+          }
+        },
         {
           "version": "1.0.2",
           "released": "2026-06-26T03:06:27Z",


### PR DESCRIPTION
Adds `script-r` 1.0.3 to `extensions.json`. The GitHub release was tagged successfully, but the automated `update-extension-list` job never recorded it in the gallery list.

On the re-run of the blocked workflow, `fetch-releases` re-collected `script-python@v1.0.3` into the `RELEASES` env alongside script-r. Since script-python 1.0.3 was already in the list from the original run, `addExtensionVersion` threw `Version 1.0.3 already exists` (`scripts/extension-list.ts:128`) and exited before adding script-r.

Generated by running the same `scripts/update-extension-list` with `RELEASES` scoped to only the script-r@v1.0.3 release, so the diff matches what the automation would have produced. Only the script-r entry changes; script-python is untouched.

**Verify:** `jq '.extensions[] | select(.name=="script-r") | .latestVersion.version' extensions.json` → `1.0.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)