### PR TITLE
simple-mcp-server example: harden landing-page links, align CONTRIBUTING with uv

### DIFF
--- a/extensions/simple-mcp-server/CHANGELOG.md
+++ b/extensions/simple-mcp-server/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the FastAPI: MCP Server extension will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.8] - 2026-07-21
+
+### Security
+
+- Set `rel="noopener"` on the landing page's external links so a linked page can't
+  reach back into the app through `window.opener`. (#436)
+
 ## [0.0.7] - 2026-07-14
 
 ### Changed

--- a/extensions/simple-mcp-server/CONTRIBUTING.md
+++ b/extensions/simple-mcp-server/CONTRIBUTING.md
@@ -1,18 +1,18 @@
 # Contributing to the FastAPI: MCP Server extension
 
-## Local Development
+## Prerequisites
 
-For local testing and development:
+- Python 3.11 or higher
+- [uv](https://docs.astral.sh/uv/)
 
-```bash
-# Install dependencies
-pip install -r requirements.txt
+## Setup
 
-# Run the server locally
-python main.py
-```
+Run `uv sync` to install dependencies.
 
-The server will start on `http://127.0.0.1:8001` with the MCP endpoint at `/mcp`.
+## Development
+
+Run `uv run python main.py` to start the server locally on
+`http://127.0.0.1:8001`, with the MCP endpoint at `/mcp`.
 
 ## Tool Development
 
@@ -25,10 +25,10 @@ To add new MCP tools, use the `@mcp.tool()` decorator:
 def your_new_tool(parameter: str) -> str:
     """
     Description of what your tool does.
-    
+
     Args:
         parameter: Description of the parameter
-        
+
     Returns:
         Description of the return value
     """
@@ -61,3 +61,19 @@ There are two distinct layers, and only the first is something a client sets:
   `Posit-Connect-User-Session-Token` header that Connect injects automatically for the
   logged-in viewer and exchanges it for a viewer-scoped client. There is no header to
   set for this, and it requires a Visitor API Key integration on the content.
+
+## Bundle
+
+The files sent in the deployment bundle are:
+
+- `main.py`
+- `index.html.jinja`
+- `requirements.txt`
+
+`pyproject.toml`, `uv.lock`, and repo docs are not bundled.
+
+## Changelog
+
+Update the [CHANGELOG](./CHANGELOG.md) using the
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, referencing the
+PR number, and bump `extension.version` in `manifest.json` to trigger a release.

--- a/extensions/simple-mcp-server/index.html.jinja
+++ b/extensions/simple-mcp-server/index.html.jinja
@@ -185,7 +185,7 @@
         <p><strong>Whichever way you use it, keep the server warm:</strong> in the content's settings, on
         the "Advanced" tab, set "Min Processes" to 1 or more under "Process Settings", so it responds
         without a cold-start delay. For more information, see the
-        <a href="https://docs.posit.co/connect/user/content-settings/index.html#process-configurations" target="_blank">content process configuration documentation</a>.</p>
+        <a href="https://docs.posit.co/connect/user/content-settings/index.html#process-configurations" target="_blank" rel="noopener">content process configuration documentation</a>.</p>
 
         <h2>1. Use it from the companion chat</h2>
 
@@ -206,7 +206,7 @@
             <code>connect_whoami</code> tool needs it to identify the viewer. Once it's added, you can confirm
             that it works here: this page will greet you by name, resolved from your session token with no API
             key. For more information, see the
-            <a href="https://docs.posit.co/connect/user/oauth-integrations/" target="_blank">OAuth Integrations documentation</a>.
+            <a href="https://docs.posit.co/connect/user/oauth-integrations/" target="_blank" rel="noopener">OAuth Integrations documentation</a>.
         </div>
         {% endif %}
 

--- a/extensions/simple-mcp-server/manifest.json
+++ b/extensions/simple-mcp-server/manifest.json
@@ -27,7 +27,7 @@
     "tags": ["python", "fastapi", "mcp"],
     "requiredFeatures": ["API Publishing", "OAuth Integrations"],
     "minimumConnectVersion": "2025.04.0",
-    "version": "0.0.7"
+    "version": "0.0.8"
   },
   "files": {
     "requirements.txt": {
@@ -37,7 +37,7 @@
       "checksum": "f251569a4d149959815befd3f69d73f4"
     },
     "index.html.jinja": {
-      "checksum": "1d5c621d2bfdb1bb073f9f2b39cdc63a"
+      "checksum": "dda978e56248215b690216664eb5f8e8"
     }
   }
 }


### PR DESCRIPTION
Follow up to #417
- Sets `rel="noopener"` on the landing page's external links so a linked page can't reach back through `window.opener`
- Aligns CONTRIBUTING with the paired `simple-shiny-chat-with-mcp` example: `uv` instead of `pip`, plus Setup/Bundle/Changelog sections