### PR TITLE
feat(integration): support Node.js extensions in local make test runs

### DIFF
--- a/integration/Makefile
+++ b/integration/Makefile
@@ -13,6 +13,10 @@ UV_LOCK := uv.lock
 WITH_CONNECT ?= with-connect
 LICENSE_FILE ?= ./license.lic
 
+# Node.js provisioning: the version installed into the container for nodejs
+# extensions (must satisfy their engines.node). Matches the CI action.
+NODE_VERSION ?= 24.14.0
+
 # Extension settings
 EXTENSION_NAME ?=
 
@@ -42,6 +46,7 @@ PYTEST_ARGS ?= "-s"
 CONNECT_VERSIONS := \
 	preview \
 	release \
+	2026.06.0 \
 	2026.04.1 \
 	2026.03.1 \
 	2026.02.0 \
@@ -90,24 +95,32 @@ clean:
 
 
 # Run test suite for a specific Connect version using with-connect.
+# Node.js extensions need a Node runtime installed into the container (the
+# published Connect images don't ship one), so they run through a helper script;
+# every other extension runs directly against with-connect.
 $(CONNECT_VERSIONS): %:
 	@if [ -z "$(EXTENSION_NAME)" ]; then \
 		echo "Error: EXTENSION_NAME is required. Usage: make <version> EXTENSION_NAME=<name>"; \
 		exit 1; \
 	fi
-	mkdir -p reports logs
-	$(WITH_CONNECT) --version $* --license $(LICENSE_FILE) \
-		-e CONNECT_SERVER_EMAILPROVIDER=None \
-		-e CONNECT_APPLICATIONS_PACKAGEAUDITINGENABLED=true \
-		-- bash -c '\
-			set -o pipefail; \
-			cd $(CURDIR) && \
-			$(UV) run tests/posit/connect/set_bootstrap_admin_email.py && \
-			EXTENSION_NAME=$(EXTENSION_NAME) \
-			BUNDLE_BASE_PATH=$(CURDIR)/bundles \
-			$(UV) run pytest $$(echo $(PYTEST_ARGS)) \
-				--junit-xml=./reports/$*.xml \
-			2>&1 | tee ./logs/$*.log'
+	@mkdir -p reports logs
+	@APPMODE=$$(python3 -c "import json; print(json.load(open('../extensions/$(EXTENSION_NAME)/manifest.json')).get('metadata', {}).get('appmode', ''))" 2>/dev/null || echo ""); \
+	if [ "$$APPMODE" = "nodejs" ]; then \
+		NODE_VERSION="$(NODE_VERSION)" WITH_CONNECT="$(WITH_CONNECT)" LICENSE_FILE="$(LICENSE_FILE)" UV="$(UV)" PYTEST_ARGS="$$(echo $(PYTEST_ARGS))" \
+			bash nodejs-integration-test.sh "$*" "$(EXTENSION_NAME)"; \
+	else \
+		$(WITH_CONNECT) --version $* --license $(LICENSE_FILE) \
+			-e CONNECT_SERVER_EMAILPROVIDER=None \
+			-e CONNECT_APPLICATIONS_PACKAGEAUDITINGENABLED=true \
+			-- bash -c 'set -o pipefail; \
+				cd $(CURDIR) && \
+				$(UV) run tests/posit/connect/set_bootstrap_admin_email.py && \
+				EXTENSION_NAME=$(EXTENSION_NAME) \
+				BUNDLE_BASE_PATH=$(CURDIR)/bundles \
+				$(UV) run pytest $$(echo $(PYTEST_ARGS)) \
+					--junit-xml=./reports/$*.xml \
+				2>&1 | tee ./logs/$*.log'; \
+	fi
 
 
 # Run test suite against all Connect versions.
@@ -152,7 +165,11 @@ package-extension:
 	fi
 	@mkdir -p ./bundles
 	@echo "Packaging extension: $(EXTENSION_NAME)"
-	@pushd .. > /dev/null && tar -czf ./integration/bundles/$(EXTENSION_NAME).tar.gz -C ./extensions $(EXTENSION_NAME) && popd > /dev/null
+	@# Package the extension the same way CI does (nested under extensions/<name>).
+	@# Force ustar format: macOS bsdtar defaults to pax, whose extended headers
+	@# Connect's bundle reader cannot parse (it fails with "Cannot open manifest").
+	@# ustar is understood by both bsdtar and GNU tar.
+	@tar --format=ustar -czf ./bundles/$(EXTENSION_NAME).tar.gz -C .. ./extensions/$(EXTENSION_NAME)
 	@echo "Package created: ./bundles/$(EXTENSION_NAME).tar.gz"
 
 

