### PR TITLE
Polish chat-with-content extension

### DIFF
--- a/.github/workflows/chat-with-content.yml
+++ b/.github/workflows/chat-with-content.yml
@@ -1,0 +1,74 @@
+name: Chat with Content
+
+on:
+  workflow_call:
+
+# Setup the environment with the extension name for easy re-use
+# Also need the GH_TOKEN for the release-extension action to be able to use gh
+env:
+  EXTENSION_NAME: chat-with-content
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  extension:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./extensions/${{ env.EXTENSION_NAME }}
+
+    steps:
+      # Checkout the repository so the rest of the actions can run with no issue
+      - uses: actions/checkout@v4
+
+      # We want to fail quickly if the linting fails, do that first
+      - uses: ./.github/actions/lint-extension
+        with:
+          extension-name: ${{ env.EXTENSION_NAME }}
+
+      # Run the Python tests before packaging.
+      - uses: astral-sh/setup-uv@v5
+        with:
+          pyproject-file: ./extensions/${{ env.EXTENSION_NAME }}/pyproject.toml
+
+      - name: Run tests
+        run: uv run pytest
+
+      # Upload only the files the extension needs to run, leaving out tests,
+      # pyproject.toml, and other repo-only files.
+      - name: Upload extension files
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.EXTENSION_NAME }}
+          path: |
+            extensions/${{ env.EXTENSION_NAME }}/app.py
+            extensions/${{ env.EXTENSION_NAME }}/helpers.py
+            extensions/${{ env.EXTENSION_NAME }}/requirements.txt
+            extensions/${{ env.EXTENSION_NAME }}/manifest.json
+
+      # Package up the extension into a TAR using the generalized
+      # package-extension action
+      - uses: ./.github/actions/package-extension
+        with:
+          extension-name: ${{ env.EXTENSION_NAME }}
+          artifact-name: ${{ env.EXTENSION_NAME }}
+
+  connect-integration-tests:
+    needs: extension
+    uses: ./.github/workflows/connect-integration-tests.yml
+    secrets: inherit
+    with:
+      extensions: '["chat-with-content"]'  # JSON array format to match the workflow input schema
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [extension, connect-integration-tests]
+    # Release the extension using the release-extension action
+    # Will only create a GitHub release if merged to `main` and the semver
+    # version has been updated
+    steps:
+      # Checkout the repository so the rest of the actions can run with no issue
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/release-extension
+        with:
+          extension-name: ${{ env.EXTENSION_NAME }}

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -56,7 +56,6 @@ jobs:
             stock-report: extensions/stock-report/**
             simple-mcp-server: extensions/simple-mcp-server/**
             simple-shiny-chat-with-mcp: extensions/simple-shiny-chat-with-mcp/**
-            chat-with-content: extensions/chat-with-content/**
             pqr: extensions/pqr/**
 
       # When infra changed, test all simple extensions; otherwise use the filter output
@@ -212,6 +211,7 @@ jobs:
       package-vulnerability-scanner: ${{ steps.resolve.outputs.package-vulnerability-scanner }}
       runtime-version-scanner: ${{ steps.resolve.outputs.runtime-version-scanner }}
       usage-metrics-dashboard: ${{ steps.resolve.outputs.usage-metrics-dashboard }}
+      chat-with-content: ${{ steps.resolve.outputs.chat-with-content }}
 
     steps:
       - uses: actions/checkout@v4
@@ -233,6 +233,7 @@ jobs:
             package-vulnerability-scanner: extensions/package-vulnerability-scanner/**
             runtime-version-scanner: extensions/runtime-version-scanner/**
             usage-metrics-dashboard: extensions/usage-metrics-dashboard/**
+            chat-with-content: extensions/chat-with-content/**
 
       # When infra changed, trigger all complex extensions too
       - id: resolve
@@ -243,11 +244,13 @@ jobs:
             echo "package-vulnerability-scanner=true" >> $GITHUB_OUTPUT
             echo "runtime-version-scanner=true" >> $GITHUB_OUTPUT
             echo "usage-metrics-dashboard=true" >> $GITHUB_OUTPUT
+            echo "chat-with-content=true" >> $GITHUB_OUTPUT
           else
             echo "publisher-command-center=${{ steps.changes.outputs.publisher-command-center }}" >> $GITHUB_OUTPUT
             echo "package-vulnerability-scanner=${{ steps.changes.outputs.package-vulnerability-scanner }}" >> $GITHUB_OUTPUT
             echo "runtime-version-scanner=${{ steps.changes.outputs.runtime-version-scanner }}" >> $GITHUB_OUTPUT
             echo "usage-metrics-dashboard=${{ steps.changes.outputs.usage-metrics-dashboard }}" >> $GITHUB_OUTPUT
+            echo "chat-with-content=${{ steps.changes.outputs.chat-with-content }}" >> $GITHUB_OUTPUT
           fi
 
   # Creates and releases the Publisher Command Center extension using a custom
@@ -287,6 +290,15 @@ jobs:
     uses: ./.github/workflows/usage-metrics-dashboard.yml
     secrets: inherit
 
+  # Creates and releases the Chat with Content extension using a custom workflow
+  chat-with-content:
+    needs: [complex-extension-changes]
+    # Only runs if the `complex-extension-changes` job detects changes in the
+    # chat-with-content extension directory
+    if: ${{ needs.complex-extension-changes.outputs.chat-with-content == 'true' }}
+    uses: ./.github/workflows/chat-with-content.yml
+    secrets: inherit
+
   # All extensions have been linted, packaged, and released, if necessary
   # Continuing to update the extension list with the latest release data
 
@@ -300,6 +312,7 @@ jobs:
       package-vulnerability-scanner,
       runtime-version-scanner,
       usage-metrics-dashboard,
+      chat-with-content,
     ]
     permissions:
       pull-requests: write
@@ -383,6 +396,7 @@ jobs:
       package-vulnerability-scanner,
       runtime-version-scanner,
       usage-metrics-dashboard,
+      chat-with-content,
     ]
     if: ${{ always() }}
     outputs:

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -67,6 +67,12 @@ jobs:
             echo "Infrastructure changed — testing all simple extensions"
             changes=$(find extensions -maxdepth 1 -mindepth 1 -type d -printf '%f\n' \
               | while read -r ext; do
+                  # Skip complex extensions: they have their own dedicated
+                  # workflow (which builds them) and would fail the simple
+                  # no-build flow (e.g. a missing frontend dist/).
+                  if [ -f ".github/workflows/$ext.yml" ]; then
+                    continue
+                  fi
                   if jq -e '.extension.minimumConnectVersion' "extensions/$ext/manifest.json" > /dev/null 2>&1; then
                     echo "$ext"
                   fi

--- a/extensions/chat-with-content/CHANGELOG.md
+++ b/extensions/chat-with-content/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the Chat with Content extension will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.8] - 2026-07-16
+
+### Added
+
+- Backend test suite (`test_helpers.py`) run in a dedicated CI workflow. (#433)
+- An in-app note explaining that the app runs as the signed-in viewer, reads
+  content with their own permissions via the Visitor API Key, and stores no admin
+  key. (#433)
+
+### Changed
+
+- Retitled to "Shiny: Chat with your content", rewrote the description, and
+  rewrote the README. (#433)
+- Refreshed the default model names to Claude Sonnet 4.5. (#433)
+- Only probe AWS Bedrock credentials at startup when no chat provider is
+  configured, avoiding an unnecessary live Bedrock call. (#433)
+- Surfaced real chat errors in the UI (`on_error="actual"`). (#433)
+- Trimmed the bundled manifest to the files the app needs to run. (#433)
+
+### Fixed
+
+- Guarded against content with no deployment time and against a missing chat
+  provider, which could previously crash the app. (#433)
+- Truncated large content before sending it to the model so a big page can't
+  overflow the context window. (#433)
+- Removed a duplicate `chatlas` dependency pin. (#433)
+
 ## [0.0.7] - 2026-06-15
 
 ### Changed

--- a/extensions/chat-with-content/CHANGELOG.md
+++ b/extensions/chat-with-content/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole content list empty. (#433)
 - Show a clear error when the app can't verify your Connect session, instead of
   silently running with the wrong identity and failing later. (#433)
+- Require the viewer's Connect session before listing content: when the app can't
+  read a session token (for example if OAuth integrations are disabled on the
+  server), it shows the setup screen instead of listing the deployer's content. (#433)
 - Don't summarize an unrelated page if the content frame redirects cross-origin
   (for example to an external login). (#433)
 - Truncated large content before sending it to the model so a big page can't

--- a/extensions/chat-with-content/CHANGELOG.md
+++ b/extensions/chat-with-content/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An in-app note explaining that the app runs as the signed-in viewer, reads
   content with their own permissions via the Visitor API Key, and stores no admin
   key. (#433)
-- Clear error notifications when content can't be listed or opened from Connect,
-  showing the reason instead of leaving the selector silently empty. (#433)
+- Clear, persistent error notifications when content can't be listed or opened
+  from Connect, showing the reason instead of leaving the selector silently
+  empty, plus a message when you have no content available to chat with. (#433)
 
 ### Changed
 
@@ -28,8 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Guarded against content with no deployment time and against a missing chat
-  provider, which could previously crash the app. (#433)
+- Guarded against content with no deployment time, a malformed deployment time,
+  and a missing chat provider, which could previously crash the app or leave the
+  whole content list empty. (#433)
+- Show a clear error when the app can't verify your Connect session, instead of
+  silently running with the wrong identity and failing later. (#433)
 - Truncated large content before sending it to the model so a big page can't
   overflow the context window. (#433)
 - Removed a duplicate `chatlas` dependency pin. (#433)

--- a/extensions/chat-with-content/CHANGELOG.md
+++ b/extensions/chat-with-content/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Chat with Content extension will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.8] - 2026-07-16
+## [0.0.8] - 2026-07-17
 
 ### Added
 
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole content list empty. (#433)
 - Show a clear error when the app can't verify your Connect session, instead of
   silently running with the wrong identity and failing later. (#433)
+- Don't summarize an unrelated page if the content frame redirects cross-origin
+  (for example to an external login). (#433)
 - Truncated large content before sending it to the model so a big page can't
   overflow the context window. (#433)
 - Removed a duplicate `chatlas` dependency pin. (#433)

--- a/extensions/chat-with-content/CHANGELOG.md
+++ b/extensions/chat-with-content/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An in-app note explaining that the app runs as the signed-in viewer, reads
   content with their own permissions via the Visitor API Key, and stores no admin
   key. (#433)
+- Clear error notifications when content can't be listed or opened from Connect,
+  showing the reason instead of leaving the selector silently empty. (#433)
 
 ### Changed
 

--- a/extensions/chat-with-content/CHANGELOG.md
+++ b/extensions/chat-with-content/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Retitled to "Shiny: Chat with your content", rewrote the description, and
-  rewrote the README. (#433)
+- Rewrote the description and the README, and aligned the in-app setup screen
+  with the MCP chat extension (only the still-missing step is shown). (#433)
 - Refreshed the default model names to Claude Sonnet 4.5. (#433)
 - Only probe AWS Bedrock credentials at startup when no chat provider is
   configured, avoiding an unnecessary live Bedrock call. (#433)

--- a/extensions/chat-with-content/CHANGELOG.md
+++ b/extensions/chat-with-content/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   step still missing rather than repeating both. (#433)
 - Refreshed the default model names to Claude Sonnet 4.5. (#433)
 - Skip the AWS Bedrock credential probe at startup when a chat provider is
-  configured, so the app doesn't wait on an unnecessary Bedrock call before
-  loading. (#433)
+  configured, and cap it with a timeout when it does run, so a slow or
+  unreachable Bedrock endpoint can't delay or hang the app's startup. (#433)
 - Show the actual error in the chat when a request fails, instead of a generic
   message. (#433)
 
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   server), it shows the setup screen instead of listing the deployer's content. (#433)
 - Don't summarize an unrelated page if the content frame redirects cross-origin
   (for example to an external login). (#433)
+- Re-summarize when you switch to a different content item whose rendered HTML is
+  byte-identical to the previous one, instead of leaving the earlier summary up. (#433)
 - Truncated large content before sending it to the model so a big page can't
   overflow the context window. (#433)
 

--- a/extensions/chat-with-content/CHANGELOG.md
+++ b/extensions/chat-with-content/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Backend test suite (`test_helpers.py`) run in a dedicated CI workflow. (#433)
 - An in-app note explaining that the app runs as the signed-in viewer, reads
   content with their own permissions via the Visitor API Key, and stores no admin
   key. (#433)
@@ -19,13 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rewrote the description and the README, and aligned the in-app setup screen
-  with the MCP chat extension (only the still-missing step is shown). (#433)
+- Rewrote the description and the README, and the setup screen now shows only the
+  step still missing rather than repeating both. (#433)
 - Refreshed the default model names to Claude Sonnet 4.5. (#433)
-- Only probe AWS Bedrock credentials at startup when no chat provider is
-  configured, avoiding an unnecessary live Bedrock call. (#433)
-- Surfaced real chat errors in the UI (`on_error="actual"`). (#433)
-- Trimmed the bundled manifest to the files the app needs to run. (#433)
+- Skip the AWS Bedrock credential probe at startup when a chat provider is
+  configured, so the app doesn't wait on an unnecessary Bedrock call before
+  loading. (#433)
+- Show the actual error in the chat when a request fails, instead of a generic
+  message. (#433)
 
 ### Fixed
 
@@ -41,17 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (for example to an external login). (#433)
 - Truncated large content before sending it to the model so a big page can't
   overflow the context window. (#433)
-- Removed a duplicate `chatlas` dependency pin. (#433)
 
 ## [0.0.7] - 2026-06-15
 
 ### Changed
 
 - Constrained the Python runtime requirement to the current major version (`>=3.10.0` → `~=3.10`). (#376)
-
-### Fixed
-
-- Corrected a stale manifest checksum; no change to bundled files. (#376)
 
 ## [0.0.6] - 2026-05-08
 

--- a/extensions/chat-with-content/CONTRIBUTING.md
+++ b/extensions/chat-with-content/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to Chat with Content
+
+## Prerequisites
+
+- Python 3.10 or higher
+- [uv](https://docs.astral.sh/uv/)
+
+## Setup
+
+Run `uv sync` to install the app and test dependencies.
+
+## Development
+
+Run `uv run shiny run app.py` to start the app locally. It reads the same
+`CHATLAS_CHAT_PROVIDER_MODEL` / API-key environment variables described in the
+[README](./README.md).
+
+## Tests
+
+Run `uv run pytest`. The tests cover the pure helpers in `helpers.py`; the Shiny
+app in `app.py` is kept thin over those functions so the logic can be tested
+without a running session or any LLM / Connect calls. CI runs the same command.
+
+## Bundle
+
+The files sent in the deployment bundle are:
+
+- `app.py`
+- `helpers.py`
+- `requirements.txt`
+
+`pyproject.toml`, tests, and repo docs are not bundled.
+
+## Changelog
+
+Update the [CHANGELOG](./CHANGELOG.md) using the
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, referencing the
+PR number, and bump `extension.version` in `manifest.json` to trigger a release.

--- a/extensions/chat-with-content/README.md
+++ b/extensions/chat-with-content/README.md
@@ -1,76 +1,113 @@
-# Chat with Content Extension
+# Shiny: Chat with your content
 
-The "Chat with Content" extension for Posit Connect provides a way to interact with and query your static content using a chat interface powered by a Large Language Model (LLM).
+## About this extension
 
-## Overview
+Chat with your content turns a report or data app you have published to Posit
+Connect into something you can ask questions about. Pick a piece of static
+content from a dropdown, and the app extracts its text, hands it to a Large
+Language Model (LLM), and answers your questions about it in a chat panel beside
+the rendered page. It opens each document with a short summary and a few
+suggested questions, and answers using only the selected content.
 
-This Shiny application allows users to select a piece of static content (such as static R Markdown, Quarto, or Jupyter Notebook documents) deployed on Posit Connect and ask questions about it. The application extracts the content from the selected document, provides it as context to an LLM, and displays the answers in a chat window.
+It works with static, rendered content: Quarto, R Markdown, and Jupyter
+documents, and static HTML.
 
-Key features:
-- Lists available static content from Connect for the user to choose from.
-- Displays the selected content in an iframe.
-- Provides a chat interface to ask questions about the content.
-- Uses an LLM to generate answers based *only* on the provided content.
-- Suggests relevant questions to ask about the content.
+## How it works
+
+- **Runs as the signed-in viewer.** The app calls the Connect API with the
+  viewer's own identity, through a Connect Visitor API Key integration, so each
+  person only sees and chats with the content they already have permission to
+  open. No admin API key is stored in the app.
+- **Answers only from the selected content.** When you choose a document, the app
+  renders it in the main panel, converts it to markdown, and sends that markdown
+  to the LLM as the only context. A system prompt instructs the model to answer
+  from that content alone and to say when it can't.
+- **Provider-agnostic.** The LLM connection is built with
+  [chatlas](https://posit-dev.github.io/chatlas/), so you can point it at OpenAI,
+  Azure OpenAI, Anthropic, Google Gemini, or Anthropic on AWS Bedrock by setting
+  environment variables (see [Setup](#setup)).
+- **Keeps requests bounded.** Very large pages are truncated before they are sent
+  to the model, so a big report won't overflow the model's context window.
+
+## Deploy it
+
+Deploy it straight from the Connect Gallery to get a copy running, then configure
+it (below). To run a customized version, get the
+[extension source](https://github.com/posit-dev/connect-extensions/tree/main/extensions/chat-with-content),
+make your changes, and publish with
+[`rsconnect deploy shiny`](https://docs.posit.co/rsconnect-python/) or a
+[git-backed deployment](https://docs.posit.co/connect/user/git-backed/). Requires
+Connect 2025.04.0 or newer with OAuth Integrations enabled.
 
 ## Setup
 
-### Administrator Setup
+After deploying, open the content's settings and configure two things.
 
-As a Posit Connect administrator, you need to configure the environment for this extension to run correctly.
+### 1. Choose an LLM provider
 
-1.  **Publish the Extension**: Publish this application to Posit Connect.
+Set the `CHATLAS_CHAT_PROVIDER_MODEL` environment variable to a
+`provider/model` string, plus the API key for that provider (set the key as a
+secret). Until a provider is configured, the app shows a setup screen. See the
+[chatlas documentation](https://posit-dev.github.io/chatlas/reference/ChatAuto.html)
+for the full list of providers and arguments.
 
-2.  **Configure Environment Variables**: In the content settings, set the following environment variables to configure the LLM provider. This extension uses the `chatlas` library, which supports various LLM providers like OpenAI, Azure OpenAI, Google Gemini, Anthropic, and Anthropic on AWS Bedrock.
+**OpenAI**
 
-    Set `CHATLAS_CHAT_PROVIDER_MODEL` to specify the provider and model in the format `provider/model`. You also need to provide the API key for the chosen service.
+- `CHATLAS_CHAT_PROVIDER_MODEL`: `openai/gpt-4o`
+- `OPENAI_API_KEY`: `<your-openai-api-key>`
 
-    **Example for OpenAI:**
+**Anthropic**
 
-    -   `CHATLAS_CHAT_PROVIDER_MODEL`: `openai/gpt-4o`
-    -   `OPENAI_API_KEY`: `<your-openai-api-key>` (Set this as a secret)
+- `CHATLAS_CHAT_PROVIDER_MODEL`: `anthropic/claude-sonnet-4-5-20250929`
+- `ANTHROPIC_API_KEY`: `<your-anthropic-api-key>`
 
-    **Example for Google Gemini:**
+**Google Gemini**
 
-    -   `CHATLAS_CHAT_PROVIDER_MODEL`: `google/gemini-1.5-flash`
-    -   `GOOGLE_API_KEY`: `<your-google-api-key>` (Set this as a secret)
+- `CHATLAS_CHAT_PROVIDER_MODEL`: `google/gemini-2.0-flash`
+- `GOOGLE_API_KEY`: `<your-google-api-key>`
 
-    **Example for Anthropic:**
+**Azure OpenAI**
 
-    -   `CHATLAS_CHAT_PROVIDER_MODEL`: `anthropic/claude-sonnet-4-20250514`
-    -   `ANTHROPIC_API_KEY`: `<your-anthropic-api-key>` (Set this as a secret)
+Set `CHATLAS_CHAT_PROVIDER_MODEL` to `azure-openai` (no model suffix) and pass the
+deployment-specific arguments via `CHATLAS_CHAT_ARGS`:
 
-    **Example for Azure OpenAI:**
+- `CHATLAS_CHAT_PROVIDER_MODEL`: `azure-openai`
+- `AZURE_OPENAI_API_KEY`: `<your-azure-openai-api-key>`
+- `CHATLAS_CHAT_ARGS`: `{"deployment_id": "gpt-4.1-mini", "endpoint": "https://{your-resource-name}.openai.azure.com", "api_version": "2025-03-01-preview"}`
+  (see [Azure OpenAI API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation))
 
-    For Azure OpenAI, set `CHATLAS_CHAT_PROVIDER_MODEL` to `azure-openai` (with no model suffix) and pass the deployment-specific arguments via `CHATLAS_CHAT_ARGS`:
+**Anthropic on AWS Bedrock**
 
-    -   `CHATLAS_CHAT_PROVIDER_MODEL`: `azure-openai`
-    -   `AZURE_OPENAI_API_KEY`: `<your-azure-openai-api-key>` (Set this as a secret)
-    -   `CHATLAS_CHAT_ARGS`: `{"deployment_id": "gpt-4.1-mini", "endpoint": "https://{your-resource-name}.openai.azure.com", "api_version": "2025-03-01-preview"}` (see [Azure OpenAI API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation))
+The app uses the
+[botocore](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/credentials.html)
+credential chain for AWS. If Connect runs on an EC2 instance with an IAM role that
+grants Bedrock access, credentials are detected automatically and no configuration
+is needed; the app defaults to the `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
+model. To use Bedrock without an IAM role, set:
 
-    **Example for Anthropic on AWS Bedrock:**
+- `AWS_ACCESS_KEY_ID`: `<your-aws-access-key>`
+- `AWS_SECRET_ACCESS_KEY`: `<your-aws-secret-key>` (set as a secret)
+- `AWS_REGION`: `<your-aws-region>` (e.g. `us-east-1`)
+- `AWS_SESSION_TOKEN`: `<your-session-token>` (optional, for temporary credentials)
 
-    The application uses the [botocore](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/credentials.html) credential chain for AWS authentication. If the Connect server is running on an EC2 instance with an IAM role that grants access to Bedrock, credentials are automatically detected and no configuration is needed. In this case, the application uses the `us.anthropic.claude-sonnet-4-20250514-v1:0` model by default.
+### 2. Add a Connect Visitor API Key integration
 
-    To use Bedrock without an IAM role, set the following environment variables in the content settings:
+The app lists and reads content as the signed-in viewer, so it needs a Visitor
+API Key integration to call the Connect API with that person's identity. On the
+content's **Access** tab, add a **Connect Visitor API Key** integration under
+**Integrations**. Until it is added, the app shows the setup screen. If you don't
+see one in the list, an administrator must enable it on your Connect server. See
+the [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
 
-    -   `AWS_ACCESS_KEY_ID`: `<your-aws-access-key>`
-    -   `AWS_SECRET_ACCESS_KEY`: `<your-aws-secret-key>` (Set this as a secret)
-    -   `AWS_REGION`: `<your-aws-region>` (e.g., `us-east-1`)
-    -   `AWS_SESSION_TOKEN`: `<your-session-token>` (Optional, for temporary credentials)
+## Customize it
 
-    For more details on supported providers and their arguments, see the [chatlas documentation](https://posit-dev.github.io/chatlas/reference/ChatAuto.html).
+- **Swap the model or provider** by changing the environment variables above.
+- **Change how the assistant behaves** by editing the system prompt in `app.py`
+  (for example, to change its tone or the suggested-prompt format).
+- **Adjust the context limit** by changing `MAX_CONTEXT_CHARS` in `helpers.py`.
 
-3.  **Enable Visitor API Key Integration**: This extension requires access to the Connect API on behalf of the visiting user to list their available content. In the content settings, add a "Connect Visitor API Key" integration.
+## Learn more
 
-### User Setup
-
-Once the administrator has configured the extension, users can start using it. There is no specific setup required for end-users.
-
-## Usage
-
-1.  Open the "Chat with Content" application in Posit Connect.
-2.  Use the dropdown menu to select a piece of content you want to chat with. The list shows static content you have access to.
-3.  The selected content will be displayed in the main panel.
-4.  The chat panel on the left will show a summary of the content and suggest some questions you can ask.
-5.  Type your questions about the content in the chat input box and press enter. The assistant will answer based on the information available in the document.
+- [chatlas](https://posit-dev.github.io/chatlas/)
+- [Shiny for Python](https://shiny.posit.co/py/)
+- [Posit Connect OAuth integrations](https://docs.posit.co/connect/user/oauth-integrations/)

--- a/extensions/chat-with-content/README.md
+++ b/extensions/chat-with-content/README.md
@@ -1,4 +1,4 @@
-# Shiny: Chat with your content
+# Chat with Content
 
 ## About this extension
 
@@ -41,63 +41,23 @@ Connect 2025.04.0 or newer with OAuth Integrations enabled.
 
 ## Setup
 
-After deploying, open the content's settings and configure two things.
+After deploying, in the content's settings:
 
-### 1. Choose an LLM provider
+- **Choose an LLM** by setting `CHATLAS_CHAT_PROVIDER_MODEL` (for example
+  `openai/gpt-4o`) plus the matching API key (`OPENAI_API_KEY`,
+  `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, ...) on the **Advanced** tab, under
+  **Environment Variables**. See the
+  [chatlas `ChatAuto` docs](https://posit-dev.github.io/chatlas/reference/ChatAuto.html)
+  for provider/model strings. On AWS Bedrock with an instance role, credentials
+  are detected automatically and no vars are needed. (The older
+  `CHATLAS_CHAT_PROVIDER` and `CHATLAS_CHAT_ARGS` still work but are deprecated.)
+- **Add a Visitor API Key integration** so the app lists and reads content as the
+  viewer: on the **Access** tab, add a "Connect Visitor API Key" integration under
+  **Integrations**. See the
+  [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
 
-Set the `CHATLAS_CHAT_PROVIDER_MODEL` environment variable to a
-`provider/model` string, plus the API key for that provider (set the key as a
-secret). Until a provider is configured, the app shows a setup screen. See the
-[chatlas documentation](https://posit-dev.github.io/chatlas/reference/ChatAuto.html)
-for the full list of providers and arguments.
-
-**OpenAI**
-
-- `CHATLAS_CHAT_PROVIDER_MODEL`: `openai/gpt-4o`
-- `OPENAI_API_KEY`: `<your-openai-api-key>`
-
-**Anthropic**
-
-- `CHATLAS_CHAT_PROVIDER_MODEL`: `anthropic/claude-sonnet-4-5-20250929`
-- `ANTHROPIC_API_KEY`: `<your-anthropic-api-key>`
-
-**Google Gemini**
-
-- `CHATLAS_CHAT_PROVIDER_MODEL`: `google/gemini-2.0-flash`
-- `GOOGLE_API_KEY`: `<your-google-api-key>`
-
-**Azure OpenAI**
-
-Set `CHATLAS_CHAT_PROVIDER_MODEL` to `azure-openai` (no model suffix) and pass the
-deployment-specific arguments via `CHATLAS_CHAT_ARGS`:
-
-- `CHATLAS_CHAT_PROVIDER_MODEL`: `azure-openai`
-- `AZURE_OPENAI_API_KEY`: `<your-azure-openai-api-key>`
-- `CHATLAS_CHAT_ARGS`: `{"deployment_id": "gpt-4.1-mini", "endpoint": "https://{your-resource-name}.openai.azure.com", "api_version": "2025-03-01-preview"}`
-  (see [Azure OpenAI API versions](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation))
-
-**Anthropic on AWS Bedrock**
-
-The app uses the
-[botocore](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/credentials.html)
-credential chain for AWS. If Connect runs on an EC2 instance with an IAM role that
-grants Bedrock access, credentials are detected automatically and no configuration
-is needed; the app defaults to the `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
-model. To use Bedrock without an IAM role, set:
-
-- `AWS_ACCESS_KEY_ID`: `<your-aws-access-key>`
-- `AWS_SECRET_ACCESS_KEY`: `<your-aws-secret-key>` (set as a secret)
-- `AWS_REGION`: `<your-aws-region>` (e.g. `us-east-1`)
-- `AWS_SESSION_TOKEN`: `<your-session-token>` (optional, for temporary credentials)
-
-### 2. Add a Connect Visitor API Key integration
-
-The app lists and reads content as the signed-in viewer, so it needs a Visitor
-API Key integration to call the Connect API with that person's identity. On the
-content's **Access** tab, add a **Connect Visitor API Key** integration under
-**Integrations**. Until it is added, the app shows the setup screen. If you don't
-see one in the list, an administrator must enable it on your Connect server. See
-the [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
+Until an LLM provider and the integration are configured, the app shows a setup
+screen with just the step(s) still missing.
 
 ## Customize it
 

--- a/extensions/chat-with-content/README.md
+++ b/extensions/chat-with-content/README.md
@@ -53,7 +53,8 @@ After deploying, in the content's settings:
   `CHATLAS_CHAT_PROVIDER` and `CHATLAS_CHAT_ARGS` still work but are deprecated.)
 - **Add a Visitor API Key integration** so the app lists and reads content as the
   viewer: on the **Access** tab, add a "Connect Visitor API Key" integration under
-  **Integrations**. See the
+  **Integrations**. If it isn't listed, an administrator must first create a
+  **Connect API** integration on your server. See the
   [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
 
 Until an LLM provider and the integration are configured, the app shows a setup

--- a/extensions/chat-with-content/README.md
+++ b/extensions/chat-with-content/README.md
@@ -14,20 +14,18 @@ documents, and static HTML.
 
 ## How it works
 
-- **Runs as the signed-in viewer.** The app calls the Connect API with the
-  viewer's own identity, through a Connect Visitor API Key integration, so each
-  person only sees and chats with the content they already have permission to
-  open. No admin API key is stored in the app.
-- **Answers only from the selected content.** When you choose a document, the app
-  renders it in the main panel, converts it to markdown, and sends that markdown
-  to the LLM as the only context. A system prompt instructs the model to answer
-  from that content alone and to say when it can't.
-- **Provider-agnostic.** The LLM connection is built with
-  [chatlas](https://posit-dev.github.io/chatlas/), so you can point it at OpenAI,
-  Azure OpenAI, Anthropic, Google Gemini, or Anthropic on AWS Bedrock by setting
-  environment variables (see [Setup](#setup)).
-- **Keeps requests bounded.** Very large pages are truncated before they are sent
-  to the model, so a big report won't overflow the model's context window.
+The app calls the Connect API as the signed-in viewer, through a Connect Visitor
+API Key integration, so each person sees and chats only with the content they
+already have permission to open. No admin API key is stored in the app. When you
+choose a document, the app renders it in the main panel, converts it to markdown,
+and sends that markdown to the LLM as the only context, with a system prompt that
+tells the model to answer from that content alone and to say when it can't.
+
+The LLM connection is built with [chatlas](https://posit-dev.github.io/chatlas/),
+so you can point it at OpenAI, Azure OpenAI, Anthropic, Google Gemini, or
+Anthropic on AWS Bedrock by setting environment variables (see [Setup](#setup)).
+Very large pages are truncated before they are sent to the model, so a big report
+won't overflow its context window.
 
 ## Deploy it
 
@@ -41,11 +39,11 @@ Connect 2025.04.0 or newer with OAuth Integrations enabled.
 
 ## Setup
 
-After deploying, in the content's settings:
+After deploying, configure two things in the content's settings:
 
-- **Choose an LLM** by setting `CHATLAS_CHAT_PROVIDER_MODEL` plus the matching
-  API key on the **Advanced** tab, under **Environment Variables**. For example,
-  to use OpenAI's GPT-4o:
+- Set an LLM provider and its API key on the **Advanced** tab, under
+  **Environment Variables**: set `CHATLAS_CHAT_PROVIDER_MODEL` plus the matching
+  key. For example, to use OpenAI's GPT-4o:
 
   ```
   CHATLAS_CHAT_PROVIDER_MODEL = openai/gpt-4o
@@ -56,12 +54,12 @@ After deploying, in the content's settings:
   (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, ...); see the
   [chatlas `ChatAuto` docs](https://posit-dev.github.io/chatlas/reference/ChatAuto.html)
   for the full list. On AWS Bedrock with an instance role, credentials are
-  detected automatically and no vars are needed. (The older
+  detected automatically and no variables are needed. (The older
   `CHATLAS_CHAT_PROVIDER` and `CHATLAS_CHAT_ARGS` still work but are deprecated.)
-- **Add a Visitor API Key integration** so the app lists and reads content as the
-  viewer: on the **Access** tab, add a "Connect Visitor API Key" integration under
-  **Integrations**. If it isn't listed, an administrator must first create a
-  **Connect API** integration on your server. See the
+- Add a "Connect Visitor API Key" integration so the app lists and reads content
+  as the viewer: on the **Access** tab, add it under **Integrations**. If it
+  isn't listed, an administrator must first create a **Connect API** integration
+  on your server. See the
   [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
 
 Until an LLM provider and the integration are configured, the app shows a setup
@@ -69,10 +67,10 @@ screen with just the step(s) still missing.
 
 ## Customize it
 
-- **Swap the model or provider** by changing the environment variables above.
-- **Change how the assistant behaves** by editing the system prompt in `app.py`
-  (for example, to change its tone or the suggested-prompt format).
-- **Adjust the context limit** by changing `MAX_CONTEXT_CHARS` in `helpers.py`.
+- Swap the model or provider by changing the environment variables above.
+- Change how the assistant behaves by editing the system prompt in `app.py` (for
+  example, its tone or the suggested-prompt format).
+- Adjust the context limit by changing `MAX_CONTEXT_CHARS` in `helpers.py`.
 
 ## Learn more
 

--- a/extensions/chat-with-content/README.md
+++ b/extensions/chat-with-content/README.md
@@ -43,13 +43,20 @@ Connect 2025.04.0 or newer with OAuth Integrations enabled.
 
 After deploying, in the content's settings:
 
-- **Choose an LLM** by setting `CHATLAS_CHAT_PROVIDER_MODEL` (for example
-  `openai/gpt-4o`) plus the matching API key (`OPENAI_API_KEY`,
-  `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, ...) on the **Advanced** tab, under
-  **Environment Variables**. See the
+- **Choose an LLM** by setting `CHATLAS_CHAT_PROVIDER_MODEL` plus the matching
+  API key on the **Advanced** tab, under **Environment Variables**. For example,
+  to use OpenAI's GPT-4o:
+
+  ```
+  CHATLAS_CHAT_PROVIDER_MODEL = openai/gpt-4o
+  OPENAI_API_KEY              = <your OpenAI API key>
+  ```
+
+  Other providers follow the same pattern with their own model string and key
+  (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, ...); see the
   [chatlas `ChatAuto` docs](https://posit-dev.github.io/chatlas/reference/ChatAuto.html)
-  for provider/model strings. On AWS Bedrock with an instance role, credentials
-  are detected automatically and no vars are needed. (The older
+  for the full list. On AWS Bedrock with an instance role, credentials are
+  detected automatically and no vars are needed. (The older
   `CHATLAS_CHAT_PROVIDER` and `CHATLAS_CHAT_ARGS` still work but are deprecated.)
 - **Add a Visitor API Key integration** so the app lists and reads content as the
   viewer: on the **Access** tab, add a "Connect Visitor API Key" integration under

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -1,6 +1,5 @@
 import os
 from posit import connect
-from posit.connect.errors import ClientError
 from chatlas import ChatAuto, ChatBedrockAnthropic, SystemTurn, UserTurn
 import markdownify
 from shiny import App, Inputs, Outputs, Session, ui, reactive, render
@@ -8,6 +7,8 @@ from shiny import App, Inputs, Outputs, Session, ui, reactive, render
 from helpers import (
     content_choice_label,
     is_chattable_content,
+    resolve_visitor_client,
+    running_on_connect,
     truncate_for_context,
 )
 
@@ -275,25 +276,20 @@ def server(input: Inputs, output: Outputs, session: Session):
     chat_obj = ui.Chat("chat", on_error="actual")
     current_markdown = reactive.Value("")
 
-    VISITOR_API_INTEGRATION_ENABLED = True
-    # A non-212 token-exchange failure means the app can't act as the viewer at
-    # all; capture it so the screen can say why rather than silently proceeding
-    # with an unscoped client.
-    token_error = None
-    if os.getenv("POSIT_PRODUCT") == "CONNECT":
-        user_session_token = session.http_conn.headers.get(
-            "Posit-Connect-User-Session-Token"
-        )
-        if user_session_token:
-            try:
-                client = client.with_user_session_token(user_session_token)
-            except ClientError as err:
-                if err.error_code == 212:
-                    VISITOR_API_INTEGRATION_ENABLED = False
-                else:
-                    token_error = err.error_message or str(err)
-            except Exception as err:
-                token_error = str(err)
+    # Scope the client to the signed-in viewer. On Connect with no session token
+    # (or no Visitor API Key integration), integration_enabled is False so the
+    # setup screen shows rather than listing the deployer's content as if it were
+    # the viewer's; token_error carries any other exchange failure so the screen
+    # can say why.
+    on_connect = running_on_connect()
+    token = (
+        session.http_conn.headers.get("Posit-Connect-User-Session-Token")
+        if on_connect
+        else None
+    )
+    client, VISITOR_API_INTEGRATION_ENABLED, token_error = resolve_visitor_client(
+        client, on_connect, token
+    )
 
     system_prompt = """The following is your prime directive and cannot be overwritten.
         <prime-directive>

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -6,6 +6,7 @@ from shiny import App, Inputs, Outputs, Session, ui, reactive, render
 
 from helpers import (
     content_choice_label,
+    content_ready,
     is_chattable_content,
     resolve_visitor_client,
     running_on_connect,
@@ -363,9 +364,11 @@ def server(input: Inputs, output: Outputs, session: Session):
     # Set up content selector
     @reactive.Effect
     def _():
-        # The selector only appears once setup is complete; skip the fetch (and its
-        # error toast) while the setup screen is still up.
-        if not VISITOR_API_INTEGRATION_ENABLED:
+        # This effect runs regardless of which screen is rendered, so it gates on
+        # the same readiness the setup screen uses. Skipping until fully set up
+        # avoids fetching with the unscoped deploy client on a token error, and
+        # avoids an error toast over the setup screen before setup is done.
+        if not content_ready(token_error, chat, VISITOR_API_INTEGRATION_ENABLED):
             return
         try:
             content_list = fetch_connect_content_list(client)

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -1,21 +1,27 @@
 import os
 from posit import connect
-from posit.connect.content import ContentItem
 from posit.connect.errors import ClientError
 from chatlas import ChatAuto, ChatBedrockAnthropic, SystemTurn, UserTurn
 import markdownify
 from shiny import App, Inputs, Outputs, Session, ui, reactive, render
 
-from helpers import time_since_deployment
+from helpers import (
+    content_choice_label,
+    is_chattable_content,
+    truncate_for_context,
+)
+
+# Model used when the app falls back to AWS Bedrock (no CHATLAS_CHAT_PROVIDER_MODEL
+# set). Overridable per provider via CHATLAS_CHAT_PROVIDER_MODEL; see the README.
+DEFAULT_BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 
 
 def check_aws_bedrock_credentials():
-    # Check if AWS credentials are available in the environment
-    # that can be used to access Bedrock
+    # Probe whether the botocore credential chain can reach Bedrock, so the app can
+    # fall back to it when no chatlas provider is configured. Makes a live call, so
+    # it is only run when there is no explicit provider (see below).
     try:
-        chat = ChatBedrockAnthropic(
-            model="us.anthropic.claude-sonnet-4-20250514-v1:0",
-        )
+        chat = ChatBedrockAnthropic(model=DEFAULT_BEDROCK_MODEL)
         chat.chat("test", echo="none")
         return True
     except Exception as e:
@@ -26,18 +32,8 @@ def check_aws_bedrock_credentials():
 
 
 def fetch_connect_content_list(client: connect.Client):
-    content_list: list[ContentItem] = client.content.find(include=["owner", "tags"])
-    app_modes = ["jupyter-static", "quarto-static", "rmd-static", "static"]
-    filtered_content_list = []
-    for content in content_list:
-        if (
-            content.app_mode in app_modes
-            and content.app_role != "none"
-            and content.content_category != "pin"
-        ):
-            filtered_content_list.append(content)
-
-    return filtered_content_list
+    content_list = client.content.find(include=["owner", "tags"])
+    return [item for item in content_list if is_chattable_content(item)]
 
 
 setup_ui = ui.page_fillable(
@@ -164,6 +160,8 @@ app_ui = ui.page_sidebar(
         ui.p(
             "Use this app to select content and ask questions about it. It currently supports static/rendered content."
         ),
+        # Show the viewer how their identity and permissions drive the app
+        ui.output_ui("identity_note"),
         ui.input_selectize("content_selection", "", choices=[], width="100%"),
         ui.chat_ui(
             "chat",
@@ -204,12 +202,20 @@ screen_ui = ui.page_output("screen")
 CHATLAS_CHAT_PROVIDER = os.getenv("CHATLAS_CHAT_PROVIDER")
 CHATLAS_CHAT_PROVIDER_MODEL = os.getenv("CHATLAS_CHAT_PROVIDER_MODEL")
 CHATLAS_CHAT_ARGS = os.getenv("CHATLAS_CHAT_ARGS")
-HAS_AWS_CREDENTIALS = check_aws_bedrock_credentials()
+
+# Only probe Bedrock when no provider is explicitly configured. The probe makes a
+# live Bedrock call at startup, so skip it whenever CHATLAS_CHAT_PROVIDER(_MODEL)
+# already tells us which provider to use.
+HAS_AWS_CREDENTIALS = (
+    check_aws_bedrock_credentials()
+    if not (CHATLAS_CHAT_PROVIDER_MODEL or CHATLAS_CHAT_PROVIDER)
+    else False
+)
 
 
 def server(input: Inputs, output: Outputs, session: Session):
     client = connect.Client()
-    chat_obj = ui.Chat("chat")
+    chat_obj = ui.Chat("chat", on_error="actual")
     current_markdown = reactive.Value("")
 
     VISITOR_API_INTEGRATION_ENABLED = True
@@ -242,6 +248,9 @@ def server(input: Inputs, output: Outputs, session: Session):
         </important>
     """
 
+    # `chat` stays None when no provider is available; the setup screen is shown in
+    # that case, so the handlers below guard against it rather than assume it exists.
+    chat = None
     if CHATLAS_CHAT_PROVIDER_MODEL or CHATLAS_CHAT_PROVIDER:
         # This will pull its configuration from environment variables
         # CHATLAS_CHAT_PROVIDER_MODEL, or the deprecated CHATLAS_CHAT_PROVIDER and CHATLAS_CHAT_ARGS
@@ -251,26 +260,46 @@ def server(input: Inputs, output: Outputs, session: Session):
     elif HAS_AWS_CREDENTIALS:
         # Fall back to Bedrock if AWS credentials are available and no provider is explicitly configured
         chat = ChatBedrockAnthropic(
-            model="us.anthropic.claude-sonnet-4-20250514-v1:0",
+            model=DEFAULT_BEDROCK_MODEL,
             system_prompt=system_prompt,
         )
 
     @render.ui
     def screen():
-        if (
-            CHATLAS_CHAT_PROVIDER_MODEL is None and CHATLAS_CHAT_PROVIDER is None and not HAS_AWS_CREDENTIALS
-        ) or not VISITOR_API_INTEGRATION_ENABLED:
+        if chat is None or not VISITOR_API_INTEGRATION_ENABLED:
             return setup_ui
         else:
             return app_ui
+
+    # Explain in-app how identity and permissions flow, using the viewer's own name
+    @render.ui
+    def identity_note():
+        name = "you"
+        try:
+            me = client.me
+            name = (
+                f"{me.first_name or ''} {me.last_name or ''}".strip()
+                or me.username
+                or "you"
+            )
+        except Exception:
+            pass
+        return ui.p(
+            ui.HTML(
+                f"Signed in as <strong>{name}</strong>, resolved from your Connect "
+                "session. Content is listed and read with your own permissions through "
+                "a Connect Visitor API Key &mdash; no admin key is stored, and answers "
+                "draw only on the content you select."
+            ),
+            class_="text-muted small",
+        )
 
     # Set up content selector
     @reactive.Effect
     def _():
         content_list = fetch_connect_content_list(client)
         content_choices = {
-            item.guid: f"{item.title or item.name} - {item.owner.first_name} {item.owner.last_name} {time_since_deployment(item.last_deployed_time)}"
-            for item in content_list
+            item.guid: content_choice_label(item) for item in content_list
         }
         ui.update_select(
             "content_selection",
@@ -291,25 +320,30 @@ def server(input: Inputs, output: Outputs, session: Session):
     @reactive.Effect
     @reactive.event(input.iframe_content)
     async def _():
-        if input.iframe_content():
-            markdown = markdownify.markdownify(
-                input.iframe_content(), heading_style="atx"
-            )
-            current_markdown.set(markdown)
+        if chat is None or not input.iframe_content():
+            return
 
-            chat._turns = [
-                SystemTurn(chat.system_prompt),
-                UserTurn(f"<context>{markdown}</context>"),
-            ]
+        # Truncate before sending so a large page can't overflow the model context
+        markdown = truncate_for_context(
+            markdownify.markdownify(input.iframe_content(), heading_style="atx")
+        )
+        current_markdown.set(markdown)
 
-            response = await chat.stream_async(
-                """Write a brief "### Summary" of the content."""
-            )
-            await chat_obj.append_message_stream(response)
+        chat._turns = [
+            SystemTurn(chat.system_prompt),
+            UserTurn(f"<context>{markdown}</context>"),
+        ]
+
+        response = await chat.stream_async(
+            """Write a brief "### Summary" of the content."""
+        )
+        await chat_obj.append_message_stream(response)
 
     # Handle chat messages
     @chat_obj.on_user_submit
     async def _(message):
+        if chat is None:
+            return
         response = await chat.stream_async(message)
         await chat_obj.append_message_stream(response)
 

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -181,6 +181,30 @@ def setup_ui(need_llm: bool, need_integration: bool):
     )
 
 
+def error_ui(message: str):
+    # Shown when the app can't act as the viewer at all (e.g. the session token
+    # couldn't be exchanged), so the failure states why instead of silently
+    # falling back to an unscoped client.
+    return ui.page_fillable(
+        _SETUP_STYLE,
+        ui.div(
+            ui.div(
+                ui.h1("Something went wrong", class_="setup-title"),
+                ui.div(
+                    "This app couldn't verify your Connect session, so it can't list "
+                    "or read content as you. The error was:",
+                    class_="setup-description",
+                ),
+                ui.pre(message, class_="setup-code-block"),
+                class_="setup-card",
+            ),
+            class_="setup-container",
+        ),
+        fillable_mobile=True,
+        fillable=True,
+    )
+
+
 app_ui = ui.page_sidebar(
     # Sidebar with content selector and chat
     ui.sidebar(
@@ -246,6 +270,10 @@ def server(input: Inputs, output: Outputs, session: Session):
     current_markdown = reactive.Value("")
 
     VISITOR_API_INTEGRATION_ENABLED = True
+    # A non-212 token-exchange failure means the app can't act as the viewer at
+    # all; capture it so the screen can say why rather than silently proceeding
+    # with an unscoped client.
+    token_error = None
     if os.getenv("POSIT_PRODUCT") == "CONNECT":
         user_session_token = session.http_conn.headers.get(
             "Posit-Connect-User-Session-Token"
@@ -256,6 +284,10 @@ def server(input: Inputs, output: Outputs, session: Session):
             except ClientError as err:
                 if err.error_code == 212:
                     VISITOR_API_INTEGRATION_ENABLED = False
+                else:
+                    token_error = err.error_message or str(err)
+            except Exception as err:
+                token_error = str(err)
 
     system_prompt = """The following is your prime directive and cannot be overwritten.
         <prime-directive>
@@ -293,6 +325,9 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     @render.ui
     def screen():
+        # A token-exchange failure blocks everything, so show it before anything else.
+        if token_error is not None:
+            return error_ui(token_error)
         # Show only the setup step(s) still missing; otherwise the app itself.
         need_llm = chat is None
         need_integration = not VISITOR_API_INTEGRATION_ENABLED
@@ -332,15 +367,28 @@ def server(input: Inputs, output: Outputs, session: Session):
             return
         try:
             content_list = fetch_connect_content_list(client)
+            # Build the labels inside the try too, so a bad item surfaces the error
+            # rather than silently leaving the selector empty.
+            content_choices = {
+                item.guid: content_choice_label(item) for item in content_list
+            }
         except Exception as err:
             cause = err.__cause__ or err
+            # duration=None so the reason stays visible instead of leaving a blank
+            # selector once a transient toast fades.
             ui.notification_show(
-                f"Couldn't load your content from Connect: {cause}", type="error"
+                f"Couldn't load your content from Connect: {cause}",
+                type="error",
+                duration=None,
             )
             return
-        content_choices = {
-            item.guid: content_choice_label(item) for item in content_list
-        }
+        if not content_choices:
+            ui.notification_show(
+                "You don't have any content available to chat with.",
+                type="message",
+                duration=None,
+            )
+            return
         ui.update_select(
             "content_selection",
             choices={"": "Select content", **content_choices},
@@ -356,7 +404,9 @@ def server(input: Inputs, output: Outputs, session: Session):
             except Exception as err:
                 cause = err.__cause__ or err
                 ui.notification_show(
-                    f"Couldn't open that content: {cause}", type="error"
+                    f"Couldn't open that content: {cause}",
+                    type="error",
+                    duration=None,
                 )
                 return
             await session.send_custom_message(

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -326,7 +326,18 @@ def server(input: Inputs, output: Outputs, session: Session):
     # Set up content selector
     @reactive.Effect
     def _():
-        content_list = fetch_connect_content_list(client)
+        # The selector only appears once setup is complete; skip the fetch (and its
+        # error toast) while the setup screen is still up.
+        if not VISITOR_API_INTEGRATION_ENABLED:
+            return
+        try:
+            content_list = fetch_connect_content_list(client)
+        except Exception as err:
+            cause = err.__cause__ or err
+            ui.notification_show(
+                f"Couldn't load your content from Connect: {cause}", type="error"
+            )
+            return
         content_choices = {
             item.guid: content_choice_label(item) for item in content_list
         }
@@ -340,7 +351,14 @@ def server(input: Inputs, output: Outputs, session: Session):
     @reactive.event(input.content_selection)
     async def _():
         if input.content_selection() and input.content_selection() != "":
-            content = client.content.get(input.content_selection())
+            try:
+                content = client.content.get(input.content_selection())
+            except Exception as err:
+                cause = err.__cause__ or err
+                ui.notification_show(
+                    f"Couldn't open that content: {cause}", type="error"
+                )
+                return
             await session.send_custom_message(
                 "update-iframe", {"url": content.content_url}
             )

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -354,7 +354,7 @@ def server(input: Inputs, output: Outputs, session: Session):
             ui.HTML(
                 f"Signed in as <strong>{name}</strong>, resolved from your Connect "
                 "session. Content is listed and read with your own permissions through "
-                "a Connect Visitor API Key &mdash; no admin key is stored, and answers "
+                "a Connect Visitor API Key. No admin key is stored, and answers "
                 "draw only on the content you select."
             ),
             class_="text-muted small",

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -11,22 +11,23 @@ from helpers import (
     truncate_for_context,
 )
 
-# Model used when the app falls back to AWS Bedrock (no CHATLAS_CHAT_PROVIDER_MODEL
-# set). Overridable per provider via CHATLAS_CHAT_PROVIDER_MODEL; see the README.
-DEFAULT_BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+# Zero-config fallback model, used only when no LLM provider is configured. Bedrock
+# picks up credentials from an instance role, so it needs no API key.
+BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 
 
 def check_aws_bedrock_credentials():
-    # Probe whether the botocore credential chain can reach Bedrock, so the app can
-    # fall back to it when no chatlas provider is configured. Makes a live call, so
-    # it is only run when there is no explicit provider (see below).
+    # Probe for usable Bedrock credentials by making a real (throwaway) Bedrock call.
+    # Bedrock is the zero-config fallback: this only runs when no provider is set via
+    # CHATLAS_CHAT_PROVIDER_MODEL, so an explicit choice is never probed over.
     try:
-        chat = ChatBedrockAnthropic(model=DEFAULT_BEDROCK_MODEL)
+        chat = ChatBedrockAnthropic(model=BEDROCK_MODEL)
         chat.chat("test", echo="none")
         return True
     except Exception as e:
         print(
-            f"AWS Bedrock credentials check failed and will fall back to checking for values for the CHATLAS_CHAT_PROVIDER_MODEL env var. Err: {e}"
+            f"AWS Bedrock credential probe failed; with no LLM provider configured, "
+            f"the app will show the setup screen. Err: {e}"
         )
         return False
 
@@ -36,9 +37,9 @@ def fetch_connect_content_list(client: connect.Client):
     return [item for item in content_list if is_chattable_content(item)]
 
 
-setup_ui = ui.page_fillable(
-    ui.tags.style(
-        """
+# Shared styling for the setup screen.
+_SETUP_STYLE = ui.tags.style(
+    """
         body {
             padding: 0;
             margin: 0;
@@ -114,44 +115,71 @@ setup_ui = ui.page_fillable(
             }
         }
         """
-    ),
-    ui.div(
-        ui.div(
-            ui.h1("Setup", class_="setup-title"),
-            ui.h2("LLM API", class_="setup-section-title"),
-            ui.div(
-                ui.HTML(
-                    "This app requires the <code>CHATLAS_CHAT_PROVIDER_MODEL</code> environment variable to be "
-                    "set along with an LLM API Key in the content settings. Please set them in your environment before running the app. "
-                    'See the <a href="https://posit-dev.github.io/chatlas/reference/ChatAuto.html" class="setup-link" target="_blank" rel="noopener">documentation</a> for more details on which arguments can be set for each Chatlas provider.'
-                ),
-                class_="setup-description",
-            ),
-            ui.h3("Example for OpenAI API", class_="setup-section-title"),
-            ui.pre(
-                """CHATLAS_CHAT_PROVIDER_MODEL = "openai/gpt-4o"
-OPENAI_API_KEY = "<key>" """,
-                class_="setup-code-block",
-            ),
-            ui.div(
-                ui.HTML(
-                    'For other provider examples (Azure OpenAI, Anthropic, AWS Bedrock, etc.), see the '
-                    '<a href="https://github.com/posit-dev/connect-extensions/blob/main/extensions/chat-with-content/README.md" class="setup-link" target="_blank" rel="noopener">README</a>.'
-                ),
-                class_="setup-description",
-            ),
-            ui.h2("Connect Visitor API Key", class_="setup-section-title"),
-            ui.div(
-                "Before you are able to use this app, you need to add a Connect Visitor API Key integration in the content settings.",
-                class_="setup-description",
-            ),
-            class_="setup-card",
-        ),
-        class_="setup-container",
-    ),
-    fillable_mobile=True,
-    fillable=True,
 )
+
+
+# The two setup steps, each shown only while its piece is still unconfigured.
+_LLM_SETUP_SECTION = (
+    ui.h2("LLM API", class_="setup-section-title"),
+    ui.div(
+        ui.HTML(
+            "This app needs the <code>CHATLAS_CHAT_PROVIDER_MODEL</code> environment variable "
+            "and a matching LLM API key. In the content settings, on the "
+            "<strong>Advanced</strong> tab, add both of them under <strong>Environment Variables</strong>. "
+            "On AWS Bedrock with an instance role, credentials are detected automatically and no "
+            "variables are needed. For more information, "
+            '<a href="https://posit-dev.github.io/chatlas/reference/ChatAuto.html" class="setup-link" target="_blank" rel="noopener">see the chatlas documentation</a>.'
+        ),
+        class_="setup-description",
+    ),
+    ui.h3("Example Environment Variables for OpenAI API", class_="setup-section-title"),
+    ui.pre(
+        """Name:   CHATLAS_CHAT_PROVIDER_MODEL
+Value:  openai/gpt-4o
+
+Name:   OPENAI_API_KEY
+Value:  <your OpenAI API key>""",
+        class_="setup-code-block",
+    ),
+)
+
+_INTEGRATION_SETUP_SECTION = (
+    ui.h2("Connect Visitor API Key", class_="setup-section-title"),
+    ui.div(
+        ui.HTML(
+            'This app needs a "Connect Visitor API Key" integration so it can list and read '
+            "content as the signed-in viewer. In the content settings, on the "
+            '<strong>Access</strong> tab, add the "Connect Visitor API Key" integration under '
+            "<strong>Integrations</strong>. For more information, "
+            '<a href="https://docs.posit.co/connect/user/oauth-integrations/" class="setup-link" target="_blank" rel="noopener">see the OAuth Integrations documentation</a>.'
+        ),
+        class_="setup-description",
+    ),
+)
+
+
+def setup_ui(need_llm: bool, need_integration: bool):
+    # Show only the piece(s) still unconfigured, so a partially configured app doesn't
+    # repeat setup steps the publisher has already done.
+    sections = []
+    if need_llm:
+        sections.extend(_LLM_SETUP_SECTION)
+    if need_integration:
+        sections.extend(_INTEGRATION_SETUP_SECTION)
+    return ui.page_fillable(
+        _SETUP_STYLE,
+        ui.div(
+            ui.div(
+                ui.h1("Setup", class_="setup-title"),
+                *sections,
+                class_="setup-card",
+            ),
+            class_="setup-container",
+        ),
+        fillable_mobile=True,
+        fillable=True,
+    )
+
 
 app_ui = ui.page_sidebar(
     # Sidebar with content selector and chat
@@ -203,10 +231,9 @@ CHATLAS_CHAT_PROVIDER = os.getenv("CHATLAS_CHAT_PROVIDER")
 CHATLAS_CHAT_PROVIDER_MODEL = os.getenv("CHATLAS_CHAT_PROVIDER_MODEL")
 CHATLAS_CHAT_ARGS = os.getenv("CHATLAS_CHAT_ARGS")
 
-# Only probe Bedrock when no provider is explicitly configured. The probe makes a
-# live Bedrock call at startup, so skip it whenever CHATLAS_CHAT_PROVIDER(_MODEL)
-# already tells us which provider to use.
-HAS_AWS_CREDENTIALS = (
+# An explicitly configured provider always wins; only probe for Bedrock credentials
+# as the zero-config fallback when nothing is set.
+HAS_AWS_BEDROCK_CREDENTIALS = (
     check_aws_bedrock_credentials()
     if not (CHATLAS_CHAT_PROVIDER_MODEL or CHATLAS_CHAT_PROVIDER)
     else False
@@ -257,19 +284,21 @@ def server(input: Inputs, output: Outputs, session: Session):
         chat = ChatAuto(
             system_prompt=system_prompt,
         )
-    elif HAS_AWS_CREDENTIALS:
+    elif HAS_AWS_BEDROCK_CREDENTIALS:
         # Fall back to Bedrock if AWS credentials are available and no provider is explicitly configured
         chat = ChatBedrockAnthropic(
-            model=DEFAULT_BEDROCK_MODEL,
+            model=BEDROCK_MODEL,
             system_prompt=system_prompt,
         )
 
     @render.ui
     def screen():
-        if chat is None or not VISITOR_API_INTEGRATION_ENABLED:
-            return setup_ui
-        else:
-            return app_ui
+        # Show only the setup step(s) still missing; otherwise the app itself.
+        need_llm = chat is None
+        need_integration = not VISITOR_API_INTEGRATION_ENABLED
+        if need_llm or need_integration:
+            return setup_ui(need_llm, need_integration)
+        return app_ui
 
     # Explain in-app how identity and permissions flow, using the viewer's own name
     @render.ui
@@ -278,8 +307,8 @@ def server(input: Inputs, output: Outputs, session: Session):
         try:
             me = client.me
             name = (
-                f"{me.first_name or ''} {me.last_name or ''}".strip()
-                or me.username
+                f"{me.get('first_name', '')} {me.get('last_name', '')}".strip()
+                or me.get("username")
                 or "you"
             )
         except Exception:

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -238,8 +238,14 @@ app_ui = ui.page_sidebar(
             iframe.src = message.url;
 
             iframe.onload = function() {
-                var iframeDoc = iframe.contentWindow.document;
-                var content = iframeDoc.documentElement.outerHTML;
+                var content;
+                try {
+                    content = iframe.contentWindow.document.documentElement.outerHTML;
+                } catch (e) {
+                    // Cross-origin (e.g. Connect redirected to an external login):
+                    // this isn't the content we asked for, so don't summarize it.
+                    return;
+                }
                 Shiny.setInputValue('iframe_content', content);
             };
         });

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -1,6 +1,7 @@
+import concurrent.futures
 import os
 from posit import connect
-from chatlas import ChatAuto, ChatBedrockAnthropic, SystemTurn, UserTurn
+from chatlas import ChatAuto, ChatBedrockAnthropic, SystemTurn
 import markdownify
 from shiny import App, Inputs, Outputs, Session, ui, reactive, render
 
@@ -17,21 +18,33 @@ from helpers import (
 # picks up credentials from an instance role, so it needs no API key.
 BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 
+# Cap the startup Bedrock probe so a reachable-but-slow endpoint can't hang the worker.
+BEDROCK_PROBE_TIMEOUT_SECONDS = 10
+
 
 def check_aws_bedrock_credentials():
     # Probe for usable Bedrock credentials by making a real (throwaway) Bedrock call.
     # Bedrock is the zero-config fallback: this only runs when no provider is set via
     # CHATLAS_CHAT_PROVIDER_MODEL, so an explicit choice is never probed over.
-    try:
-        chat = ChatBedrockAnthropic(model=BEDROCK_MODEL)
-        chat.chat("test", echo="none")
+    # The probe makes a live network call at import, so run it under a timeout: a
+    # reachable-but-slow Bedrock (partial credentials, throttling) must not block
+    # worker startup. On timeout, fall back to the setup screen.
+    def _probe():
+        ChatBedrockAnthropic(model=BEDROCK_MODEL).chat("test", echo="none")
         return True
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        return pool.submit(_probe).result(timeout=BEDROCK_PROBE_TIMEOUT_SECONDS)
     except Exception as e:
         print(
-            f"AWS Bedrock credential probe failed; with no LLM provider configured, "
-            f"the app will show the setup screen. Err: {e}"
+            f"AWS Bedrock credential probe failed or timed out; with no LLM provider "
+            f"configured, the app will show the setup screen. Err: {e}"
         )
         return False
+    finally:
+        # Don't wait on a hung probe thread; let startup continue.
+        pool.shutdown(wait=False)
 
 
 def fetch_connect_content_list(client: connect.Client):
@@ -248,7 +261,9 @@ app_ui = ui.page_sidebar(
                     // this isn't the content we asked for, so don't summarize it.
                     return;
                 }
-                Shiny.setInputValue('iframe_content', content);
+                // priority 'event' so selecting a different item whose HTML is
+                // byte-identical to the last still re-fires and re-summarizes.
+                Shiny.setInputValue('iframe_content', content, {priority: 'event'});
             };
         });
     """),
@@ -275,7 +290,6 @@ HAS_AWS_BEDROCK_CREDENTIALS = (
 def server(input: Inputs, output: Outputs, session: Session):
     client = connect.Client()
     chat_obj = ui.Chat("chat", on_error="actual")
-    current_markdown = reactive.Value("")
 
     # Scope the client to the signed-in viewer. On Connect with no session token
     # (or no Visitor API Key integration), integration_enabled is False so the
@@ -428,15 +442,14 @@ def server(input: Inputs, output: Outputs, session: Session):
         markdown = truncate_for_context(
             markdownify.markdownify(input.iframe_content(), heading_style="atx")
         )
-        current_markdown.set(markdown)
 
-        chat._turns = [
-            SystemTurn(chat.system_prompt),
-            UserTurn(f"<context>{markdown}</context>"),
-        ]
-
+        # Reset the conversation to just the system prompt, then send the content and
+        # the summary request together as one user turn. Sending them as two separate
+        # user turns puts two user messages in a row, which strict providers (Anthropic
+        # on Bedrock, the zero-config fallback) reject.
+        chat._turns = [SystemTurn(chat.system_prompt)]
         response = await chat.stream_async(
-            """Write a brief "### Summary" of the content."""
+            f'<context>{markdown}</context>\n\nWrite a brief "### Summary" of the content.'
         )
         await chat_obj.append_message_stream(response)
 

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -229,7 +229,9 @@ app_ui = ui.page_sidebar(
         ),
         # Show the viewer how their identity and permissions drive the app
         ui.output_ui("identity_note"),
-        ui.input_selectize("content_selection", "", choices=[], width="100%"),
+        # Rendered with its choices (see content_selector) rather than declared empty
+        # and filled with update_select, so the dropdown paints already populated.
+        ui.output_ui("content_selector"),
         ui.chat_ui(
             "chat",
             placeholder="Type your question here...",
@@ -374,7 +376,12 @@ def server(input: Inputs, output: Outputs, session: Session):
             class_="text-muted small",
         )
 
-    # Set up content selector
+    # The content selector's choices. Held in a reactive value and rendered directly
+    # by content_selector, so the dropdown is populated when it first paints instead
+    # of racing an update_select message against the dynamically rendered screen.
+    selector_choices = reactive.Value({})
+
+    # Load the viewer's content into the selector.
     @reactive.Effect
     def _():
         # This effect runs regardless of which screen is rendered, so it gates on
@@ -387,7 +394,7 @@ def server(input: Inputs, output: Outputs, session: Session):
             content_list = fetch_connect_content_list(client)
             # Build the labels inside the try too, so a bad item surfaces the error
             # rather than silently leaving the selector empty.
-            content_choices = {
+            choices = {
                 item.guid: content_choice_label(item) for item in content_list
             }
         except Exception as err:
@@ -400,16 +407,22 @@ def server(input: Inputs, output: Outputs, session: Session):
                 duration=None,
             )
             return
-        if not content_choices:
+        if not choices:
             ui.notification_show(
                 "You don't have any content available to chat with.",
                 type="message",
                 duration=None,
             )
             return
-        ui.update_select(
+        selector_choices.set({"": "Select content", **choices})
+
+    @render.ui
+    def content_selector():
+        return ui.input_selectize(
             "content_selection",
-            choices={"": "Select content", **content_choices},
+            "",
+            choices=selector_choices.get(),
+            width="100%",
         )
 
     # Update iframe when content selection changes

--- a/extensions/chat-with-content/app.py
+++ b/extensions/chat-with-content/app.py
@@ -352,12 +352,11 @@ def server(input: Inputs, output: Outputs, session: Session):
         except Exception:
             pass
         return ui.p(
-            ui.HTML(
-                f"Signed in as <strong>{name}</strong>, resolved from your Connect "
-                "session. Content is listed and read with your own permissions through "
-                "a Connect Visitor API Key. No admin key is stored, and answers "
-                "draw only on the content you select."
-            ),
+            "Signed in as ",
+            ui.strong(name),
+            ", resolved from your Connect session. Content is listed and read "
+            "with your own permissions through a Connect Visitor API Key. No "
+            "admin key is stored, and answers draw only on the content you select.",
             class_="text-muted small",
         )
 

--- a/extensions/chat-with-content/helpers.py
+++ b/extensions/chat-with-content/helpers.py
@@ -1,31 +1,41 @@
 from datetime import datetime, timezone
 
+# Static/rendered content the app can extract text from. Interactive apps (Shiny,
+# Streamlit, ...) render in the browser, so their HTML holds no content to chat with.
+CHATTABLE_APP_MODES = ("jupyter-static", "quarto-static", "rmd-static", "static")
+
+# Upper bound on the markdown handed to the LLM. A large report can produce a DOM
+# far bigger than the model's context window; truncating keeps the request within
+# bounds instead of erroring, at the cost of dropping the tail of very long pages.
+MAX_CONTEXT_CHARS = 100_000
+
 
 def time_since_deployment(deployment_time_str):
     """
-    Calculate time since deployment from ISO format datetime string.
+    Human-readable time since deployment, e.g. "last deployed 3 hours ago".
 
     Args:
-        deployment_time_str (str): Datetime string in format "2025-03-19T23:16:11Z"
+        deployment_time_str: ISO datetime string like "2025-03-19T23:16:11Z",
+            or None/empty when Connect has no deployment time for the content.
 
     Returns:
-        str: Human-readable time difference like "last deployed 3 hours ago"
+        str: The phrase, or "" when no deployment time is available.
     """
-    # Parse the deployment time
-    deployment_time = datetime.fromisoformat(deployment_time_str.replace("Z", "+00:00"))
+    # Content that has never been deployed reports no time; skip the label rather
+    # than crash on a None passed to fromisoformat().
+    if not deployment_time_str:
+        return ""
 
-    # Get current time in UTC
+    deployment_time = datetime.fromisoformat(deployment_time_str.replace("Z", "+00:00"))
     current_time = datetime.now(timezone.utc)
 
-    # Calculate the difference
     time_diff = current_time - deployment_time
     total_seconds = time_diff.total_seconds()
 
-    # Handle future dates
+    # Handle clock skew where the deployment time is slightly in the future
     if total_seconds < 0:
         return "last deployed in the future"
 
-    # Convert to appropriate unit
     if total_seconds < 60:
         value = int(total_seconds)
         unit = "second" if value == 1 else "seconds"
@@ -49,3 +59,36 @@ def time_since_deployment(deployment_time_str):
         unit = "year" if value == 1 else "years"
 
     return f"last deployed {value} {unit} ago"
+
+
+def is_chattable_content(item):
+    """Whether a Connect content item exposes static text the app can chat with."""
+    return (
+        item.app_mode in CHATTABLE_APP_MODES
+        and item.app_role != "none"
+        and item.content_category != "pin"
+    )
+
+
+def content_choice_label(item):
+    """Dropdown label for a content item, tolerating a missing title or owner."""
+    title = item.title or item.name or item.guid
+    owner = getattr(item, "owner", None)
+    name = ""
+    if owner is not None:
+        name = f"{owner.first_name or ''} {owner.last_name or ''}".strip()
+    deployed = time_since_deployment(item.last_deployed_time)
+
+    # Join only the parts we actually have so the label never shows " -  ".
+    suffix = " ".join(part for part in (name, deployed) if part)
+    return f"{title} - {suffix}" if suffix else title
+
+
+def truncate_for_context(markdown, max_chars=MAX_CONTEXT_CHARS):
+    """Cap the content markdown so a large page can't overflow the model context."""
+    if len(markdown) <= max_chars:
+        return markdown
+    return (
+        markdown[:max_chars]
+        + "\n\n[Content truncated because it exceeds the size this app sends to the model.]"
+    )

--- a/extensions/chat-with-content/helpers.py
+++ b/extensions/chat-with-content/helpers.py
@@ -26,7 +26,14 @@ def time_since_deployment(deployment_time_str):
     if not deployment_time_str:
         return ""
 
-    deployment_time = datetime.fromisoformat(deployment_time_str.replace("Z", "+00:00"))
+    try:
+        deployment_time = datetime.fromisoformat(
+            deployment_time_str.replace("Z", "+00:00")
+        )
+    except (ValueError, TypeError):
+        # A malformed timestamp shouldn't crash the whole content list; just omit
+        # the "last deployed" phrase for this one item.
+        return ""
     current_time = datetime.now(timezone.utc)
 
     time_diff = current_time - deployment_time

--- a/extensions/chat-with-content/helpers.py
+++ b/extensions/chat-with-content/helpers.py
@@ -35,6 +35,15 @@ def resolve_visitor_client(client, on_connect, token):
         return client, True, getattr(err, "error_message", None) or str(err)
 
 
+# Whether the app is fully set up and should load and use the viewer's content.
+# The content selector runs as a reactive effect independent of the rendered
+# screen, so it gates on this itself: a token error leaves the client as the
+# unscoped deploy client (must never load with it), and a missing LLM or
+# integration means the setup screen is up, so there's nothing to load for yet.
+def content_ready(token_error, chat, integration_enabled):
+    return token_error is None and chat is not None and integration_enabled
+
+
 def time_since_deployment(deployment_time_str):
     # Content that has never been deployed reports no time; skip the label rather
     # than crash on a None passed to fromisoformat().

--- a/extensions/chat-with-content/helpers.py
+++ b/extensions/chat-with-content/helpers.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timezone
 
 # Static/rendered content the app can extract text from. Interactive apps (Shiny,
@@ -10,17 +11,31 @@ CHATTABLE_APP_MODES = ("jupyter-static", "quarto-static", "rmd-static", "static"
 MAX_CONTEXT_CHARS = 100_000
 
 
+# Both env vars are checked because a missed "on Connect" detection would fall back
+# to the deploy client for a viewer (see resolve_visitor_client), so err toward True.
+def running_on_connect():
+    return "CONNECT" in (os.getenv("POSIT_PRODUCT"), os.getenv("RSTUDIO_PRODUCT"))
+
+
+# Returns (client, integration_enabled, error). The gate is the point: on Connect
+# with no token (or no Visitor API Key integration, Connect error 212), keep the
+# client unchanged and integration_enabled False so the caller shows the setup
+# screen instead of listing the deployer's content. Off Connect, the deploy client
+# is the intended one.
+def resolve_visitor_client(client, on_connect, token):
+    if not on_connect:
+        return client, True, None
+    if not token:
+        return client, False, None
+    try:
+        return client.with_user_session_token(token), True, None
+    except Exception as err:
+        if getattr(err, "error_code", None) == 212:
+            return client, False, None
+        return client, True, getattr(err, "error_message", None) or str(err)
+
+
 def time_since_deployment(deployment_time_str):
-    """
-    Human-readable time since deployment, e.g. "last deployed 3 hours ago".
-
-    Args:
-        deployment_time_str: ISO datetime string like "2025-03-19T23:16:11Z",
-            or None/empty when Connect has no deployment time for the content.
-
-    Returns:
-        str: The phrase, or "" when no deployment time is available.
-    """
     # Content that has never been deployed reports no time; skip the label rather
     # than crash on a None passed to fromisoformat().
     if not deployment_time_str:
@@ -39,7 +54,7 @@ def time_since_deployment(deployment_time_str):
     time_diff = current_time - deployment_time
     total_seconds = time_diff.total_seconds()
 
-    # Handle clock skew where the deployment time is slightly in the future
+    # Deployment time slightly in the future (clock skew between servers).
     if total_seconds < 0:
         return "last deployed in the future"
 
@@ -69,7 +84,6 @@ def time_since_deployment(deployment_time_str):
 
 
 def is_chattable_content(item):
-    """Whether a Connect content item exposes static text the app can chat with."""
     return (
         item.app_mode in CHATTABLE_APP_MODES
         and item.app_role != "none"
@@ -78,7 +92,6 @@ def is_chattable_content(item):
 
 
 def content_choice_label(item):
-    """Dropdown label for a content item, tolerating a missing title or owner."""
     title = item.title or item.name or item.guid
     owner = getattr(item, "owner", None)
     name = ""
@@ -92,7 +105,6 @@ def content_choice_label(item):
 
 
 def truncate_for_context(markdown, max_chars=MAX_CONTEXT_CHARS):
-    """Cap the content markdown so a large page can't overflow the model context."""
     if len(markdown) <= max_chars:
         return markdown
     return (

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -41,10 +41,10 @@
       "checksum": "0c56ba1ce838560d153c50e71dc2b025"
     },
     "app.py": {
-      "checksum": "cd319be749dae78dd65a35e590ba67ed"
+      "checksum": "9ea3ec38d0104e0aa63a9681321e9777"
     },
     "helpers.py": {
-      "checksum": "33588d3ac6120efe124f48910fd342eb"
+      "checksum": "6c84b2c2aa126481f9daf150523dd704"
     }
   }
 }

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -20,8 +20,8 @@
   },
   "extension": {
     "name": "chat-with-content",
-    "title": "Shiny: Chat with your content",
-    "description": "Chat with your published content on Connect using an LLM. Pick a report, notebook, or static page you can access, and this Shiny app answers questions about it in a chat panel beside the rendered page, running as the signed-in viewer through a Connect Visitor API Key so each person only chats with content they are allowed to open. Point it at OpenAI, Anthropic, Google, Azure, or AWS Bedrock, and edit the system prompt to build your own content-aware assistant.",
+    "title": "Chat with Content",
+    "description": "Chat with your published content on Connect using an LLM. Pick a report, notebook, or static page you can access, and the app answers questions about it in a chat panel beside the rendered page, running as the signed-in viewer through a Connect Visitor API Key so each person only chats with content they are allowed to open. Works with OpenAI, Anthropic, Google, Azure, or AWS Bedrock.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/chat-with-content",
     "category": "extension",
     "tags": ["llm", "shiny", "chat", "python"],
@@ -34,7 +34,7 @@
       "checksum": "0c56ba1ce838560d153c50e71dc2b025"
     },
     "app.py": {
-      "checksum": "656f27b6f834fb91000f99be44d99c63"
+      "checksum": "7ff9ef215ec7a96f993321b0cae7ec50"
     },
     "helpers.py": {
       "checksum": "bc54e313091d80eb228c44d988fa519d"

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -24,9 +24,16 @@
     "description": "Chat with your published content on Connect using an LLM. Pick a report, notebook, or static page you can access, and the app answers questions about it in a chat panel beside the rendered page, running as the signed-in viewer through a Connect Visitor API Key so each person only chats with content they are allowed to open. Works with OpenAI, Anthropic, Google, Azure, or AWS Bedrock.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/chat-with-content",
     "category": "extension",
-    "tags": ["llm", "shiny", "chat", "python"],
+    "tags": [
+      "llm",
+      "shiny",
+      "chat",
+      "python"
+    ],
     "minimumConnectVersion": "2025.04.0",
-    "requiredFeatures": ["OAuth Integrations"],
+    "requiredFeatures": [
+      "OAuth Integrations"
+    ],
     "version": "0.0.8"
   },
   "files": {
@@ -34,7 +41,7 @@
       "checksum": "0c56ba1ce838560d153c50e71dc2b025"
     },
     "app.py": {
-      "checksum": "7ff9ef215ec7a96f993321b0cae7ec50"
+      "checksum": "6a0d74d082574b1743646b4f62c4e6f5"
     },
     "helpers.py": {
       "checksum": "bc54e313091d80eb228c44d988fa519d"

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -41,10 +41,10 @@
       "checksum": "0c56ba1ce838560d153c50e71dc2b025"
     },
     "app.py": {
-      "checksum": "df762c70715e8e94c83bdc5181a2393b"
+      "checksum": "b27de545a2910caacedc3505d8d44214"
     },
     "helpers.py": {
-      "checksum": "2e83b315256992cf6e54a5fc8e0c4f06"
+      "checksum": "33588d3ac6120efe124f48910fd342eb"
     }
   }
 }

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -41,10 +41,10 @@
       "checksum": "0c56ba1ce838560d153c50e71dc2b025"
     },
     "app.py": {
-      "checksum": "6a0d74d082574b1743646b4f62c4e6f5"
+      "checksum": "9dc0e4b04a1430544c6f27a587425522"
     },
     "helpers.py": {
-      "checksum": "bc54e313091d80eb228c44d988fa519d"
+      "checksum": "2e83b315256992cf6e54a5fc8e0c4f06"
     }
   }
 }

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -41,7 +41,7 @@
       "checksum": "0c56ba1ce838560d153c50e71dc2b025"
     },
     "app.py": {
-      "checksum": "9dc0e4b04a1430544c6f27a587425522"
+      "checksum": "df762c70715e8e94c83bdc5181a2393b"
     },
     "helpers.py": {
       "checksum": "2e83b315256992cf6e54a5fc8e0c4f06"

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -20,33 +20,24 @@
   },
   "extension": {
     "name": "chat-with-content",
-    "title": "Chat with Content",
-    "description": "Provides a way to interact with and query content using an LLM chat interface.",
+    "title": "Shiny: Chat with your content",
+    "description": "Chat with your published content on Connect using an LLM. Pick a report, notebook, or static page you can access, and this Shiny app answers questions about it in a chat panel beside the rendered page, running as the signed-in viewer through a Connect Visitor API Key so each person only chats with content they are allowed to open. Point it at OpenAI, Anthropic, Google, Azure, or AWS Bedrock, and edit the system prompt to build your own content-aware assistant.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/chat-with-content",
     "category": "extension",
     "tags": ["llm", "shiny", "chat", "python"],
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": ["OAuth Integrations"],
-    "version": "0.0.7"
+    "version": "0.0.8"
   },
   "files": {
     "requirements.txt": {
       "checksum": "0c56ba1ce838560d153c50e71dc2b025"
     },
-    ".gitignore": {
-      "checksum": "693ec79eaa892babde62587aaacf0d8b"
-    },
-    "README.md": {
-      "checksum": "7b072eef923c062a0bf1667dde6c2b95"
-    },
     "app.py": {
-      "checksum": "74b2cad1b559b06c306a1ee44ce00185"
+      "checksum": "656f27b6f834fb91000f99be44d99c63"
     },
     "helpers.py": {
-      "checksum": "b18f4bc0072b6e47864670a3174b0cea"
-    },
-    "pyproject.toml": {
-      "checksum": "604c28539dcb8abf952d7099ce2994bc"
+      "checksum": "bc54e313091d80eb228c44d988fa519d"
     }
   }
 }

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -41,7 +41,7 @@
       "checksum": "0c56ba1ce838560d153c50e71dc2b025"
     },
     "app.py": {
-      "checksum": "b27de545a2910caacedc3505d8d44214"
+      "checksum": "cd319be749dae78dd65a35e590ba67ed"
     },
     "helpers.py": {
       "checksum": "33588d3ac6120efe124f48910fd342eb"

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -38,10 +38,10 @@
   },
   "files": {
     "requirements.txt": {
-      "checksum": "0c56ba1ce838560d153c50e71dc2b025"
+      "checksum": "cb941e127f37bee990fb5d435ae994ff"
     },
     "app.py": {
-      "checksum": "9ea3ec38d0104e0aa63a9681321e9777"
+      "checksum": "15a43097e593d3a9ff50785833a1d3f9"
     },
     "helpers.py": {
       "checksum": "6c84b2c2aa126481f9daf150523dd704"

--- a/extensions/chat-with-content/manifest.json
+++ b/extensions/chat-with-content/manifest.json
@@ -41,7 +41,7 @@
       "checksum": "cb941e127f37bee990fb5d435ae994ff"
     },
     "app.py": {
-      "checksum": "15a43097e593d3a9ff50785833a1d3f9"
+      "checksum": "ce4b917a029d14a0080ab64a9227a1a8"
     },
     "helpers.py": {
       "checksum": "6c84b2c2aa126481f9daf150523dd704"

--- a/extensions/chat-with-content/pyproject.toml
+++ b/extensions/chat-with-content/pyproject.toml
@@ -1,17 +1,22 @@
 [project]
 name = "chat-with-content"
 version = "0.1.0"
-description = "Add your description here"
+description = "Shiny app that lets Connect viewers chat with their deployed content using an LLM."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "anthropic[bedrock]>=0.54.0",
     "boto3>=1.38.40",
-    "chatlas",
     "google-genai>=1.22.0",
     "markdownify>=1.1.0",
     "openai>=1.91.0",
     "posit-sdk>=0.10.0",
     "shiny>=1.4.0",
     "chatlas>=0.10.0",
+]
+
+# Test-only dependencies; not bundled into the extension (requirements.txt is).
+[dependency-groups]
+dev = [
+    "pytest>=8",
 ]

--- a/extensions/chat-with-content/requirements.txt
+++ b/extensions/chat-with-content/requirements.txt
@@ -3,6 +3,6 @@ boto3>=1.38.40
 google-genai>=1.22.0
 markdownify>=1.1.0
 openai>=1.91.0
-posit-sdk>=0.10.0
+posit-sdk>=0.10.0,<1.0.0
 shiny>=1.4.0
 chatlas>=0.10.0

--- a/extensions/chat-with-content/test_helpers.py
+++ b/extensions/chat-with-content/test_helpers.py
@@ -36,6 +36,12 @@ def test_time_since_deployment_none_and_empty():
     assert helpers.time_since_deployment("") == ""
 
 
+def test_time_since_deployment_malformed_returns_empty():
+    # A malformed timestamp must not raise (it would otherwise crash the whole
+    # content list); it just omits the "last deployed" phrase.
+    assert helpers.time_since_deployment("not-a-date") == ""
+
+
 def test_time_since_deployment_future():
     future = (datetime.now(timezone.utc) + timedelta(hours=1)).strftime(
         "%Y-%m-%dT%H:%M:%SZ"

--- a/extensions/chat-with-content/test_helpers.py
+++ b/extensions/chat-with-content/test_helpers.py
@@ -1,0 +1,120 @@
+# Unit tests for the pure helpers. The Shiny app (app.py) is intentionally kept
+# thin over these functions so the logic can be tested without a running session
+# or any LLM / Connect calls.
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import helpers
+
+
+def iso_ago(**delta):
+    # ISO timestamp `delta` in the past, in the "...Z" form Connect returns.
+    dt = datetime.now(timezone.utc) - timedelta(**delta)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def make_item(**overrides):
+    item = {
+        "guid": "g1",
+        "name": "the-name",
+        "title": "The Title",
+        "app_mode": "static",
+        "app_role": "owner",
+        "content_category": "",
+        "last_deployed_time": iso_ago(hours=2),
+        "owner": SimpleNamespace(first_name="Ada", last_name="Lovelace"),
+    }
+    item.update(overrides)
+    return SimpleNamespace(**item)
+
+
+# --- time_since_deployment -------------------------------------------------
+
+
+def test_time_since_deployment_none_and_empty():
+    assert helpers.time_since_deployment(None) == ""
+    assert helpers.time_since_deployment("") == ""
+
+
+def test_time_since_deployment_future():
+    future = (datetime.now(timezone.utc) + timedelta(hours=1)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    assert helpers.time_since_deployment(future) == "last deployed in the future"
+
+
+def test_time_since_deployment_units_and_pluralization():
+    assert helpers.time_since_deployment(iso_ago(seconds=5)) == "last deployed 5 seconds ago"
+    assert helpers.time_since_deployment(iso_ago(seconds=90)) == "last deployed 1 minute ago"
+    assert helpers.time_since_deployment(iso_ago(minutes=5)) == "last deployed 5 minutes ago"
+    assert helpers.time_since_deployment(iso_ago(hours=2)) == "last deployed 2 hours ago"
+    assert helpers.time_since_deployment(iso_ago(days=1, hours=1)) == "last deployed 1 day ago"
+    assert helpers.time_since_deployment(iso_ago(days=20)) == "last deployed 2 weeks ago"
+    assert helpers.time_since_deployment(iso_ago(days=45)) == "last deployed 1 month ago"
+    assert helpers.time_since_deployment(iso_ago(days=400)) == "last deployed 1 year ago"
+
+
+# --- is_chattable_content --------------------------------------------------
+
+
+def test_is_chattable_content_accepts_static_content():
+    assert helpers.is_chattable_content(make_item()) is True
+    assert helpers.is_chattable_content(make_item(app_mode="quarto-static")) is True
+
+
+def test_is_chattable_content_rejects_interactive_apps():
+    assert helpers.is_chattable_content(make_item(app_mode="python-shiny")) is False
+
+
+def test_is_chattable_content_rejects_unpublished_and_pins():
+    assert helpers.is_chattable_content(make_item(app_role="none")) is False
+    assert helpers.is_chattable_content(make_item(content_category="pin")) is False
+
+
+# --- content_choice_label --------------------------------------------------
+
+
+def test_content_choice_label_full():
+    label = helpers.content_choice_label(make_item())
+    assert label == "The Title - Ada Lovelace last deployed 2 hours ago"
+
+
+def test_content_choice_label_falls_back_to_name_then_guid():
+    assert helpers.content_choice_label(make_item(title=None)).startswith("the-name")
+    assert helpers.content_choice_label(
+        make_item(title=None, name=None)
+    ).startswith("g1")
+
+
+def test_content_choice_label_tolerates_missing_owner_and_date():
+    label = helpers.content_choice_label(
+        make_item(owner=None, last_deployed_time=None)
+    )
+    # No owner and no deploy time -> just the title, no dangling " - ".
+    assert label == "The Title"
+
+
+def test_content_choice_label_handles_blank_owner_names():
+    label = helpers.content_choice_label(
+        make_item(
+            owner=SimpleNamespace(first_name=None, last_name=None),
+            last_deployed_time=None,
+        )
+    )
+    assert label == "The Title"
+
+
+# --- truncate_for_context --------------------------------------------------
+
+
+def test_truncate_for_context_leaves_short_content_untouched():
+    text = "a" * 100
+    assert helpers.truncate_for_context(text, max_chars=1000) == text
+
+
+def test_truncate_for_context_caps_long_content():
+    text = "a" * 5000
+    result = helpers.truncate_for_context(text, max_chars=1000)
+    assert result.startswith("a" * 1000)
+    assert "truncated" in result
+    assert len(result) < len(text)

--- a/extensions/chat-with-content/test_helpers.py
+++ b/extensions/chat-with-content/test_helpers.py
@@ -198,3 +198,24 @@ def test_truncate_for_context_caps_long_content():
     assert result.startswith("a" * 1000)
     assert "truncated" in result
     assert len(result) < len(text)
+
+
+# --- content_ready ---------------------------------------------------------
+
+
+def test_content_ready_true_when_session_llm_and_integration_all_present():
+    assert helpers.content_ready(None, object(), True) is True
+
+
+def test_content_ready_false_on_token_error():
+    # A token error leaves the client as the unscoped deploy client, so content
+    # must not load even though the integration flag is True.
+    assert helpers.content_ready("exchange failed", object(), True) is False
+
+
+def test_content_ready_false_without_llm():
+    assert helpers.content_ready(None, None, True) is False
+
+
+def test_content_ready_false_when_integration_disabled():
+    assert helpers.content_ready(None, object(), False) is False

--- a/extensions/chat-with-content/test_helpers.py
+++ b/extensions/chat-with-content/test_helpers.py
@@ -28,6 +28,80 @@ def make_item(**overrides):
     return SimpleNamespace(**item)
 
 
+# --- running_on_connect ----------------------------------------------------
+
+
+def test_running_on_connect_detects_either_env_var(monkeypatch):
+    monkeypatch.delenv("RSTUDIO_PRODUCT", raising=False)
+    monkeypatch.setenv("POSIT_PRODUCT", "CONNECT")
+    assert helpers.running_on_connect() is True
+
+    monkeypatch.delenv("POSIT_PRODUCT", raising=False)
+    monkeypatch.setenv("RSTUDIO_PRODUCT", "CONNECT")
+    assert helpers.running_on_connect() is True
+
+
+def test_running_on_connect_false_off_connect(monkeypatch):
+    monkeypatch.delenv("POSIT_PRODUCT", raising=False)
+    monkeypatch.delenv("RSTUDIO_PRODUCT", raising=False)
+    assert helpers.running_on_connect() is False
+
+
+# --- resolve_visitor_client ------------------------------------------------
+
+
+class _FakeError(Exception):
+    def __init__(self, error_code=None, error_message=None):
+        self.error_code = error_code
+        self.error_message = error_message
+
+
+class _FakeClient:
+    def __init__(self, raises=None, scoped="scoped-client"):
+        self._raises = raises
+        self._scoped = scoped
+
+    def with_user_session_token(self, token):
+        if self._raises:
+            raise self._raises
+        return self._scoped
+
+
+def test_resolve_visitor_off_connect_uses_client_as_is():
+    c = _FakeClient()
+    assert helpers.resolve_visitor_client(c, False, None) == (c, True, None)
+
+
+def test_resolve_visitor_no_token_on_connect_requires_setup():
+    # The key fix: no session token on Connect must NOT fall back to the deploy
+    # client (which would list the deployer's content); it requires setup.
+    c = _FakeClient()
+    assert helpers.resolve_visitor_client(c, True, None) == (c, False, None)
+
+
+def test_resolve_visitor_scopes_to_the_viewer_with_a_token():
+    c = _FakeClient(scoped="viewer-client")
+    assert helpers.resolve_visitor_client(c, True, "tok") == (
+        "viewer-client",
+        True,
+        None,
+    )
+
+
+def test_resolve_visitor_missing_integration_requires_setup():
+    c = _FakeClient(raises=_FakeError(error_code=212))
+    assert helpers.resolve_visitor_client(c, True, "tok") == (c, False, None)
+
+
+def test_resolve_visitor_other_error_is_surfaced():
+    c = _FakeClient(raises=_FakeError(error_code=5, error_message="permission denied"))
+    assert helpers.resolve_visitor_client(c, True, "tok") == (
+        c,
+        True,
+        "permission denied",
+    )
+
+
 # --- time_since_deployment -------------------------------------------------
 
 

--- a/extensions/portfolio-dashboard/CHANGELOG.md
+++ b/extensions/portfolio-dashboard/CHANGELOG.md
@@ -9,20 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Retitled to `R Shiny: Portfolio Dashboard`, rewrote the description and README, and added explanatory comments to `app.R` (the Sortino ratio, the MAR, and the input throttle). (#413)
+- Retitled to `R Shiny: Portfolio Dashboard`, and rewrote the description and README. (#413)
 - Switched the sample data from `returns.rds` to `returns.csv` (columns: date, portfolio, returns), refreshed it through 2025 with both average return and volatility rising across the conservative, balanced, and aggressive tiers and a shared 2022 downturn, and made the portfolio selector read its options from the file, so swapping the data file updates it automatically. (#413)
 - Clarified the sidebar input labels to `Minimum Acceptable Rate (MAR)` and `Rolling Window (months)`, and lowered the MAR slider's maximum to a realistic monthly rate (2%). (#413)
-- Switched the rolling Sortino series to trailing (right-aligned) windows so each value reads as of its date, and replaced the month-scale range buttons (a leftover from unused daily data) with 1-, 3-, and 5-year ranges suited to the monthly data. (#413)
+- Switched the rolling Sortino series to trailing (right-aligned) windows so each value reads as of its date, and replaced the month-scale range buttons with 1-, 3-, and 5-year ranges suited to the monthly data. (#413)
 
 ### Fixed
 
-- Removed the dated 2016 election marker and annotation, the unused `dygraphs` import (and dropped `dygraphs`, `stringi`, `stringr`, and `utf8` from the bundled packages, none of which the app needs), and the dead daily-returns series; added the explicit `ggplot2` import; fixed the hardcoded rolling-window label to follow the window input; and replaced the deprecated `size` aesthetic with `linewidth`. (#413)
+- Removed the dated 2016 election marker and annotation, and fixed the hardcoded rolling-window label so it follows the window input. (#413)
 - Showed a message instead of a blank Rolling Sortino plot when the start date leaves fewer months than the rolling window. (#413)
-- Removed an unused by-hand Sortino calculation, and named the scatterplot colors so up and down months stay correctly colored even when a selection contains only one. (#413)
+- Named the scatterplot colors so up and down months stay correctly colored even when a selection contains only one. (#413)
 
 ## [0.0.4] - 2026-06-11
 
-### Changed
-
-- Modernized R code to use the native pipe (`|>`) and consolidated `mutate()` calls. (#365)
-
+- Maintenance release; no user-facing changes. (#365)

--- a/extensions/portfolio-dashboard/README.md
+++ b/extensions/portfolio-dashboard/README.md
@@ -14,12 +14,11 @@ for your own.
 Pick a portfolio, a starting date, a Minimum Acceptable Rate (MAR), and a
 rolling-window length in the sidebar, and four linked plots update:
 
-- **Rolling Sortino**: the Sortino ratio over the rolling window, with a range
-  selector.
-- **Scatterplot**: monthly returns, colored by whether they land above or below
+- A rolling Sortino plot of the ratio over the window, with a range selector.
+- A scatterplot of monthly returns, colored by whether they land above or below
   the MAR.
-- **Histogram**: the distribution of returns, with the MAR marked.
-- **Density**: the return density, with the downside (below-MAR) region shaded.
+- A histogram of the return distribution, with the MAR marked.
+- A density plot of returns, with the downside (below-MAR) region shaded.
 
 The Sortino ratio measures return per unit of *downside* volatility (returns
 below the MAR), so unlike the Sharpe ratio it doesn't penalize upside swings.

--- a/extensions/quarto-presentation/CHANGELOG.md
+++ b/extensions/quarto-presentation/CHANGELOG.md
@@ -18,4 +18,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Retitled to `Quarto: Presentation` and rewrote the description and README around the reveal.js slide-deck pattern. (#410)
 - Reworked the deck into a teaching showcase of what a Quarto slide can hold: an overview with doc links, a syntax-highlighted code block, a Mermaid diagram, an interactive Observable JS chart, a multi-column and incremental-reveal slide, and a publish-to-Connect slide. The sample content carries a light business flavor (a quarterly revenue readout). (#410)
 - Loaded the chart from a small bundled `data.csv` that can be swapped out, instead of Observable's external `olympians` sample dataset. (#410)
-- Pinned the Quarto project to render only `index.qmd` so the changelog is not rendered as a stray page, and added explanatory comments. (#410)
+- Pinned the Quarto project to render only `index.qmd` so the changelog is not rendered as a stray page. (#410)

--- a/extensions/quarto-presentation/README.md
+++ b/extensions/quarto-presentation/README.md
@@ -14,14 +14,14 @@ business flavor (a quarterly revenue readout) that you can swap for your own.
 The deck (`index.qmd`) is roughly one slide per capability, each linking to its
 Quarto docs:
 
-- **What goes on a slide**: an overview of the features, with links.
-- **Show your work with code**: a syntax-highlighted code block (Quarto can also
-  execute R, Python, and Julia and embed the output).
-- **Diagrams**: a Mermaid diagram drawn from text.
-- **Interactive charts**: an Observable JS chart with a segment filter, loaded
-  from a bundled `data.csv` you can swap out.
-- **Layout and reveals**: a multi-column slide with an incremental list.
-- **Publish to Connect**: how to render and publish.
+- An overview slide of the deck's features, with links.
+- A syntax-highlighted code block (Quarto can also execute R, Python, and Julia
+  and embed the output).
+- A Mermaid diagram drawn from text.
+- An interactive Observable JS chart with a segment filter, loaded from a bundled
+  `data.csv` you can swap out.
+- A multi-column slide with an incremental list.
+- A slide on how to render and publish to Connect.
 
 ## Customize it
 

--- a/extensions/script-python/CHANGELOG.md
+++ b/extensions/script-python/CHANGELOG.md
@@ -20,12 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Exported the CSV files without the leading row-index column. (#392)
-- Re-pinned `requirements.txt` to a minimal, Python 3.9-compatible set so the example installs on 3.9 servers; the previous `ipykernel` pin required Python 3.10, contradicting the declared `~=3.9` floor. (#392)
+- Re-pinned `requirements.txt` to a minimal, Python 3.9-compatible set so the example installs on 3.9 servers. (#392)
 - Pinned the Quarto project to render only the script, so the gallery serves the script rather than a sibling Markdown file (e.g. the changelog). (#392)
-
-### Removed
-
-- Removed the committed `script.quarto_ipynb` build intermediate, which Quarto regenerates on render. (#392)
 
 ## [1.0.1] - 2026-06-11
 

--- a/extensions/simple-mcp-server/CHANGELOG.md
+++ b/extensions/simple-mcp-server/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Retitled to "FastAPI: MCP Server", rewrote the README and description, and reframed the example so its three tools read as starting points to swap out. (#417)
 - The landing page now greets the signed-in viewer by name, resolved from their Connect session token (the same identity the `connect_whoami` tool returns). (#417)
-- Regenerated `requirements.txt` to resolve from the minimum supported Python (3.11) rather than a single 3.14 lock, for broader install compatibility. (#417)
+- Regenerated `requirements.txt` to resolve from the minimum supported Python (3.11) for broader install compatibility. (#417)
 - Bounded the per-viewer client cache so a long-running server can't grow it without limit. (#417)
 
 ### Fixed
@@ -33,15 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.5] - 2026-06-11
 
-### Changed
-
-- Switched to with-connect for integration tests. (#355)
+- Maintenance release; no user-facing changes. (#355)
 
 ## [0.0.4] - 2026-05-04
 
-### Fixed
-
-- Fixed deprecation warnings. (#349)
+- Maintenance release; no user-facing changes. (#349)
 
 ## [0.0.3] - 2026-02-03
 

--- a/extensions/simple-mcp-server/README.md
+++ b/extensions/simple-mcp-server/README.md
@@ -46,17 +46,19 @@ Connect 2025.04.0 or newer with API Publishing and OAuth Integrations enabled.
 
 After deploying, configure it for how you'll use it:
 
-- **As the signed-in viewer** (the paired chat, or any Connect content): in the content's
-  settings, on the **Access** tab, add a "Connect Visitor API Key" integration under
-  **Integrations**. This lets `connect_whoami` identify who's calling. See the
+- As the signed-in viewer (the paired chat, or any Connect content): on the
+  **Access** tab, add a "Connect Visitor API Key" integration under
+  **Integrations**. If it isn't listed, an administrator must first create a
+  **Connect API** integration on your server. This lets `connect_whoami` identify
+  who's calling. See the
   [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
-- **From your own MCP client** (Claude Code, Cursor, ...): point it at `{content-url}/mcp`
+- From your own MCP client (Claude Code, Cursor, ...): point it at `{content-url}/mcp`
   and authenticate with a Connect API key (`Authorization: Key <API_KEY>`); the landing page
   has copy-paste snippets. `list_known_datasets` and `calculate_summary_statistics` need only
   the API key; `connect_whoami` also requires the "Connect Visitor API Key" integration above,
   and then reports the identity tied to that API key (the per-viewer identity demo is clearest
   from the companion chat).
-- **Keep it responsive** (optional): on the **Advanced** tab, set **Min processes** to 1 or
+- Keep it responsive (optional): on the **Advanced** tab, set **Min processes** to 1 or
   more under **Process Settings** so the server doesn't cold-start. See the
   [process configuration documentation](https://docs.posit.co/connect/user/content-settings/index.html#process-configurations).
 

--- a/extensions/simple-mcp-server/README.md
+++ b/extensions/simple-mcp-server/README.md
@@ -46,11 +46,11 @@ Connect 2025.04.0 or newer with API Publishing and OAuth Integrations enabled.
 
 After deploying, configure it for how you'll use it:
 
-- As the signed-in viewer (the paired chat, or any Connect content): on the
-  **Access** tab, add a "Connect Visitor API Key" integration under
-  **Integrations**. If it isn't listed, an administrator must first create a
-  **Connect API** integration on your server. This lets `connect_whoami` identify
-  who's calling. See the
+- As the signed-in viewer (the paired chat, or any Connect content): in the
+  content's settings, on the **Access** tab, add a "Connect Visitor API Key"
+  integration under **Integrations**. If it isn't listed, an administrator must
+  first create a **Connect API** integration on your server. This lets
+  `connect_whoami` identify who's calling. See the
   [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
 - From your own MCP client (Claude Code, Cursor, ...): point it at `{content-url}/mcp`
   and authenticate with a Connect API key (`Authorization: Key <API_KEY>`); the landing page

--- a/extensions/simple-shiny-chat-with-mcp/CHANGELOG.md
+++ b/extensions/simple-shiny-chat-with-mcp/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Forward only the viewer's own key to MCP servers; the app no longer falls back to forwarding its own Connect API key, and the unused `X-MCP-Authorization` header was dropped. (#418)
 - Forward the viewer's Connect key only to MCP servers on this Connect server, matched by full origin (scheme, host, and port) so it can't leak to another origin entered in the sidebar; off-Connect servers are still reachable, just without it. (#418)
-- Pass the MCP auth header through a pre-built `httpx` client so registration works with the current `mcp` transport, which no longer accepts a `headers` argument. Give that client the MCP SDK's own defaults (a 30s timeout with a 300s read, and redirect following); without them tool calls timed out after 5s and a trailing-slash URL failed to register. (#418)
+- Fixed MCP server registration and tool calls that could time out after 5 seconds or fail for a trailing-slash URL. (#418)
 - Close each viewer's MCP server connections when their session ends, so their background tasks and open connections don't leak across sessions. (#418)
 - Surface the underlying cause when adding an MCP server fails, instead of a generic "failed to register" message. (#418)
 - Show the actual error text in the chat when a message fails, instead of a generic sanitized notice. (#418)
@@ -19,27 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apply the assistant's system prompt on AWS Bedrock too (it was only applied to other providers), and make the LLM-provider selection unambiguous: an explicitly configured `CHATLAS_CHAT_PROVIDER_MODEL` now takes precedence over auto-detected Bedrock credentials (Bedrock previously overrode it), Bedrock is probed only as the zero-config fallback, and the setup screen can't disagree with whether a model is configured. (#418)
 - Reject a blank MCP server URL with a clear message instead of a confusing registration error. (#418)
 - Keep the session alive when resolving the viewer fails for an unexpected reason (anything other than a missing integration); log it and continue instead of raising. (#418)
-- Restore the white background behind chat messages so text stays readable over the page's gradient; a newer `shinychat` renamed the message elements, so the old CSS selector no longer matched. (#418)
+- Restore the white background behind chat messages so text stays readable over the page's gradient. (#418)
 
 ### Changed
 
-- Retitled to "Python Shiny: AI Chat with MCP Tools", rewrote the description, and rewrote the README to the standardized template. (#418)
+- Retitled to "Python Shiny: AI Chat with MCP Tools", and rewrote the description and README. (#418)
 - The MCP sidebar now shows the signed-in viewer, so it's clear that tools run with their Connect permissions. (#418)
-- Pinned dependencies: `chatlas` to a release (was git `main`), corrected `python-dotenv` (was `dotenv`), and reconciled the runtime to Python 3.11. (#418)
-- Aligned the setup screen and README settings language with the FastAPI: MCP Server example, naming the Access, Integrations, and Environment Variables locations. (#418)
+- Clarified the setup screen and README settings language, naming the Access, Integrations, and Environment Variables locations. (#418)
 - The setup screen now shows only the step still unconfigured (the LLM provider, the Visitor API Key integration, or both), instead of repeating both steps whenever either is missing. (#418)
 - The info modal now shows the provider and model cleanly, instead of dumping the provider's internal object state. (#418)
-- Dropped the unused `nest-asyncio` dependency. (#418)
 
 ## [0.0.6] - 2026-06-15
 
 ### Changed
 
 - Constrained the Python runtime requirement to the current major version (`>=3.10` → `~=3.10`). (#376)
-
-### Fixed
-
-- Corrected a stale manifest checksum; no change to bundled files. (#376)
 
 ## [0.0.5] - 2026-05-08
 

--- a/extensions/simple-shiny-chat-with-mcp/README.md
+++ b/extensions/simple-shiny-chat-with-mcp/README.md
@@ -44,11 +44,19 @@ Connect 2025.04.0 or newer with OAuth Integrations enabled.
 
 After deploying, in the content's settings:
 
-- **Choose an LLM** by setting `CHATLAS_CHAT_PROVIDER_MODEL` (for example
-  `openai/gpt-4o`) plus the matching API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
-  `GOOGLE_API_KEY`, ...) on the **Advanced** tab, under **Environment Variables**. See the
+- **Choose an LLM** by setting `CHATLAS_CHAT_PROVIDER_MODEL` plus the matching
+  API key on the **Advanced** tab, under **Environment Variables**. For example,
+  to use OpenAI's GPT-4o:
+
+  ```
+  CHATLAS_CHAT_PROVIDER_MODEL = openai/gpt-4o
+  OPENAI_API_KEY              = <your OpenAI API key>
+  ```
+
+  Other providers follow the same pattern with their own model string and key
+  (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, ...); see the
   [chatlas `ChatAuto` docs](https://posit-dev.github.io/chatlas/reference/ChatAuto.html)
-  for provider/model strings. On AWS Bedrock with an instance role, credentials are
+  for the full list. On AWS Bedrock with an instance role, credentials are
   detected automatically and no vars are needed. (The older `CHATLAS_CHAT_PROVIDER`
   and `CHATLAS_CHAT_ARGS` still work but are deprecated.)
 - **Add a Visitor API Key integration** so tools run as the viewer: on the **Access**

--- a/extensions/simple-shiny-chat-with-mcp/README.md
+++ b/extensions/simple-shiny-chat-with-mcp/README.md
@@ -21,12 +21,12 @@ tools, but it works with any streamable HTTP MCP server.
 - Enter an MCP server URL in the sidebar and the app registers its tools. The LLM
   then calls them in conversation, shows the raw tool output, and asks for
   confirmation before any action that creates, updates, or deletes data.
-- **Viewer identity:** the app reads the viewer's Connect session token and, when it
-  calls an MCP server on this same Connect server, forwards the viewer's own
-  credentials, so the tools act as the viewer with their permissions, never as this
-  app. The sidebar shows who you're signed in as. This needs a Visitor API Key
-  integration (see Setup). MCP servers on other hosts are reached without the Connect
-  key, since it wouldn't apply there.
+- The app reads the viewer's Connect session token and, when it calls an MCP server
+  on this same Connect server, forwards the viewer's own credentials, so the tools
+  act as the viewer with their permissions, never as this app. The sidebar shows who
+  you're signed in as. This needs a Visitor API Key integration (see Setup). MCP
+  servers on other hosts are reached without the Connect key, since it wouldn't apply
+  there.
 - Until an LLM provider and that integration are configured, the app shows a setup
   screen instead of the chat.
 
@@ -44,9 +44,9 @@ Connect 2025.04.0 or newer with OAuth Integrations enabled.
 
 After deploying, in the content's settings:
 
-- **Choose an LLM** by setting `CHATLAS_CHAT_PROVIDER_MODEL` plus the matching
-  API key on the **Advanced** tab, under **Environment Variables**. For example,
-  to use OpenAI's GPT-4o:
+- Set an LLM provider and its API key on the **Advanced** tab, under
+  **Environment Variables**: set `CHATLAS_CHAT_PROVIDER_MODEL` plus the matching
+  key. For example, to use OpenAI's GPT-4o:
 
   ```
   CHATLAS_CHAT_PROVIDER_MODEL = openai/gpt-4o
@@ -57,10 +57,12 @@ After deploying, in the content's settings:
   (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, ...); see the
   [chatlas `ChatAuto` docs](https://posit-dev.github.io/chatlas/reference/ChatAuto.html)
   for the full list. On AWS Bedrock with an instance role, credentials are
-  detected automatically and no vars are needed. (The older `CHATLAS_CHAT_PROVIDER`
-  and `CHATLAS_CHAT_ARGS` still work but are deprecated.)
-- **Add a Visitor API Key integration** so tools run as the viewer: on the **Access**
-  tab, add a "Connect Visitor API Key" integration under **Integrations**. See the
+  detected automatically and no variables are needed. (The older
+  `CHATLAS_CHAT_PROVIDER` and `CHATLAS_CHAT_ARGS` still work but are deprecated.)
+- Add a "Connect Visitor API Key" integration so tools run as the viewer: on the
+  **Access** tab, add it under **Integrations**. If it isn't listed, an
+  administrator must first create a **Connect API** integration on your server.
+  See the
   [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
 
 ## Customize it


### PR DESCRIPTION
Fixes #429 (can be reviewed commit by commit):
- Rewrote the README and description, and added CONTRIBUTING doc
- Reworked setup screen to match the `simple-shiny-chat-with-mcp` example (clear instructions and indicates what still needs to be configured)
- Added an in-app "how this works" note (signed in as you; content read with your permissions; no admin key stored)
- Surface errors clearly to the user
- Truncate large pages before sending to the model; guard null/malformed deploy times and a missing chat provider (no more crashes)
- Added a helper test suite + CI
- Refreshed default model to Claude Sonnet 4.5
- Bedrock probe only runs when no provider is configured (similar to `simple-shiny-chat-with-mcp`)

Manually deployed for verification.