### PR TITLE
Standardize CONTRIBUTING, README, and CHANGELOG docs 

### DIFF
--- a/extensions/portfolio-dashboard/CHANGELOG.md
+++ b/extensions/portfolio-dashboard/CHANGELOG.md
@@ -9,20 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Retitled to `R Shiny: Portfolio Dashboard`, rewrote the description and README, and added explanatory comments to `app.R` (the Sortino ratio, the MAR, and the input throttle). (#413)
+- Retitled to `R Shiny: Portfolio Dashboard`, and rewrote the description and README. (#413)
 - Switched the sample data from `returns.rds` to `returns.csv` (columns: date, portfolio, returns), refreshed it through 2025 with both average return and volatility rising across the conservative, balanced, and aggressive tiers and a shared 2022 downturn, and made the portfolio selector read its options from the file, so swapping the data file updates it automatically. (#413)
 - Clarified the sidebar input labels to `Minimum Acceptable Rate (MAR)` and `Rolling Window (months)`, and lowered the MAR slider's maximum to a realistic monthly rate (2%). (#413)
-- Switched the rolling Sortino series to trailing (right-aligned) windows so each value reads as of its date, and replaced the month-scale range buttons (a leftover from unused daily data) with 1-, 3-, and 5-year ranges suited to the monthly data. (#413)
+- Switched the rolling Sortino series to trailing (right-aligned) windows so each value reads as of its date, and replaced the month-scale range buttons with 1-, 3-, and 5-year ranges suited to the monthly data. (#413)
 
 ### Fixed
 
-- Removed the dated 2016 election marker and annotation, the unused `dygraphs` import (and dropped `dygraphs`, `stringi`, `stringr`, and `utf8` from the bundled packages, none of which the app needs), and the dead daily-returns series; added the explicit `ggplot2` import; fixed the hardcoded rolling-window label to follow the window input; and replaced the deprecated `size` aesthetic with `linewidth`. (#413)
+- Removed the dated 2016 election marker and annotation, and fixed the hardcoded rolling-window label so it follows the window input. (#413)
 - Showed a message instead of a blank Rolling Sortino plot when the start date leaves fewer months than the rolling window. (#413)
-- Removed an unused by-hand Sortino calculation, and named the scatterplot colors so up and down months stay correctly colored even when a selection contains only one. (#413)
+- Named the scatterplot colors so up and down months stay correctly colored even when a selection contains only one. (#413)
 
 ## [0.0.4] - 2026-06-11
 
-### Changed
-
-- Modernized R code to use the native pipe (`|>`) and consolidated `mutate()` calls. (#365)
-
+- Maintenance release; no user-facing changes. (#365)

--- a/extensions/portfolio-dashboard/CHANGELOG.md
+++ b/extensions/portfolio-dashboard/CHANGELOG.md
@@ -22,4 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.4] - 2026-06-11
 
-- Maintenance release; no user-facing changes. (#365)
+### Changed
+
+- Modernized R code to use the native pipe (`|>`) and consolidated `mutate()` calls. (#365)

--- a/extensions/portfolio-dashboard/README.md
+++ b/extensions/portfolio-dashboard/README.md
@@ -14,12 +14,11 @@ for your own.
 Pick a portfolio, a starting date, a Minimum Acceptable Rate (MAR), and a
 rolling-window length in the sidebar, and four linked plots update:
 
-- **Rolling Sortino**: the Sortino ratio over the rolling window, with a range
-  selector.
-- **Scatterplot**: monthly returns, colored by whether they land above or below
+- A rolling Sortino plot of the ratio over the window, with a range selector.
+- A scatterplot of monthly returns, colored by whether they land above or below
   the MAR.
-- **Histogram**: the distribution of returns, with the MAR marked.
-- **Density**: the return density, with the downside (below-MAR) region shaded.
+- A histogram of the return distribution, with the MAR marked.
+- A density plot of returns, with the downside (below-MAR) region shaded.
 
 The Sortino ratio measures return per unit of *downside* volatility (returns
 below the MAR), so unlike the Sharpe ratio it doesn't penalize upside swings.

--- a/extensions/quarto-presentation/CHANGELOG.md
+++ b/extensions/quarto-presentation/CHANGELOG.md
@@ -18,4 +18,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Retitled to `Quarto: Presentation` and rewrote the description and README around the reveal.js slide-deck pattern. (#410)
 - Reworked the deck into a teaching showcase of what a Quarto slide can hold: an overview with doc links, a syntax-highlighted code block, a Mermaid diagram, an interactive Observable JS chart, a multi-column and incremental-reveal slide, and a publish-to-Connect slide. The sample content carries a light business flavor (a quarterly revenue readout). (#410)
 - Loaded the chart from a small bundled `data.csv` that can be swapped out, instead of Observable's external `olympians` sample dataset. (#410)
-- Pinned the Quarto project to render only `index.qmd` so the changelog is not rendered as a stray page, and added explanatory comments. (#410)
+- Pinned the Quarto project to render only `index.qmd` so the changelog is not rendered as a stray page. (#410)

--- a/extensions/quarto-presentation/README.md
+++ b/extensions/quarto-presentation/README.md
@@ -14,14 +14,14 @@ business flavor (a quarterly revenue readout) that you can swap for your own.
 The deck (`index.qmd`) is roughly one slide per capability, each linking to its
 Quarto docs:
 
-- **What goes on a slide**: an overview of the features, with links.
-- **Show your work with code**: a syntax-highlighted code block (Quarto can also
-  execute R, Python, and Julia and embed the output).
-- **Diagrams**: a Mermaid diagram drawn from text.
-- **Interactive charts**: an Observable JS chart with a segment filter, loaded
-  from a bundled `data.csv` you can swap out.
-- **Layout and reveals**: a multi-column slide with an incremental list.
-- **Publish to Connect**: how to render and publish.
+- An overview slide of the deck's features, with links.
+- A syntax-highlighted code block (Quarto can also execute R, Python, and Julia
+  and embed the output).
+- A Mermaid diagram drawn from text.
+- An interactive Observable JS chart with a segment filter, loaded from a bundled
+  `data.csv` you can swap out.
+- A multi-column slide with an incremental list.
+- A slide on how to render and publish to Connect.
 
 ## Customize it
 

--- a/extensions/script-python/CHANGELOG.md
+++ b/extensions/script-python/CHANGELOG.md
@@ -20,12 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Exported the CSV files without the leading row-index column. (#392)
-- Re-pinned `requirements.txt` to a minimal, Python 3.9-compatible set so the example installs on 3.9 servers; the previous `ipykernel` pin required Python 3.10, contradicting the declared `~=3.9` floor. (#392)
+- Re-pinned `requirements.txt` to a minimal, Python 3.9-compatible set so the example installs on 3.9 servers. (#392)
 - Pinned the Quarto project to render only the script, so the gallery serves the script rather than a sibling Markdown file (e.g. the changelog). (#392)
-
-### Removed
-
-- Removed the committed `script.quarto_ipynb` build intermediate, which Quarto regenerates on render. (#392)
 
 ## [1.0.1] - 2026-06-11
 

--- a/extensions/simple-mcp-server/CHANGELOG.md
+++ b/extensions/simple-mcp-server/CHANGELOG.md
@@ -40,11 +40,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.5] - 2026-06-11
 
-- Maintenance release; no user-facing changes. (#355)
+### Changed
+
+- Switched to with-connect for integration tests. (#355)
 
 ## [0.0.4] - 2026-05-04
 
-- Maintenance release; no user-facing changes. (#349)
+### Fixed
+
+- Fixed deprecation warnings. (#349)
 
 ## [0.0.3] - 2026-02-03
 

--- a/extensions/simple-mcp-server/CHANGELOG.md
+++ b/extensions/simple-mcp-server/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Retitled to "FastAPI: MCP Server", rewrote the README and description, and reframed the example so its three tools read as starting points to swap out. (#417)
 - The landing page now greets the signed-in viewer by name, resolved from their Connect session token (the same identity the `connect_whoami` tool returns). (#417)
-- Regenerated `requirements.txt` to resolve from the minimum supported Python (3.11) rather than a single 3.14 lock, for broader install compatibility. (#417)
+- Regenerated `requirements.txt` to resolve from the minimum supported Python (3.11) for broader install compatibility. (#417)
 - Bounded the per-viewer client cache so a long-running server can't grow it without limit. (#417)
 
 ### Fixed
@@ -40,15 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.5] - 2026-06-11
 
-### Changed
-
-- Switched to with-connect for integration tests. (#355)
+- Maintenance release; no user-facing changes. (#355)
 
 ## [0.0.4] - 2026-05-04
 
-### Fixed
-
-- Fixed deprecation warnings. (#349)
+- Maintenance release; no user-facing changes. (#349)
 
 ## [0.0.3] - 2026-02-03
 

--- a/extensions/simple-mcp-server/CONTRIBUTING.md
+++ b/extensions/simple-mcp-server/CONTRIBUTING.md
@@ -64,13 +64,15 @@ There are two distinct layers, and only the first is something a client sets:
 
 ## Bundle
 
-The files sent in the deployment bundle are:
+The release tarball is this whole directory, so everything committed here ships,
+including this file. What Connect checksums is `manifest.json`'s `files` list:
 
-- `main.py`
 - `index.html.jinja`
+- `main.py`
 - `requirements.txt`
 
-`pyproject.toml`, `uv.lock`, and repo docs are not bundled.
+Refresh those checksums whenever you edit one of them. `uv.lock` is gitignored, so it
+never reaches the bundle.
 
 ## Changelog
 

--- a/extensions/simple-mcp-server/CONTRIBUTING.md
+++ b/extensions/simple-mcp-server/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to the FastAPI: MCP Server extension
+# Contributing to FastAPI: MCP Server
 
 ## Prerequisites
 
@@ -54,10 +54,10 @@ def example_tool(input_value: str) -> str:
 
 There are two distinct layers, and only the first is something a client sets:
 
-- **Reaching the content** (transport): an MCP client authenticates to Connect with a
+- Reaching the content (transport): an MCP client authenticates to Connect with a
   Connect API key in the standard `Authorization` header (`Authorization: Key
   YOUR_API_KEY`). This is how the request reaches the deployed server.
-- **Acting as the viewer** (tools like `connect_whoami`): the tool reads the
+- Acting as the viewer (tools like `connect_whoami`): the tool reads the
   `Posit-Connect-User-Session-Token` header that Connect injects automatically for the
   logged-in viewer and exchanges it for a viewer-scoped client. There is no header to
   set for this, and it requires a Visitor API Key integration on the content.

--- a/extensions/simple-mcp-server/README.md
+++ b/extensions/simple-mcp-server/README.md
@@ -46,19 +46,19 @@ Connect 2025.04.0 or newer with API Publishing and OAuth Integrations enabled.
 
 After deploying, configure it for how you'll use it:
 
-- **As the signed-in viewer** (the paired chat, or any Connect content): in the content's
-  settings, on the **Access** tab, add a "Connect Visitor API Key" integration under
-  **Integrations**. This lets `connect_whoami` identify who's calling. If it isn't
-  listed, an administrator must first create a **Connect API** integration on your
-  server. See the
+- As the signed-in viewer (the paired chat, or any Connect content): in the
+  content's settings, on the **Access** tab, add a "Connect Visitor API Key"
+  integration under **Integrations**. If it isn't listed, an administrator must
+  first create a **Connect API** integration on your server. This lets
+  `connect_whoami` identify who's calling. See the
   [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
-- **From your own MCP client** (Claude Code, Cursor, ...): point it at `{content-url}/mcp`
+- From your own MCP client (Claude Code, Cursor, ...): point it at `{content-url}/mcp`
   and authenticate with a Connect API key (`Authorization: Key <API_KEY>`); the landing page
   has copy-paste snippets. `list_known_datasets` and `calculate_summary_statistics` need only
   the API key; `connect_whoami` also requires the "Connect Visitor API Key" integration above,
   and then reports the identity tied to that API key (the per-viewer identity demo is clearest
   from the companion chat).
-- **Keep it responsive** (optional): on the **Advanced** tab, set **Min processes** to 1 or
+- Keep it responsive (optional): on the **Advanced** tab, set **Min processes** to 1 or
   more under **Process Settings** so the server doesn't cold-start. See the
   [process configuration documentation](https://docs.posit.co/connect/user/content-settings/index.html#process-configurations).
 

--- a/extensions/simple-shiny-chat-with-mcp/CHANGELOG.md
+++ b/extensions/simple-shiny-chat-with-mcp/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Forward only the viewer's own key to MCP servers; the app no longer falls back to forwarding its own Connect API key, and the unused `X-MCP-Authorization` header was dropped. (#418)
 - Forward the viewer's Connect key only to MCP servers on this Connect server, matched by full origin (scheme, host, and port) so it can't leak to another origin entered in the sidebar; off-Connect servers are still reachable, just without it. (#418)
-- Pass the MCP auth header through a pre-built `httpx` client so registration works with the current `mcp` transport, which no longer accepts a `headers` argument. Give that client the MCP SDK's own defaults (a 30s timeout with a 300s read, and redirect following); without them tool calls timed out after 5s and a trailing-slash URL failed to register. (#418)
+- Fixed MCP server registration and tool calls that could time out after 5 seconds or fail for a trailing-slash URL. (#418)
 - Close each viewer's MCP server connections when their session ends, so their background tasks and open connections don't leak across sessions. (#418)
 - Surface the underlying cause when adding an MCP server fails, instead of a generic "failed to register" message. (#418)
 - Show the actual error text in the chat when a message fails, instead of a generic sanitized notice. (#418)
@@ -36,27 +36,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apply the assistant's system prompt on AWS Bedrock too (it was only applied to other providers), and make the LLM-provider selection unambiguous: an explicitly configured `CHATLAS_CHAT_PROVIDER_MODEL` now takes precedence over auto-detected Bedrock credentials (Bedrock previously overrode it), Bedrock is probed only as the zero-config fallback, and the setup screen can't disagree with whether a model is configured. (#418)
 - Reject a blank MCP server URL with a clear message instead of a confusing registration error. (#418)
 - Keep the session alive when resolving the viewer fails for an unexpected reason (anything other than a missing integration); log it and continue instead of raising. (#418)
-- Restore the white background behind chat messages so text stays readable over the page's gradient; a newer `shinychat` renamed the message elements, so the old CSS selector no longer matched. (#418)
+- Restore the white background behind chat messages so text stays readable over the page's gradient. (#418)
 
 ### Changed
 
-- Retitled to "Python Shiny: AI Chat with MCP Tools", rewrote the description, and rewrote the README to the standardized template. (#418)
+- Retitled to "Python Shiny: AI Chat with MCP Tools", and rewrote the description and README. (#418)
 - The MCP sidebar now shows the signed-in viewer, so it's clear that tools run with their Connect permissions. (#418)
-- Pinned dependencies: `chatlas` to a release (was git `main`), corrected `python-dotenv` (was `dotenv`), and reconciled the runtime to Python 3.11. (#418)
-- Aligned the setup screen and README settings language with the FastAPI: MCP Server example, naming the Access, Integrations, and Environment Variables locations. (#418)
+- Clarified the setup screen and README settings language, naming the Access, Integrations, and Environment Variables locations. (#418)
 - The setup screen now shows only the step still unconfigured (the LLM provider, the Visitor API Key integration, or both), instead of repeating both steps whenever either is missing. (#418)
 - The info modal now shows the provider and model cleanly, instead of dumping the provider's internal object state. (#418)
-- Dropped the unused `nest-asyncio` dependency. (#418)
 
 ## [0.0.6] - 2026-06-15
 
 ### Changed
 
 - Constrained the Python runtime requirement to the current major version (`>=3.10` → `~=3.10`). (#376)
-
-### Fixed
-
-- Corrected a stale manifest checksum; no change to bundled files. (#376)
 
 ## [0.0.5] - 2026-05-08
 

--- a/extensions/simple-shiny-chat-with-mcp/CONTRIBUTING.md
+++ b/extensions/simple-shiny-chat-with-mcp/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to the Python Shiny: AI Chat with MCP Tools extension
+# Contributing to Python Shiny: AI Chat with MCP Tools
 
 ## Prerequisites
 

--- a/extensions/simple-shiny-chat-with-mcp/CONTRIBUTING.md
+++ b/extensions/simple-shiny-chat-with-mcp/CONTRIBUTING.md
@@ -52,12 +52,14 @@ Tools run as the signed-in viewer, never as the app:
 
 ## Bundle
 
-The files sent in the deployment bundle are:
+The release tarball is this whole directory, so everything committed here ships,
+including this file. What Connect checksums is `manifest.json`'s `files` list:
 
 - `app.py`
 - `requirements.txt`
 
-`pyproject.toml`, `uv.lock`, and repo docs are not bundled.
+Refresh those checksums whenever you edit one of them. `uv.lock` is gitignored, so it
+never reaches the bundle.
 
 ## Changelog
 

--- a/extensions/simple-shiny-chat-with-mcp/README.md
+++ b/extensions/simple-shiny-chat-with-mcp/README.md
@@ -21,12 +21,12 @@ tools, but it works with any streamable HTTP MCP server.
 - Enter an MCP server URL in the sidebar and the app registers its tools. The LLM
   then calls them in conversation, shows the raw tool output, and asks for
   confirmation before any action that creates, updates, or deletes data.
-- **Viewer identity:** the app reads the viewer's Connect session token and, when it
-  calls an MCP server on this same Connect server, forwards the viewer's own
-  credentials, so the tools act as the viewer with their permissions, never as this
-  app. The sidebar shows who you're signed in as. This needs a Visitor API Key
-  integration (see Setup). MCP servers on other hosts are reached without the Connect
-  key, since it wouldn't apply there.
+- The app reads the viewer's Connect session token and, when it calls an MCP server
+  on this same Connect server, forwards the viewer's own credentials, so the tools
+  act as the viewer with their permissions, never as this app. The sidebar shows who
+  you're signed in as. This needs a Visitor API Key integration (see Setup). MCP
+  servers on other hosts are reached without the Connect key, since it wouldn't apply
+  there.
 - Until an LLM provider and that integration are configured, the app shows a setup
   screen instead of the chat.
 
@@ -44,17 +44,25 @@ Connect 2025.04.0 or newer with OAuth Integrations enabled.
 
 After deploying, in the content's settings:
 
-- **Choose an LLM** by setting `CHATLAS_CHAT_PROVIDER_MODEL` (for example
-  `openai/gpt-4o`) plus the matching API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
-  `GOOGLE_API_KEY`, ...) on the **Advanced** tab, under **Environment Variables**. See the
+- Set an LLM provider and its API key on the **Advanced** tab, under
+  **Environment Variables**: set `CHATLAS_CHAT_PROVIDER_MODEL` plus the matching
+  key. For example, to use OpenAI's GPT-4o:
+
+  ```
+  CHATLAS_CHAT_PROVIDER_MODEL = openai/gpt-4o
+  OPENAI_API_KEY              = <your OpenAI API key>
+  ```
+
+  Other providers follow the same pattern with their own model string and key
+  (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, ...); see the
   [chatlas `ChatAuto` docs](https://posit-dev.github.io/chatlas/reference/ChatAuto.html)
-  for provider/model strings. On AWS Bedrock with an instance role, credentials are
-  detected automatically and no vars are needed. (The older `CHATLAS_CHAT_PROVIDER`
-  and `CHATLAS_CHAT_ARGS` still work but are deprecated.)
-- **Add a Visitor API Key integration** so tools run as the viewer: on the **Access**
-  tab, add a "Connect Visitor API Key" integration under **Integrations**. If it
-  isn't listed, an administrator must first create a **Connect API** integration on
-  your server. See the
+  for the full list. On AWS Bedrock with an instance role, credentials are
+  detected automatically and no variables are needed. (The older
+  `CHATLAS_CHAT_PROVIDER` and `CHATLAS_CHAT_ARGS` still work but are deprecated.)
+- Add a "Connect Visitor API Key" integration so tools run as the viewer: on the
+  **Access** tab, add it under **Integrations**. If it isn't listed, an
+  administrator must first create a **Connect API** integration on your server.
+  See the
   [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
 
 ## Customize it


### PR DESCRIPTION
In #433, we identified that we want to: 
- Avoid Claude `- **label**` style
- Only have entries for user-facing changes in the CHANGELOG

This PR standardizes for both of those (as well as a change to the CONTRIBUTING) for: `portfolio-dashboard`, `quarto-presentation`, `script-python`, `simple-mcp-server`, `simple-shiny-chat-with-mcp`.