### PR TITLE
feat(package-vulnerability-scanner): batch package reads with per-item resilience

### DIFF
--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -133,6 +133,10 @@ CONTENT_MAX_ATTEMPTS = 3
 # that thread lives on until the request-level deadline frees it.
 CONNECT_API_TIMEOUT_SECONDS = 30
 
+# Maximum content items to read packages for at once, so a large scan doesn't
+# overwhelm Connect.
+CONTENT_FETCH_CONCURRENCY = 5
+
 
 # A 5xx from Connect or its gateway (e.g. a 504 while it is under scan load), or a
 # call that timed out outright, is worth retrying; a 4xx or a missing item is not.
@@ -182,27 +186,91 @@ async def search_content(request: Request, show_all: bool = False):
         raise _upstream_error("Couldn't load your content from Connect.", e)
 
 
-@app.get("/api/packages/{guid}")
-async def get_packages(guid: str, request: Request):
+class PackageScanRequest(BaseModel):
+    guids: list[str] = []
+    # True for the administrator "all content" view, which reads every item's
+    # packages from the server-wide endpoint in one pass rather than item by item.
+    show_all: bool = False
+
+
+# The fields the scan needs from a content item's package record.
+def _package_fields(pkg) -> dict:
+    return {
+        "name": pkg["name"],
+        "version": pkg["version"],
+        "language": pkg["language"],
+        "hash": pkg.get("hash"),
+    }
+
+
+# Read one content item's packages. Any viewer can read this for content they own.
+# This is a blocking SDK call, so it runs in a thread (via _fetch_with_retry)
+# rather than on the event loop.
+def _read_item_packages(visitor: connect.Client, guid: str) -> list:
+    return [_package_fields(pkg) for pkg in visitor.content.get(guid).packages]
+
+
+# Read every content item's packages from the server-wide endpoint in one pass,
+# grouped by content guid. That endpoint is administrator-only, so this backs the
+# admin "all content" view, where reading thousands of items one at a time would
+# be far too slow. This is a blocking SDK call, so it runs in a thread.
+def _read_all_packages_grouped(visitor: connect.Client) -> dict[str, list]:
+    by_guid: dict[str, list] = {}
+    for pkg in visitor.packages.fetch():
+        by_guid.setdefault(pkg["app_guid"], []).append(_package_fields(pkg))
+    return by_guid
+
+
+# Read each requested item's packages concurrently, but only a few at a time so a
+# large scan doesn't overwhelm Connect. An item that can't be read is reported in
+# its own result rather than failing the whole scan; a missing Visitor API Key
+# integration is re-raised so the caller can show the setup prompt.
+async def _read_each_item_packages(visitor: connect.Client, guids: list[str]) -> dict:
+    semaphore = asyncio.Semaphore(CONTENT_FETCH_CONCURRENCY)
+
+    async def fetch_one(guid: str) -> tuple[str, dict]:
+        async with semaphore:
+            try:
+                packages = await _fetch_with_retry(
+                    lambda: _read_item_packages(visitor, guid)
+                )
+                return guid, {"packages": packages}
+            except ClientError as e:
+                if e.error_code == 212:
+                    raise  # missing integration: surface as the setup screen
+                return guid, {
+                    "packages": [],
+                    "error": f"Connect API error: {e.error_message}",
+                }
+            except Exception as e:
+                print(f"Could not read packages for {guid}: {e}")
+                return guid, {
+                    "packages": [],
+                    "error": "Couldn't read this content's packages.",
+                }
+
+    pairs = await asyncio.gather(*(fetch_one(guid) for guid in guids))
+    return dict(pairs)
+
+
+@app.post("/api/packages")
+async def get_packages(scan: PackageScanRequest, request: Request):
+    # A missing Visitor API Key integration surfaces as the in-app setup prompt;
+    # any other global failure is reported so the scan never silently returns
+    # empty. In the own-content path, a single unreadable item is reported on that
+    # item rather than failing the whole scan.
     try:
         # A session-token exchange makes a real Connect API call, so it has to
         # run off the event loop like every other blocking SDK call here.
         visitor = await _fetch_with_retry(lambda: get_visitor_client(request))
