### PR TITLE
docs: note the admin prerequisite in the simple MCP examples' setup

### DIFF
--- a/extensions/simple-mcp-server/README.md
+++ b/extensions/simple-mcp-server/README.md
@@ -48,7 +48,9 @@ After deploying, configure it for how you'll use it:
 
 - **As the signed-in viewer** (the paired chat, or any Connect content): in the content's
   settings, on the **Access** tab, add a "Connect Visitor API Key" integration under
-  **Integrations**. This lets `connect_whoami` identify who's calling. See the
+  **Integrations**. This lets `connect_whoami` identify who's calling. If it isn't
+  listed, an administrator must first create a **Connect API** integration on your
+  server. See the
   [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
 - **From your own MCP client** (Claude Code, Cursor, ...): point it at `{content-url}/mcp`
   and authenticate with a Connect API key (`Authorization: Key <API_KEY>`); the landing page

--- a/extensions/simple-shiny-chat-with-mcp/README.md
+++ b/extensions/simple-shiny-chat-with-mcp/README.md
@@ -52,7 +52,9 @@ After deploying, in the content's settings:
   detected automatically and no vars are needed. (The older `CHATLAS_CHAT_PROVIDER`
   and `CHATLAS_CHAT_ARGS` still work but are deprecated.)
 - **Add a Visitor API Key integration** so tools run as the viewer: on the **Access**
-  tab, add a "Connect Visitor API Key" integration under **Integrations**. See the
+  tab, add a "Connect Visitor API Key" integration under **Integrations**. If it
+  isn't listed, an administrator must first create a **Connect API** integration on
+  your server. See the
   [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
 
 ## Customize it


### PR DESCRIPTION
Add a quick line to the README clarifying how to fix if a user doesn't have the integration as an option.