### PR TITLE
simple-shiny-chat-with-mcp: update Bedrock model, improve the info panel

### DIFF
--- a/extensions/simple-shiny-chat-with-mcp/CHANGELOG.md
+++ b/extensions/simple-shiny-chat-with-mcp/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Python Shiny: AI Chat with MCP Tools extension will b
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.8] - 2026-07-20
+
+### Changed
+
+- Refresh the zero-config Bedrock fallback model to Claude Sonnet 4.5. (#435)
+
+### Fixed
+
+- Make the header's info button visible against the background (it was low-contrast
+  and easy to miss), and give the panel it opens a short description of the app and
+  a Model Context Protocol docs link alongside the model. (#435)
+
 ## [0.0.7] - 2026-07-14
 
 ### Fixed

--- a/extensions/simple-shiny-chat-with-mcp/CHANGELOG.md
+++ b/extensions/simple-shiny-chat-with-mcp/CHANGELOG.md
@@ -10,12 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refresh the zero-config Bedrock fallback model to Claude Sonnet 4.5. (#435)
+- Standardized the server add/remove failure messages on "Couldn't ..." wording. (#435)
+- Sharpened the setup screen and identity note: they now name the Connect Visitor API
+  Key and note that no admin key is stored, and the setup screen mentions that AWS
+  Bedrock with an instance role needs no credentials. (#435)
 
 ### Fixed
 
 - Make the header's info button visible against the background (it was low-contrast
   and easy to miss), and give the panel it opens a short description of the app and
   a Model Context Protocol docs link alongside the model. (#435)
+- Open the setup-screen documentation links in a new tab with `rel="noopener"`. (#435)
 
 ## [0.0.7] - 2026-07-14
 

--- a/extensions/simple-shiny-chat-with-mcp/CONTRIBUTING.md
+++ b/extensions/simple-shiny-chat-with-mcp/CONTRIBUTING.md
@@ -1,18 +1,18 @@
 # Contributing to the Python Shiny: AI Chat with MCP Tools extension
 
-## Local Development
+## Prerequisites
 
-For local testing and development:
+- Python 3.11 or higher
+- [uv](https://docs.astral.sh/uv/)
 
-```bash
-# Install dependencies
-pip install -r requirements.txt
+## Setup
 
-# Run the app locally
-shiny run --reload app.py
-```
+Run `uv sync` to install dependencies.
 
-The app starts on `http://127.0.0.1:8000`.
+## Development
+
+Run `uv run shiny run --reload app.py` to start the app locally on
+`http://127.0.0.1:8000`.
 
 Set an LLM provider first, or the app shows its setup screen instead of the chat.
 It reads these from the environment (a local `.env` works, via `python-dotenv`):
@@ -49,3 +49,18 @@ Tools run as the signed-in viewer, never as the app:
 - The key is forwarded only to MCP servers on this Connect server. A Connect key is
   meaningless to another host and must not leak to one, so servers elsewhere are
   reached without it.
+
+## Bundle
+
+The files sent in the deployment bundle are:
+
+- `app.py`
+- `requirements.txt`
+
+`pyproject.toml`, `uv.lock`, and repo docs are not bundled.
+
+## Changelog
+
+Update the [CHANGELOG](./CHANGELOG.md) using the
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, referencing the
+PR number, and bump `extension.version` in `manifest.json` to trigger a release.

--- a/extensions/simple-shiny-chat-with-mcp/app.py
+++ b/extensions/simple-shiny-chat-with-mcp/app.py
@@ -140,8 +140,9 @@ _LLM_SETUP_SECTION = (
             "This app needs the <code>CHATLAS_CHAT_PROVIDER_MODEL</code> environment variable "
             "and a matching LLM API key. In the content settings, on the "
             "<strong>Advanced</strong> tab, add both of them under <strong>Environment Variables</strong>. "
+            "On AWS Bedrock with an instance role, credentials are detected automatically and no variables are needed. "
             "For more information, "
-            '<a href="https://posit-dev.github.io/chatlas/reference/ChatAuto.html" class="setup-link">see the chatlas documentation</a>.'
+            '<a href="https://posit-dev.github.io/chatlas/reference/ChatAuto.html" class="setup-link" target="_blank" rel="noopener">see the chatlas documentation</a>.'
         ),
         class_="setup-description",
     ),
@@ -165,7 +166,7 @@ _INTEGRATION_SETUP_SECTION = (
             "<strong>Access</strong> tab, add the \"Connect Visitor API Key\" integration under "
             "<strong>Integrations</strong>. "
             "For more information, "
-            '<a href="https://docs.posit.co/connect/user/oauth-integrations/" class="setup-link">see the OAuth Integrations documentation</a>.'
+            '<a href="https://docs.posit.co/connect/user/oauth-integrations/" class="setup-link" target="_blank" rel="noopener">see the OAuth Integrations documentation</a>.'
         ),
         class_="setup-description",
     ),
@@ -366,7 +367,9 @@ If a user's request would require multiple tool calls, create a plan of action f
         if not viewer_name:
             return None
         return ui.p(
-            f"Signed in as {viewer_name}. Tools you add run as you, with your Connect permissions.",
+            f"Signed in as {viewer_name}, resolved from your Connect session. Tools you "
+            "add run as you, with your own permissions, through a Connect Visitor API "
+            "Key. No admin key is stored.",
             class_="small",
             style="opacity: 0.85;",
         )
@@ -482,7 +485,7 @@ If a user's request would require multiple tool calls, create a plan of action f
             # surface that cause so the toast says why, not just "failed".
             traceback.print_exc()
             cause = e.__cause__ or e
-            ui.notification_show(f"Error adding server: {cause}", type="error")
+            ui.notification_show(f"Couldn't add server: {cause}", type="error")
 
     @reactive.effect
     async def handle_delete_buttons():
@@ -497,7 +500,7 @@ If a user's request would require multiple tool calls, create a plan of action f
                     traceback.print_exc()
                     cause = e.__cause__ or e
                     ui.notification_show(
-                        f"Error removing server '{srv['name']}': {cause}",
+                        f"Couldn't remove server '{srv['name']}': {cause}",
                         type="error",
                     )
                     return

--- a/extensions/simple-shiny-chat-with-mcp/app.py
+++ b/extensions/simple-shiny-chat-with-mcp/app.py
@@ -15,7 +15,7 @@ load_dotenv()
 
 # Zero-config fallback model, used only when no LLM provider is configured. Bedrock
 # picks up credentials from an instance role, so it needs no API key.
-BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 
 
 def check_aws_bedrock_credentials():
@@ -241,14 +241,10 @@ app_ui = ui.page_fillable(
         }
 
         #info_link {
+            color: white;
             font-size: medium;
             vertical-align: super;
             margin-left: 10px;
-        }
-        .sdk_suggested_prompt {
-            cursor: pointer;
-            border-radius: 0.5em;
-            display: list-item;
         }
         .external-link {
             cursor: alias;
@@ -515,9 +511,23 @@ If a user's request would require multiple tool calls, create a plan of action f
     @reactive.event(input.info_link)
     async def _():
         modal = ui.modal(
-            ui.h1("Information"),
-            ui.h3("Model"),
-            ui.p(f"{chat.provider.name} / {chat.provider.model}"),
+            ui.h3("About this app"),
+            ui.p(
+                "Add MCP servers in the sidebar to give the assistant tools, then "
+                "ask it to use them."
+            ),
+            ui.p(
+                ui.tags.strong("Model: "),
+                f"{chat.provider.name} / {chat.provider.model}",
+            ),
+            ui.p(
+                ui.tags.a(
+                    "Learn more about the Model Context Protocol",
+                    href="https://modelcontextprotocol.io/",
+                    target="_blank",
+                    rel="noopener",
+                )
+            ),
             easy_close=True,
         )
         ui.modal_show(modal)

--- a/extensions/simple-shiny-chat-with-mcp/manifest.json
+++ b/extensions/simple-shiny-chat-with-mcp/manifest.json
@@ -14,29 +14,34 @@
     }
   },
   "environment": {
-      "python": {
-        "requires": "~=3.11"
-      }
-    },
+    "python": {
+      "requires": "~=3.11"
+    }
+  },
   "extension": {
     "name": "simple-shiny-chat-with-mcp",
     "title": "Python Shiny: AI Chat with MCP Tools",
     "description": "A Python Shiny chat app that connects an LLM to tools over the Model Context Protocol (MCP), running on Connect. The tools run as the signed-in viewer, with their Connect permissions, not a shared key. Meant to be used with the FastAPI: MCP Server extension, but you can also point it at your own MCP server to build a chat over your own tools.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/simple-shiny-chat-with-mcp",
     "category": "example",
-    "tags": ["python", "shiny", "mcp", "llm"],
+    "tags": [
+      "python",
+      "shiny",
+      "mcp",
+      "llm"
+    ],
     "requiredFeatures": [
       "OAuth Integrations"
     ],
     "minimumConnectVersion": "2025.04.0",
-    "version": "0.0.7"
+    "version": "0.0.8"
   },
   "files": {
     "requirements.txt": {
       "checksum": "6d5f6221f547d843153e65cb81b5206c"
     },
     "app.py": {
-      "checksum": "055e91c4f285cf171c1eb4de1a297f8e"
+      "checksum": "5d9311016c4e91ebe49640d0934f46fa"
     }
   }
 }