-        # Iterating .packages makes its own blocking call, so it has to run
-        # inside the same retried thread as the content fetch, not after it.
-        return await _fetch_with_retry(
-            lambda: list(visitor.content.get(guid).packages)
-        )
+        if scan.show_all:
+            by_guid = await _fetch_with_retry(
+                lambda: _read_all_packages_grouped(visitor)
+            )
+            return {guid: {"packages": by_guid.get(guid, [])} for guid in scan.guids}
+        return await _read_each_item_packages(visitor, scan.guids)
     except ClientError as e:
-        if e.error_code == 212:
-            raise _setup_required(e)
-        # Preserve the existing "not found" shape for other Connect errors (e.g.
-        # an invalid guid), rather than folding every ClientError into the
-        # missing-integration case.
-        raise HTTPException(
-            status_code=404,
-            detail=f"Content not found or error fetching packages: {e.error_message}",
-        )
+        raise _setup_required(e)
     except HTTPException:
         raise  # e.g. the 424 from get_visitor_client; don't re-wrap as a 502
     except Exception as e:

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -133,6 +133,12 @@ CONTENT_MAX_ATTEMPTS = 3
 # that thread lives on until the request-level deadline frees it.
 CONNECT_API_TIMEOUT_SECONDS = 30
 
+# The administrator "all content" read paginates through every package record on
+# the server, so its runtime scales with the size of the deployment rather than
+# with one request. Taking minutes there is expected, not a hang, so it gets a
+# far larger budget than a single-item call.
+SERVER_WIDE_TIMEOUT_SECONDS = 300
+
 # Maximum content items to read packages for at once, so a large scan doesn't
 # overwhelm Connect.
 CONTENT_FETCH_CONCURRENCY = 5
@@ -156,12 +162,14 @@ def _is_transient(exc: Exception) -> bool:
 # Run a synchronous SDK call off the event loop, retrying a transient 5xx (e.g. a
 # 504 while Connect is under load) or an outright timeout with a short backoff
 # before giving up.
-async def _fetch_with_retry(fn):
+async def _fetch_with_retry(fn, timeout=None):
+    # Read the default here rather than in the signature, where it would freeze
+    # at import and stop tracking the constant.
+    if timeout is None:
+        timeout = CONNECT_API_TIMEOUT_SECONDS
     for attempt in range(CONTENT_MAX_ATTEMPTS):
         try:
-            return await asyncio.wait_for(
-                asyncio.to_thread(fn), CONNECT_API_TIMEOUT_SECONDS
-            )
+            return await asyncio.wait_for(asyncio.to_thread(fn), timeout)
         except Exception as e:
             if _is_transient(e) and attempt < CONTENT_MAX_ATTEMPTS - 1:
                 await asyncio.sleep(0.5 * (attempt + 1))
@@ -270,7 +278,8 @@ async def get_packages(scan: PackageScanRequest, request: Request):
         visitor = await _fetch_with_retry(lambda: get_visitor_client(request))
         if scan.show_all:
             by_guid = await _fetch_with_retry(
-                lambda: _read_all_packages_grouped(visitor)
+                lambda: _read_all_packages_grouped(visitor),
+                timeout=SERVER_WIDE_TIMEOUT_SECONDS,
             )
             return {guid: {"packages": by_guid.get(guid, [])} for guid in scan.guids}
         return await _read_each_item_packages(visitor, scan.guids)

--- a/extensions/package-vulnerability-scanner/main.py
+++ b/extensions/package-vulnerability-scanner/main.py
@@ -217,7 +217,12 @@ def _read_item_packages(visitor: connect.Client, guid: str) -> list:
 def _read_all_packages_grouped(visitor: connect.Client) -> dict[str, list]:
     by_guid: dict[str, list] = {}
     for pkg in visitor.packages.fetch():
