### PR TITLE
fix: pin quarto extensions to render only their served document

### DIFF
--- a/extensions/pqr/CHANGELOG.md
+++ b/extensions/pqr/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Quarto Document with Python and R extension will be d
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-07-28
+
+### Changed
+
+- Added a `_quarto.yml` pinning `project.render` to `index.qmd` so only the document renders, preventing a sibling `CHANGELOG.md` from rendering as a stray page. (#449)
+
 ## [0.1.3] - 2026-06-22
 
 ### Fixed

--- a/extensions/pqr/_quarto.yml
+++ b/extensions/pqr/_quarto.yml
@@ -1,6 +1,5 @@
 project:
-  title: Stock Report
-  # Render only the report so it is the unambiguous primary document.
+  # Render only the document so it is the unambiguous primary document.
   # Without this, Quarto also renders sibling Markdown (e.g. CHANGELOG.md)
   # and the default served document can become that file instead.
   render:

--- a/extensions/pqr/manifest.json
+++ b/extensions/pqr/manifest.json
@@ -1264,6 +1264,9 @@
     ".Rprofile": {
       "checksum": "57f9047cb06fdbef821b61f49e21406e"
     },
+    "_quarto.yml": {
+      "checksum": "6087acf57476d9f95b353c3db3ae0fb2"
+    },
     "index.qmd": {
       "checksum": "e3c9e1907f7e77e8d7da0492e92d9def"
     },
@@ -1289,6 +1292,6 @@
     "category": "example",
     "tags": ["python", "quarto", "r"],
     "minimumConnectVersion": "2025.04.0",
-    "version": "0.1.3"
+    "version": "0.1.4"
   }
 }

--- a/extensions/quarto-document/_quarto.yml
+++ b/extensions/quarto-document/_quarto.yml
@@ -1,2 +1,7 @@
 project:
   title: Quarto Document
+  # Render only the document so it is the unambiguous primary document.
+  # Without this, Quarto also renders sibling Markdown (e.g. CHANGELOG.md)
+  # and the default served document can become that file instead.
+  render:
+    - index.qmd

--- a/extensions/quarto-document/connect-extension.qmd
+++ b/extensions/quarto-document/connect-extension.qmd
@@ -1,8 +1,0 @@
----
-title: Quarto Document
-categories:
-    - quarto
----
-
-This Quarto example shows how a basic document can present diagrams and
-interactivity.

--- a/extensions/quarto-document/manifest.json
+++ b/extensions/quarto-document/manifest.json
@@ -18,7 +18,7 @@
   "packages": null,
   "files": {
     "_quarto.yml": {
-      "checksum": "e498dcc5956dba39a6df10ac9568fcb9"
+      "checksum": "d5f926f04e252b3042f30d8b7e0c6902"
     },
     "index.qmd": {
       "checksum": "52f82c15783f37b2de073e22e1b5a648"
@@ -32,7 +32,7 @@
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/quarto-document",
     "minimumConnectVersion": "2025.04.0",
     "category": "example",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "environment": {
     "quarto": {

--- a/extensions/quarto-stock-report-python/CHANGELOG.md
+++ b/extensions/quarto-stock-report-python/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Quarto Stock Report using Python extension will be do
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2026-07-28
+
+### Changed
+
+- Pinned the Quarto `project.render` list to `index.qmd` so only the report renders, preventing a sibling `CHANGELOG.md` from rendering as a stray page. (#449)
+- Removed `connect-extension.qmd`, a superseded legacy gallery-metadata file that is no longer used. (#449)
+
 ## [1.0.5] - 2026-06-15
 
 ### Changed

--- a/extensions/quarto-stock-report-python/connect-extension.qmd
+++ b/extensions/quarto-stock-report-python/connect-extension.qmd
@@ -1,8 +1,0 @@
----
-title: Quarto Stock Report using Python
-categories:
-    - python 
-    - quarto 
----
-
-This stock report is generated using Quarto and  Python. It is an example of how you might automate regular updates using a data source. The report also generates a custom email, sharing the results directly to stakeholders.

--- a/extensions/quarto-stock-report-python/manifest.json
+++ b/extensions/quarto-stock-report-python/manifest.json
@@ -12,7 +12,7 @@
     "minimumConnectVersion": "2025.04.0",
     "category": "example",
     "tags": ["quarto", "python"],
-    "version": "1.0.5"
+    "version": "1.0.6"
   },
   "environment": {
     "python": {
@@ -38,7 +38,7 @@
   },
   "files": {
     "_quarto.yml": {
-      "checksum": "35b4c4c58cce875b126683c525ad40f4"
+      "checksum": "c18e19d86e99c788e4ccfabf68179aa2"
     },
     "index.qmd": {
       "checksum": "7eeaeddb32075ffea02ef77ada5b719b"

--- a/extensions/quarto-stock-report-r/CHANGELOG.md
+++ b/extensions/quarto-stock-report-r/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Quarto Stock Report using R extension will be documen
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2026-07-28
+
+### Changed
+
+- Pinned the Quarto `project.render` list to `index.qmd` so only the report renders, preventing a sibling `CHANGELOG.md` from rendering as a stray page. (#449)
+
 ## [1.0.4] - 2026-06-11
 
 ### Changed

--- a/extensions/quarto-stock-report-r/_quarto.yml
+++ b/extensions/quarto-stock-report-r/_quarto.yml
@@ -1,2 +1,7 @@
 project:
   title: Stock Report
+  # Render only the report so it is the unambiguous primary document.
+  # Without this, Quarto also renders sibling Markdown (e.g. CHANGELOG.md)
+  # and the default served document can become that file instead.
+  render:
+    - index.qmd

--- a/extensions/quarto-stock-report-r/manifest.json
+++ b/extensions/quarto-stock-report-r/manifest.json
@@ -32,7 +32,7 @@
     "category": "example",
     "minimumConnectVersion": "2025.04.0",
     "tags": ["quarto", "r"],
-    "version": "1.0.4"
+    "version": "1.0.5"
   },
   "packages": {
     "DT": {
@@ -2419,13 +2419,13 @@
   },
   "files": {
     "_quarto.yml": {
-      "checksum": "35b4c4c58cce875b126683c525ad40f4"
+      "checksum": "c18e19d86e99c788e4ccfabf68179aa2"
     },
     ".output_metadata.json": {
       "checksum": "a335b9151c7b39bed18fd0f56928ce68"
     },
     "CHANGELOG.md": {
-      "checksum": "6adb848a545277816a79a36437af87db"
+      "checksum": "eb505cb295c52e67ec53e5557bc34141"
     },
     "data.csv": {
       "checksum": "d64607673ef065841a9d355317ec8d7b"


### PR DESCRIPTION
Split out of #442 per @dotNomad's review.

Quarto renders every sibling Markdown file as its own page. With no pinned entrypoint, the served document can silently flip to one of those pages instead. This pins `project.render` to the entrypoint in `pqr`, `quarto-stock-report-python`, and `quarto-stock-report-r`, which were each rendering a stray `CHANGELOG` page.

Also removes `connect-extension.qmd` from `quarto-document` and `quarto-stock-report-python`, a superseded legacy gallery-metadata file that's no longer used.

The CI guard for this class of bug is in a follow-up PR, stacked on this one.