--- a/extensions/simple-shiny-chat-with-mcp/manifest.json
+++ b/extensions/simple-shiny-chat-with-mcp/manifest.json
@@ -41,7 +41,7 @@
       "checksum": "6d5f6221f547d843153e65cb81b5206c"
     },
     "app.py": {
-      "checksum": "5d9311016c4e91ebe49640d0934f46fa"
+      "checksum": "2559ded4a34e3bdbaa602d6e9afbc852"
     }
   }
 }


### PR DESCRIPTION
Follow up to #407 
- Updates Bedrock model from Sonnet 4 to 4.5 (matches `chat-with-content` extension)
- Makes the header info button visible (it was low-contrast against the background) and adds a short app description and a Model Context Protocol docs link to the panel it opens
- Removes the dead `.sdk_suggested_prompt` CSS

Old version:
<img width="437" height="79" alt="Screenshot 2026-07-21 at 12 04 24 PM" src="https://github.com/user-attachments/assets/aca21acb-7f98-4ed5-a1d8-3491b26bb4fd" />
<img width="522" height="300" alt="Screenshot 2026-07-21 at 12 04 31 PM" src="https://github.com/user-attachments/assets/5f02ffa9-83a2-47ee-b1e2-c1705794e8d1" />

New version:
<img width="433" height="80" alt="Screenshot 2026-07-21 at 12 15 39 PM" src="https://github.com/user-attachments/assets/91d4e776-54f0-4aa5-bc2e-13e6580bf418" />
<img width="503" height="338" alt="Screenshot 2026-07-21 at 12 15 45 PM" src="https://github.com/user-attachments/assets/037dbf85-89e5-4005-aa62-ac9869ef0d1e" />