--- a/integration/nodejs-integration-test.sh
+++ b/integration/nodejs-integration-test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Run the integration test for a Node.js extension against a local Connect.
+#
+# Published Connect images do not include a Node.js runtime, so a plain
+# `with-connect` run cannot execute Node.js content. This script starts Connect,
+# installs Node into the running container, enables Node in Connect's config, and
+# restarts Connect so it loads Node before the extension is deployed. It mirrors
+# the provisioning the CI action does for nodejs extensions.
+#
+# Usage: nodejs-integration-test.sh <connect-version> <extension-name>
+set -euo pipefail
+
+CONNECT_VERSION="${1:?connect version required}"
+EXTENSION_NAME="${2:?extension name required}"
+
+: "${WITH_CONNECT:=with-connect}"
+: "${LICENSE_FILE:=./license.lic}"
+: "${UV:=uv}"
+: "${PYTEST_ARGS:=-s}"
+: "${NODE_VERSION:=24.14.0}"
+
+cd "$(dirname "$0")"
+mkdir -p reports logs
+
+# Start Connect without Node. with-connect prints CONNECT_API_KEY,
+# CONNECT_SERVER, and CONTAINER_ID for us to eval into this shell.
+CONNECT_API_KEY=""
+CONNECT_SERVER=""
+CONTAINER_ID=""
+eval "$("$WITH_CONNECT" --version "$CONNECT_VERSION" --license "$LICENSE_FILE" \
+  -e CONNECT_SERVER_EMAILPROVIDER=None \
+  -e CONNECT_APPLICATIONS_PACKAGEAUDITINGENABLED=true)"
+
+# Always stop Connect on exit, however we exit.
+trap '"$WITH_CONNECT" --stop "$CONTAINER_ID" >/dev/null 2>&1 || true' EXIT
+
+# Match the Node.js build to the container's architecture. On Apple Silicon the
+# Connect container runs arm64, where a linux-x64 Node.js build cannot execute.
+CONTAINER_ARCH="$(docker exec "$CONTAINER_ID" uname -m)"
+case "$CONTAINER_ARCH" in
+  x86_64) NODE_ARCH="x64" ;;
+  aarch64) NODE_ARCH="arm64" ;;
+  *) echo "Unsupported container architecture: $CONTAINER_ARCH"; exit 1 ;;
+esac
+
+# Download and unpack Node on this machine, then copy it into the container
+# (the Connect images do not reliably include curl/tar/xz).
+curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz
+rm -rf "/tmp/node/${NODE_VERSION}"
+mkdir -p "/tmp/node/${NODE_VERSION}"
+tar -xJf /tmp/node.tar.xz -C "/tmp/node/${NODE_VERSION}" --strip-components=1
+docker exec "$CONTAINER_ID" mkdir -p /opt/node
+docker cp "/tmp/node/${NODE_VERSION}" "$CONTAINER_ID:/opt/node/${NODE_VERSION}"
+
+# Turn Node on in Connect's config and restart so it loads. Connect validates the
+# configured executable at startup, so Node must be in place before the restart.
+docker exec "$CONTAINER_ID" sh -c \
+  "printf '\n[NodeJs]\nEnabled = true\nExecutable = /opt/node/${NODE_VERSION}/bin/node\n' >> /etc/rstudio-connect/rstudio-connect.gcfg"
+docker restart "$CONTAINER_ID"
+
+echo "Waiting for Connect to restart with Node enabled..."
+for _ in $(seq 1 45); do
+  if curl -fsS "${CONNECT_SERVER}/__api__/server_settings" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+if ! curl -fsS "${CONNECT_SERVER}/__api__/server_settings" >/dev/null 2>&1; then
+  echo "Connect did not come back up after enabling Node:"
+  docker logs "$CONTAINER_ID" 2>&1 | tail -60
+  exit 1
+fi
+
+# Run the tests against the provisioned Connect.
+export CONNECT_SERVER CONNECT_API_KEY
+"$UV" run tests/posit/connect/set_bootstrap_admin_email.py
+EXTENSION_NAME="$EXTENSION_NAME" BUNDLE_BASE_PATH="$PWD/bundles" \
+  "$UV" run pytest $PYTEST_ARGS --junit-xml="./reports/${CONNECT_VERSION}.xml" 2>&1 \
+  | tee "./logs/${CONNECT_VERSION}.log"


### PR DESCRIPTION
Local `make` integration testing now supports Node.js extensions, so a Node/Express
extension can be developed and verified locally, not just in CI. This is
harness/tooling groundwork; it applies to whatever Node/Express example or
extension we ultimately build on top of it. Mirrors the same change already made in
connect-staging-extensions.

## What changed

- `nodejs-integration-test.sh` (new): for `appmode: nodejs` extensions, starts
  Connect via with-connect, installs a Node runtime into the container (the
  published Connect images ship none), enables it, restarts, then runs the test.
  The Node build is architecture-matched (arm64/x64), so it works on Apple Silicon
  and on CI runners.
- `Makefile`: routes `nodejs` extensions to that script and leaves every other
  extension on the existing with-connect path; adds `NODE_VERSION` and `2026.06.0`
  to the version list.
- `package-extension`: forces `ustar` format. macOS bsdtar defaults to pax, whose
  headers Connect's bundle reader cannot parse for a nested manifest ("Cannot open
  manifest"); ustar is read by both bsdtar and GNU tar.

## Not in scope

- No Node extension content yet. The actual example/extension (Node + Express) is
  separate follow-up work and will build on this harness.
- CI-side Node support (provisioning, lint, `engines.node`) lands via #373/#423;
  this is the local `make` counterpart.

## Verified

Ran locally end-to-end against Connect 2026.06.0: a Node extension deploys and
returns HTTP 200, and a non-Node extension still deploys through the unchanged path.