### PR TITLE
chore(simple-mcp-server): sync pyproject version with manifest

### DIFF
--- a/extensions/simple-mcp-server/pyproject.toml
+++ b/extensions/simple-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simple-mcp-server"
-version = "0.0.7"
+version = "0.0.8"
 description = "A FastAPI server that exposes MCP tools on Posit Connect."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Follow up to #436 - bump pyproject version for consistency with manifest version