### PR TITLE
make release re-runs idempotent

### DIFF
--- a/.github/actions/release-extension/action.yml
+++ b/.github/actions/release-extension/action.yml
@@ -95,13 +95,19 @@ runs:
         echo "RELEASE_TAG=$RELEASE_TAG" >> "$GITHUB_ENV"
       shell: bash
 
-    # Create the release, unless the tag already exists (the "Get release
-    # data" step below reads it by tag either way).
+    # Create the release, or if the tag already exists, ensure its asset is
+    # uploaded. `gh release view` confirms the release exists but not that its
+    # asset finished uploading, so a run that died mid-upload would leave a
+    # release with no asset (a 404 in the gallery feed). Re-uploading with
+    # --clobber heals that case and overwrites an existing asset with the
+    # identical file otherwise. The "Get release data" step below reads the tag
+    # either way.
     - name: Release
       if: github.ref_name == 'main' && steps.should_release.outputs.should_release == 'true'
       run: |
         if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
-          echo "Release $RELEASE_TAG already exists; skipping creation."
+          echo "Release $RELEASE_TAG already exists; ensuring its asset is uploaded."
+          gh release upload "$RELEASE_TAG" ${{ inputs.extension-name }}.tar.gz --clobber
         else
           gh release create $RELEASE_TAG \
             --title "${{ inputs.extension-name }} v$MANIFEST_VERSION" \

--- a/.github/actions/release-extension/action.yml
+++ b/.github/actions/release-extension/action.yml
@@ -95,12 +95,20 @@ runs:
         echo "RELEASE_TAG=$RELEASE_TAG" >> "$GITHUB_ENV"
       shell: bash
 
+    # Skip creation if the release already exists so re-running the workflow
+    # over an already-released tag is a no-op. The "Get release data" step
+    # below fetches the release by tag regardless, so the downstream extension
+    # list update still runs off the existing release.
     - name: Release
       if: github.ref_name == 'main' && steps.should_release.outputs.should_release == 'true'
       run: |
-        gh release create $RELEASE_TAG \
-          --title "${{ inputs.extension-name }} v$MANIFEST_VERSION" \
-          ${{ inputs.extension-name }}.tar.gz
+        if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
+          echo "Release $RELEASE_TAG already exists; skipping creation."
+        else
+          gh release create $RELEASE_TAG \
+            --title "${{ inputs.extension-name }} v$MANIFEST_VERSION" \
+            ${{ inputs.extension-name }}.tar.gz
+        fi
       shell: bash
 
     # We fetch the GitHub release using the GitHub API, storing the data 

--- a/.github/actions/release-extension/action.yml
+++ b/.github/actions/release-extension/action.yml
@@ -95,10 +95,8 @@ runs:
         echo "RELEASE_TAG=$RELEASE_TAG" >> "$GITHUB_ENV"
       shell: bash
 
-    # Skip creation if the release already exists so re-running the workflow
-    # over an already-released tag is a no-op. The "Get release data" step
-    # below fetches the release by tag regardless, so the downstream extension
-    # list update still runs off the existing release.
+    # Create the release, unless the tag already exists (the "Get release
+    # data" step below reads it by tag either way).
     - name: Release
       if: github.ref_name == 'main' && steps.should_release.outputs.should_release == 'true'
       run: |

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -456,6 +456,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add extensions.json
+          # Nothing to commit when every release is already recorded.
+          git diff --staged --quiet && echo "No extension list changes to commit." && exit 0
           git commit -m "Update extension list"
           git pull --rebase
           git push

--- a/scripts/extension-list.ts
+++ b/scripts/extension-list.ts
@@ -123,8 +123,7 @@ class ExtensionList {
     if (!semverValid(version.version)) {
       throw new Error(`Invalid version: ${version.version}`);
     }
-    // Skip versions that are already recorded so re-running the workflow over
-    // an already-released version is a no-op instead of a hard failure.
+    // Skip versions that are already recorded.
     if (extension.versions.some((v) => semverEq(v.version, version.version))) {
       console.log(
         `Version ${version.version} already exists for ${name}, skipping.`

--- a/scripts/extension-list.ts
+++ b/scripts/extension-list.ts
@@ -123,9 +123,13 @@ class ExtensionList {
     if (!semverValid(version.version)) {
       throw new Error(`Invalid version: ${version.version}`);
     }
-    // Check if the version already exists
+    // Skip versions that are already recorded so re-running the workflow over
+    // an already-released version is a no-op instead of a hard failure.
     if (extension.versions.some((v) => semverEq(v.version, version.version))) {
-      throw new Error(`Version ${version.version} already exists`);
+      console.log(
+        `Version ${version.version} already exists for ${name}, skipping.`
+      );
+      return;
     }
 
     // Add the version to the list


### PR DESCRIPTION
Re-running an Extension Workflow that partially succeeded now skips already-completed work instead of failing, so a run self-heals rather than needing a manual fix like #424.

- `.github/actions/release-extension/action.yml`: the release step no longer fails when the tag exists. It checks out the run's commit (where `extensions.json` predates the release), so `should_release` stays `true` on a re-run; guarded with `gh release view`, and "Get release data" reads the tag either way.
- `scripts/extension-list.ts`: `addExtensionVersion` skips an already-recorded version instead of throwing, so one already-listed extension no longer aborts the rest of the batch.

**Verify:** `cd scripts && npx tsc && RELEASES='[<already-listed release>,<new release>]' node ./dist/extension-list.js` - logs a skip for the existing version and adds the new one without throwing.