-        by_guid.setdefault(pkg["app_guid"], []).append(_package_fields(pkg))
+        # One malformed record (e.g. a missing field) shouldn't fail the whole
+        # admin scan; skip it and keep grouping the rest.
+        try:
+            by_guid.setdefault(pkg["app_guid"], []).append(_package_fields(pkg))
+        except KeyError as e:
+            print(f"Skipping malformed package record (missing {e}): {pkg}")
     return by_guid
 
 

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -23,14 +23,14 @@
     "dist/assets/index-Bd7WoAqv.css": {
       "checksum": "980b7708188eee5f84707dcc6cf3b01d"
     },
-    "dist/assets/index-DDPGfFmA.js": {
-      "checksum": "b6d254fb7554759a23d54603d83fd836"
+    "dist/assets/index-BEWOoybn.js": {
+      "checksum": "da5ddbd1d9affbb66e1449a6f1e9392b"
     },
     "dist/index.html": {
-      "checksum": "58ca7cb5afb344897d80bf2bb8a0b1ac"
+      "checksum": "1a6d2fe30d21376a0668ad781de538e6"
     },
     "main.py": {
-      "checksum": "331f2474111a6280734062de89152bb6"
+      "checksum": "8697dad866d91d30ec56cf62707bc817"
     },
     "requirements.txt": {
       "checksum": "9fc5cc5fb559eded1f323793b73e82c5"

--- a/extensions/package-vulnerability-scanner/src/stores/packages.test.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/packages.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+
+import { usePackagesStore } from "./packages";
+
+function mockFetch(impl: () => unknown) {
+  const fn = vi.fn(async () => impl());
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("packages store fetchPackages", () => {
+  it("does nothing and makes no request for an empty guid list", async () => {
+    const fetchFn = mockFetch(() => ok({}));
+    const store = usePackagesStore();
+
+    await store.fetchPackages([]);
+
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(store.contentItems).toEqual({});
+  });
+
+  it("sends show_all in the request body, defaulting to false", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    const fn = vi.fn(async (_url: string, opts: RequestInit) => {
+      bodies.push(JSON.parse(opts.body as string));
+      return ok({});
+    });
+    vi.stubGlobal("fetch", fn);
+    const store = usePackagesStore();
+
+    await store.fetchPackages(["g1"]);
+    await store.fetchPackages(["g2"], true);
+
+    expect(bodies[0].show_all).toBe(false);
+    expect(bodies[1].show_all).toBe(true);
+  });
+
+  it("populates packages per guid and resolves loading state on success", async () => {
+    mockFetch(() =>
+      ok({
+        g1: {
+          packages: [
+            { name: "flask", version: "2.0", language: "python", hash: null },
+          ],
+        },
+        g2: { packages: [] },
+      }),
+    );
+    const store = usePackagesStore();
+
+    await store.fetchPackages(["g1", "g2"]);
+
+    expect(store.contentItems.g1.packages).toHaveLength(1);
+    expect(store.contentItems.g1.isFetched).toBe(true);
+    expect(store.contentItems.g1.isLoading).toBe(false);
+    expect(store.contentItems.g1.error).toBeNull();
+    expect(store.contentItems.g2.packages).toEqual([]);
+    expect(store.error).toBeNull();
+  });
+
+  it("defaults a requested guid missing from the response to no packages", async () => {
+    mockFetch(() => ok({}));
+    const store = usePackagesStore();
+
+    await store.fetchPackages(["g1"]);
+
+    expect(store.contentItems.g1.packages).toEqual([]);
+    expect(store.contentItems.g1.isFetched).toBe(true);
+    expect(store.contentItems.g1.error).toBeNull();
+  });
+
+  it("records a per-item error without setting the store-level error", async () => {
+    mockFetch(() => ok({ g1: { error: "boom for g1" } }));
+    const store = usePackagesStore();
+
+    await store.fetchPackages(["g1"]);
+
+    expect(store.contentItems.g1.error?.message).toBe("boom for g1");
+    expect(store.contentItems.g1.packages).toEqual([]);
+    expect(store.contentItems.g1.isFetched).toBe(true);
+    // A single item's failure is not a whole-scan failure.
+    expect(store.error).toBeNull();
+  });
+
+  it("sets the store error and resolves every item on a failed request", async () => {
+    mockFetch(() => ({ ok: false, status: 502 }));
+    const store = usePackagesStore();
+
+    await expect(store.fetchPackages(["g1", "g2"])).rejects.toThrow(
+      "status 502",
+    );
+
+    expect(store.error).not.toBeNull();
+    for (const guid of ["g1", "g2"]) {
+      expect(store.contentItems[guid].error).not.toBeNull();
+      expect(store.contentItems[guid].isFetched).toBe(true);
+      expect(store.contentItems[guid].isLoading).toBe(false);
+    }
+  });
+
+  it("handles a network rejection the same as a failed request", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    vi.stubGlobal("fetch", fn);
+    const store = usePackagesStore();
+
+    await expect(store.fetchPackages(["g1"])).rejects.toThrow("network down");
+    expect(store.error).not.toBeNull();
+    expect(store.contentItems.g1.isLoading).toBe(false);
+  });
+
+  it("setPackagesForContent stores a fetched item directly", () => {
+    const store = usePackagesStore();
+    const err = new Error("not deployed");
+
+    store.setPackagesForContent("g1", [], err);
+
+    expect(store.contentItems.g1.error).toBe(err);
+    expect(store.contentItems.g1.isFetched).toBe(true);
+    expect(store.contentItems.g1.isLoading).toBe(false);
+  });
+});

--- a/extensions/package-vulnerability-scanner/src/stores/packages.test.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/packages.test.ts
@@ -34,6 +34,23 @@ describe("packages store fetchPackages", () => {
     expect(store.contentItems).toEqual({});
   });
 
+  it("clears a previous failure even when there is nothing left to fetch", async () => {
+    mockFetch(() => ({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: "Connect is down" }),
+    }));
+    const store = usePackagesStore();
+    await expect(store.fetchPackages(["g1"])).rejects.toThrow(
+      "Connect is down",
+    );
+    expect(store.error).not.toBeNull();
+
+    await store.fetchPackages([]);
+
+    expect(store.error).toBeNull();
+  });
+
   it("sends show_all in the request body, defaulting to false", async () => {
     const bodies: Array<Record<string, unknown>> = [];
     const fn = vi.fn(async (_url: string, opts: RequestInit) => {

--- a/extensions/package-vulnerability-scanner/src/stores/packages.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/packages.ts
@@ -30,8 +30,10 @@ export const usePackagesStore = defineStore("packages", () => {
   // content items are in view. `showAll` is the admin "all content" view, which
   // the backend reads from its faster server-wide endpoint.
   async function fetchPackages(guids: string[], showAll: boolean = false) {
-    if (guids.length === 0) return;
+    // Clear before the empty-list check, so a caller that ends up with nothing
+    // left to fetch still retires the previous attempt's failure.
     error.value = null;
+    if (guids.length === 0) return;
 
     for (const guid of guids) {
       if (!contentItems.value[guid]) {
@@ -58,10 +60,7 @@ export const usePackagesStore = defineStore("packages", () => {
 
       if (!response.ok) {
         throw new Error(
-          await errorDetail(
-            response,
-            "Couldn't load packages from Connect.",
-          ),
+          await errorDetail(response, "Couldn't load packages from Connect."),
         );
       }
 

--- a/extensions/package-vulnerability-scanner/src/stores/packages.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/packages.ts
@@ -1,6 +1,8 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 
+import { errorDetail } from "../lib/errorDetail";
+
 export interface Package {
   hash: string | null;
   language: string;
@@ -23,44 +25,79 @@ export const usePackagesStore = defineStore("packages", () => {
   const isLoading = ref(false);
   const error = ref<Error | null>(null);
 
-  // Fetch packages for a specific content ID
-  async function fetchPackagesForContent(contentId: string) {
-    if (!contentItems.value[contentId]) {
-      // Initialize content item
-      contentItems.value[contentId] = {
-        guid: contentId,
-        packages: [],
-        isLoading: true,
-        error: null,
-        isFetched: false,
-        lastFetchTime: null,
-      };
-    } else {
-      // Update existing content item loading state
-      contentItems.value[contentId].isLoading = true;
-      contentItems.value[contentId].error = null;
+  // Fetch packages for the given content in one request. The backend returns
+  // them grouped by GUID, so this stays one round-trip no matter how many
+  // content items are in view. `showAll` is the admin "all content" view, which
+  // the backend reads from its faster server-wide endpoint.
+  async function fetchPackages(guids: string[], showAll: boolean = false) {
+    if (guids.length === 0) return;
+    error.value = null;
+
+    for (const guid of guids) {
+      if (!contentItems.value[guid]) {
+        contentItems.value[guid] = {
+          guid,
+          packages: [],
+          isLoading: true,
+          error: null,
+          isFetched: false,
+          lastFetchTime: null,
+        };
+      } else {
+        contentItems.value[guid].isLoading = true;
+        contentItems.value[guid].error = null;
+      }
     }
 
     try {
-      const response = await fetch(`api/packages/${contentId}`);
+      const response = await fetch("api/packages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ guids, show_all: showAll }),
+      });
 
       if (!response.ok) {
-        throw new Error(`HTTP error - Status: ${response.status}`);
+        throw new Error(
+          await errorDetail(
+            response,
+            "Couldn't load packages from Connect.",
+          ),
+        );
       }
 
-      const data = await response.json();
+      const data: Record<string, { packages?: Package[]; error?: string }> =
+        await response.json();
 
-      // Update the content item with the fetched packages
-      contentItems.value[contentId].packages = data;
-      contentItems.value[contentId].isFetched = true;
-      contentItems.value[contentId].lastFetchTime = new Date();
+      for (const guid of guids) {
+        const item = contentItems.value[guid];
+        if (!item) continue;
+        const result = data[guid] ?? {};
+        if (result.error) {
+          item.packages = [];
+          item.error = new Error(result.error);
+        } else {
+          item.packages = result.packages ?? [];
+          item.error = null;
+        }
+        item.isFetched = true;
+        item.lastFetchTime = new Date();
+        item.isLoading = false;
+      }
     } catch (err) {
       console.error("Error fetching packages:", err);
-      contentItems.value[contentId].error = err as Error;
-      contentItems.value[contentId].isFetched = true;
+      // Record the failure at the store level so the summary can report it, and
+      // resolve every requested item's loading state so a failed request shows
+      // an error instead of spinning forever.
+      error.value = err as Error;
+      for (const guid of guids) {
+        const item = contentItems.value[guid];
+        if (item) {
+          item.error = err as Error;
+          item.isFetched = true;
+          item.isLoading = false;
+        }
+      }
       throw err;
-    } finally {
-      contentItems.value[contentId].isLoading = false;
     }
   }
 
@@ -79,8 +116,18 @@ export const usePackagesStore = defineStore("packages", () => {
     };
   }
 
+  // Still called from ContentList.vue's not-yet-updated toggle handler; that
+  // caller goes away (the batched fetch keeps the cache across toggles instead)
+  // in the PR that rewrites ContentList.vue.
   function clearAllPackages() {
     contentItems.value = {};
+  }
+
+  // Thin compatibility wrapper for ContentList.vue's not-yet-updated per-item
+  // fetch loop; removed once that caller is rewritten to call fetchPackages
+  // directly with every guid it needs at once.
+  async function fetchPackagesForContent(guid: string) {
+    return fetchPackages([guid]);
   }
 
   return {
@@ -90,8 +137,9 @@ export const usePackagesStore = defineStore("packages", () => {
     error,
 
     // Actions
-    fetchPackagesForContent,
+    fetchPackages,
     setPackagesForContent,
     clearAllPackages,
+    fetchPackagesForContent,
   };
 });

--- a/extensions/package-vulnerability-scanner/test_main.py
+++ b/extensions/package-vulnerability-scanner/test_main.py
@@ -590,6 +590,37 @@ def test_packages_endpoint_show_all_uses_server_wide(monkeypatch, api):
     visitor.content.get.assert_not_called()
 
 
+def test_packages_endpoint_show_all_skips_malformed_record(monkeypatch, api):
+    # One record missing a required field shouldn't fail the whole admin scan;
+    # it's skipped and the rest are still grouped and returned.
+    visitor = MagicMock()
+    visitor.packages.fetch.return_value = [
+        {
+            "app_guid": "g1",
+            "name": "flask",
+            "version": "2.0",
+            "language": "python",
+            "hash": "h1",
+        },
+        {"app_guid": "g1", "name": "numpy"},  # missing version, language
+        {
+            "app_guid": "g2",
+            "name": "dplyr",
+            "version": "1.1",
+            "language": "r",
+            "hash": "h3",
+        },
+    ]
+    monkeypatch.setattr(main, "get_visitor_client", lambda request: visitor)
+
+    resp = api.post("/api/packages", json={"guids": ["g1", "g2"], "show_all": True})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [p["name"] for p in data["g1"]["packages"]] == ["flask"]
+    assert [p["name"] for p in data["g2"]["packages"]] == ["dplyr"]
+
+
 def test_packages_endpoint_non_client_error_is_502(monkeypatch, api):
     # A non-Connect failure in the server-wide read returns a descriptive 502 for
     # the whole request rather than a bare 500.

--- a/extensions/package-vulnerability-scanner/test_main.py
+++ b/extensions/package-vulnerability-scanner/test_main.py
@@ -454,52 +454,150 @@ def test_content_endpoint_non_client_error_is_502(monkeypatch, api):
     assert resp.json()["detail"] == "Couldn't load your content from Connect."
 
 
-# --- /api/packages/{guid} ---------------------------------------------------
+# --- /api/packages ---------------------------------------------------------
 
 
-def test_packages_endpoint_ok(monkeypatch, api):
+def make_visitor(packages_by_guid):
+    # Build a visitor client whose content.get(guid).packages returns that guid's
+    # package list.
+    def get(guid):
+        content = MagicMock()
+        content.packages = packages_by_guid[guid]
+        return content
+
     visitor = MagicMock()
-    visitor.content.get.return_value.packages = [{"name": "requests"}]
+    visitor.content.get.side_effect = get
+    return visitor
+
+
+def test_packages_endpoint_returns_packages_per_content(monkeypatch, api):
+    visitor = make_visitor(
+        {
+            "g1": [
+                {"name": "flask", "version": "2.0", "language": "python", "hash": "h1"},
+                {"name": "numpy", "version": "1.0", "language": "python", "hash": "h2"},
+            ],
+            "g2": [
+                {"name": "dplyr", "version": "1.1", "language": "r", "hash": "h3"},
+            ],
+            "g3": [],  # requested but has no packages
+        }
+    )
     monkeypatch.setattr(main, "get_visitor_client", lambda request: visitor)
 
-    resp = api.get("/api/packages/g1")
+    resp = api.post("/api/packages", json={"guids": ["g1", "g2", "g3"]})
 
     assert resp.status_code == 200
-    assert resp.json() == [{"name": "requests"}]
-    visitor.content.get.assert_called_once_with("g1")
+    data = resp.json()
+    assert {p["name"] for p in data["g1"]["packages"]} == {"flask", "numpy"}
+    assert [p["name"] for p in data["g2"]["packages"]] == ["dplyr"]
+    assert data["g3"]["packages"] == []
+    assert visitor.content.get.call_count == 3  # one read per requested item
 
 
 def test_packages_endpoint_setup_required(monkeypatch, api):
-    def raise_setup_error(request):
-        raise make_client_error(212)
-
-    monkeypatch.setattr(main, "get_visitor_client", raise_setup_error)
-
-    resp = api.get("/api/packages/g1")
-
-    assert resp.status_code == 424
-    assert "Visitor API Key" in resp.json()["detail"]
-
-
-def test_packages_endpoint_other_client_error_is_404(monkeypatch, api):
-    # An invalid guid, or any other Connect error, keeps the existing "not found"
-    # shape rather than being folded into the missing-integration case.
+    # A missing Visitor API Key integration (ClientError 212) fails the whole scan
+    # with a 424 so the UI shows the setup screen, rather than a per-item error.
     visitor = MagicMock()
-    visitor.content.get.side_effect = make_client_error(5, message="No such content")
+    visitor.content.get.side_effect = make_client_error(212)
     monkeypatch.setattr(main, "get_visitor_client", lambda request: visitor)
 
-    resp = api.get("/api/packages/g1")
+    assert api.post("/api/packages", json={"guids": ["g1"]}).status_code == 424
 
-    assert resp.status_code == 404
-    assert "No such content" in resp.json()["detail"]
+
+def test_packages_endpoint_reports_per_item_failures(monkeypatch, api):
+    # An item that can't be read comes back with an error while the others still
+    # return their packages, so one bad item doesn't fail the whole scan.
+    def get(guid):
+        if guid == "bad_api":
+            # non-212 Connect error
+            raise make_client_error(
+                4, http_status=404, message="Content not found"
+            )
+        if guid == "bad_other":
+            raise RuntimeError("connection reset")
+        content = MagicMock()
+        content.packages = [
+            {"name": "flask", "version": "2.0", "language": "python", "hash": "h1"}
+        ]
+        return content
+
+    visitor = MagicMock()
+    visitor.content.get.side_effect = get
+    monkeypatch.setattr(main, "get_visitor_client", lambda request: visitor)
+
+    resp = api.post("/api/packages", json={"guids": ["good", "bad_api", "bad_other"]})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [p["name"] for p in data["good"]["packages"]] == ["flask"]
+    # The Connect error surfaces the human-readable message, not the raw object dump.
+    assert data["bad_api"]["packages"] == []
+    assert data["bad_api"]["error"] == "Connect API error: Content not found"
+    # A non-Connect error is reported with a curated message (the raw exception is
+    # logged, not shown).
+    assert data["bad_other"]["packages"] == []
+    assert data["bad_other"]["error"] == "Couldn't read this content's packages."
+
+
+def test_packages_endpoint_show_all_uses_server_wide(monkeypatch, api):
+    # The admin "all content" view reads the server-wide packages endpoint once and
+    # groups by guid, rather than fetching each item individually.
+    visitor = MagicMock()
+    visitor.packages.fetch.return_value = [
+        {
+            "app_guid": "g1",
+            "name": "flask",
+            "version": "2.0",
+            "language": "python",
+            "hash": "h1",
+        },
+        {
+            "app_guid": "g1",
+            "name": "numpy",
+            "version": "1.0",
+            "language": "python",
+            "hash": "h2",
+        },
+        {
+            "app_guid": "g2",
+            "name": "dplyr",
+            "version": "1.1",
+            "language": "r",
+            "hash": "h3",
+        },
+        {
+            "app_guid": "gX",
+            "name": "other",
+            "version": "0.1",
+            "language": "python",
+            "hash": "h4",
+        },
+    ]
+    monkeypatch.setattr(main, "get_visitor_client", lambda request: visitor)
+
+    resp = api.post(
+        "/api/packages", json={"guids": ["g1", "g2", "g3"], "show_all": True}
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert {p["name"] for p in data["g1"]["packages"]} == {"flask", "numpy"}
+    assert [p["name"] for p in data["g2"]["packages"]] == ["dplyr"]
+    assert data["g3"]["packages"] == []  # requested but has no packages
+    assert "gX" not in data  # not requested, so not returned
+    visitor.packages.fetch.assert_called_once()
+    visitor.content.get.assert_not_called()
 
 
 def test_packages_endpoint_non_client_error_is_502(monkeypatch, api):
+    # A non-Connect failure in the server-wide read returns a descriptive 502 for
+    # the whole request rather than a bare 500.
     visitor = MagicMock()
-    visitor.content.get.side_effect = RuntimeError("network down")
+    visitor.packages.fetch.side_effect = RuntimeError("network down")
     monkeypatch.setattr(main, "get_visitor_client", lambda request: visitor)
 
-    resp = api.get("/api/packages/g1")
+    resp = api.post("/api/packages", json={"guids": ["g1"], "show_all": True})
 
     assert resp.status_code == 502
     assert resp.json()["detail"] == "Couldn't fetch packages from Connect."

--- a/extensions/package-vulnerability-scanner/test_main.py
+++ b/extensions/package-vulnerability-scanner/test_main.py
@@ -150,6 +150,24 @@ def test_fetch_with_retry_returns_value():
     assert len(calls) == 1
 
 
+def test_fetch_with_retry_honors_a_caller_supplied_timeout(monkeypatch):
+    # The server-wide read passes its own, much larger budget; make sure the
+    # override reaches asyncio.wait_for instead of the per-call default.
+    seen = []
+    real_wait_for = asyncio.wait_for
+
+    async def record(aw, timeout):
+        seen.append(timeout)
+        return await real_wait_for(aw, timeout)
+
+    monkeypatch.setattr(main.asyncio, "wait_for", record)
+
+    asyncio.run(main._fetch_with_retry(lambda: "ok"))
+    asyncio.run(main._fetch_with_retry(lambda: "ok", timeout=1234))
+
+    assert seen == [main.CONNECT_API_TIMEOUT_SECONDS, 1234]
+
+
 def test_fetch_with_retry_retries_transient_then_succeeds(monkeypatch):
     monkeypatch.setattr(main.asyncio, "sleep", noop_sleep)
     calls = []
@@ -588,6 +606,28 @@ def test_packages_endpoint_show_all_uses_server_wide(monkeypatch, api):
     assert "gX" not in data  # not requested, so not returned
     visitor.packages.fetch.assert_called_once()
     visitor.content.get.assert_not_called()
+
+
+def test_packages_endpoint_show_all_uses_the_server_wide_timeout(monkeypatch, api):
+    # That read paginates the whole server, so it must not inherit the
+    # single-call budget that would abort it partway through a large scan.
+    seen = []
+    real_wait_for = asyncio.wait_for
+
+    async def record(aw, timeout):
+        seen.append(timeout)
+        return await real_wait_for(aw, timeout)
+
+    monkeypatch.setattr(main.asyncio, "wait_for", record)
+    visitor = MagicMock()
+    visitor.packages.fetch.return_value = []
+    monkeypatch.setattr(main, "get_visitor_client", lambda request: visitor)
+
+    resp = api.post("/api/packages", json={"guids": ["g1"], "show_all": True})
+
+    assert resp.status_code == 200
+    assert main.SERVER_WIDE_TIMEOUT_SECONDS in seen
+    assert main.SERVER_WIDE_TIMEOUT_SECONDS > main.CONNECT_API_TIMEOUT_SECONDS
 
 
 def test_packages_endpoint_show_all_skips_malformed_record(monkeypatch, api):


### PR DESCRIPTION
Split out of #428 into small, reviewable PRs (tracking issue #415). Stacked 5/10 — stacked on #456, merge bottom-up.

Replaces the single-item `GET /api/packages/{guid}` with a batched `POST /api/packages` that reads every requested item in one request, plus an administrator "all content" path that reads Connect's server-wide packages endpoint once instead of item by item. An unreadable item is reported on that item rather than failing the whole scan.

The server-wide read gets its own `SERVER_WIDE_TIMEOUT_SECONDS` (300s) rather than the 30s per-call budget: it paginates every package record on the server, so its runtime scales with the size of the deployment. Under the shared budget a large server would time out partway through, retry the whole pass twice more, and then fail the scan this batching exists to make possible.

The packages store also clears its previous failure before the empty-list early return, so a caller that ends up with nothing left to fetch still retires the last attempt's error (see #459, which depends on this).
