### PR TITLE
Add Dependabot config for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"                    # .github/workflows/*
+      - "/.github/actions/*"   # composite actions (action.yml)
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Introduces a weekly Dependabot scan to bump GitHub actions in a single grouped PR.