### PR TITLE
feat(package-vulnerability-scanner): batch package/vuln loading in the content list

### DIFF
--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -23,11 +23,11 @@
     "dist/assets/index-CKUnK_gI.css": {
       "checksum": "910900dfbf81f7ac4caf125b844a495c"
     },
-    "dist/assets/index-CgkWwSXn.js": {
-      "checksum": "31a12fd9c6e9d80d692a587a0bc20ec5"
+    "dist/assets/index-BR_SAMDl.js": {
+      "checksum": "1641c59b4d18d7029985a3b98890a397"
     },
     "dist/index.html": {
-      "checksum": "d8f8de453602d81829635911a04d612d"
+      "checksum": "5bb81dbee09e839af32e17caedc8a436"
     },
     "main.py": {
       "checksum": "ea913b00aaac84531ee46021969f4eaa"

--- a/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentCard.vue
@@ -34,7 +34,7 @@ const hasLanguageVersion = computed(() => {
 });
 
 function handleClick() {
-  scannerStore.currentContent = props.content;
+  scannerStore.currentContentGuid = props.content.guid;
   scrollTo({ top: 0, left: 0, behavior: "instant" });
 }
 </script>

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.test.ts
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { mount, flushPromises } from "@vue/test-utils";
+
+import ContentList from "./ContentList.vue";
+import { useContentStore } from "../stores/content";
+import { useScannerStore } from "../stores/scanner";
+import type { User } from "../stores/user";
+
+const user = {
+  guid: "u1",
+  username: "amy",
+  first_name: "Amy",
+  last_name: "Lin",
+  user_role: "administrator",
+} as User;
+
+function item(guid: string) {
+  return { guid, title: guid, bundle_id: "1" };
+}
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+// Routes by endpoint so a test can fail one of them independently. `contentList`
+// is what /api/content returns next; `packagesFail` fails the next package read.
+function stubFetch(state: { contentList: string[]; packagesFail: boolean }) {
+  const fn = vi.fn(async (url: string) => {
+    if (url.startsWith("api/content")) {
+      return ok(state.contentList.map(item));
+    }
+    if (url === "api/packages") {
+      if (state.packagesFail) {
+        return {
+          ok: false,
+          status: 500,
+          json: async () => ({ detail: "Connect is down" }),
+        };
+      }
+      return ok(
+        Object.fromEntries(state.contentList.map((g) => [g, { packages: [] }])),
+      );
+    }
+    return ok({ pypi: {}, cran: {} });
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("ContentList scan state across the content toggle", () => {
+  it("retires a failed all-content scan when switching back to your own content", async () => {
+    const state = { contentList: ["g1"], packagesFail: false };
+    stubFetch(state);
+    const contentStore = useContentStore();
+    const scannerStore = useScannerStore();
+    contentStore.contentList = [item("g1")];
+    contentStore.isContentLoaded = true;
+
+    mount(ContentList, { props: { user }, shallow: true });
+    await flushPromises();
+    expect(scannerStore.scanFailed).toBe(false);
+
+    // Switch to all content; that view's package read fails.
+    state.contentList = ["g1", "g2"];
+    state.packagesFail = true;
+    contentStore.showAllContent = true;
+    await flushPromises();
+    expect(scannerStore.scanFailed).toBe(true);
+    expect(scannerStore.scanError).toBe("Connect is down");
+
+    // Switching back leaves nothing new to fetch, but the previous view's
+    // failure must not outlive it.
+    state.contentList = ["g1"];
+    contentStore.showAllContent = false;
+    await flushPromises();
+
+    expect(scannerStore.scanFailed).toBe(false);
+    expect(scannerStore.scanError).toBeNull();
+  });
+});

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.test.ts
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.test.ts
@@ -89,4 +89,63 @@ describe("ContentList scan state across the content toggle", () => {
     expect(scannerStore.scanFailed).toBe(false);
     expect(scannerStore.scanError).toBeNull();
   });
+
+  it("ignores an abandoned view's failure that lands after a newer toggle", async () => {
+    // Hold the all-content package read open so the switch back overtakes it,
+    // then release it as a failure: the newer view must have the last word.
+    const state = { contentList: ["g1"] };
+    let releaseFailure: () => void = () => {};
+    let holdNext = false;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.startsWith("api/content")) {
+          return ok(state.contentList.map(item));
+        }
+        if (url === "api/packages") {
+          if (holdNext) {
+            holdNext = false;
+            return new Promise((resolve) => {
+              releaseFailure = () =>
+                resolve({
+                  ok: false,
+                  status: 500,
+                  json: async () => ({ detail: "Connect is down" }),
+                });
+            });
+          }
+          return ok(
+            Object.fromEntries(
+              state.contentList.map((g) => [g, { packages: [] }]),
+            ),
+          );
+        }
+        return ok({ pypi: {}, cran: {} });
+      }),
+    );
+
+    const contentStore = useContentStore();
+    const scannerStore = useScannerStore();
+    contentStore.contentList = [item("g1")];
+    contentStore.isContentLoaded = true;
+
+    mount(ContentList, { props: { user }, shallow: true });
+    await flushPromises();
+
+    state.contentList = ["g1", "g2"];
+    holdNext = true;
+    contentStore.showAllContent = true;
+    await flushPromises();
+
+    state.contentList = ["g1"];
+    contentStore.showAllContent = false;
+    await flushPromises();
+
+    releaseFailure();
+    await flushPromises();
+
+    expect(scannerStore.scanError).toBeNull();
+    expect(scannerStore.scanFailed).toBe(false);
+  });
 });

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -32,50 +32,49 @@ const scannerStore = useScannerStore();
 // Use store's showAllContent to persist state across remounts
 const { showAllContent } = storeToRefs(contentStore);
 
-// Watch for toggle changes and refetch content
+// Refetch the content list when the toggle changes. Packages already fetched
+// stay cached, so only newly visible content is loaded.
 watch(showAllContent, async () => {
-  packagesStore.clearAllPackages();
-  await contentStore.fetchContentList(true);
-  fetchPackagesInBatches();
+  try {
+    await contentStore.fetchContentList(true);
+    scanPackages();
+  } catch {
+    // The refetch failed; App surfaces contentStore.error, so nothing to do here.
+  }
 });
 
-// Fetch packages in batches to avoid overwhelming the server
-async function fetchPackagesInBatches(batchSize = 3) {
+// Load packages for the visible content in one batched request, then look up
+// vulnerabilities for the exact installed versions.
+async function scanPackages() {
   const contentToFetch = contentStore.contentList.filter(
     (content) =>
       !packagesStore.contentItems[content.guid]?.isFetched &&
       !packagesStore.contentItems[content.guid]?.isLoading,
   );
 
-  // Process in batches
-  for (let i = 0; i < contentToFetch.length; i += batchSize) {
-    const batch = contentToFetch.slice(i, i + batchSize);
-
-    // Fetch packages for this batch in parallel
-    const fetchPromises = batch.map(async (content) => {
-      if (content.bundle_id === null) {
-        packagesStore.setPackagesForContent(
-          content.guid,
-          [],
-          new Error("This content has not been fully deployed."),
-        );
-        return;
-      }
-      try {
-        return await packagesStore.fetchPackagesForContent(content.guid);
-      } catch (err) {
-        return console.error(
-          `Error fetching packages for ${content.guid}:`,
-          err,
-        );
-      }
-    });
-
-    await Promise.all(fetchPromises);
+  // Content that never finished deploying has no packages to read.
+  const guidsToFetch: string[] = [];
+  for (const content of contentToFetch) {
+    if (content.bundle_id === null) {
+      packagesStore.setPackagesForContent(
+        content.guid,
+        [],
+        new Error("This content has not been fully deployed."),
+      );
+    } else {
+      guidsToFetch.push(content.guid);
+    }
   }
 
-  // Packages are loaded; look up vulnerabilities for the exact installed
-  // versions. Skip on a plain remount where nothing new was fetched.
+  if (guidsToFetch.length > 0) {
+    try {
+      await packagesStore.fetchPackages(guidsToFetch, showAllContent.value);
+    } catch (err) {
+      console.error("Error fetching packages:", err);
+    }
+  }
+
+  // Skip the vuln lookup on a plain remount where nothing new was fetched.
   if (contentToFetch.length > 0 || !vulnStore.isFetched) {
     await vulnStore.fetchVulns(
       collectInstalledPackages(
@@ -86,7 +85,7 @@ async function fetchPackagesInBatches(batchSize = 3) {
   }
 }
 
-fetchPackagesInBatches();
+scanPackages();
 
 const tabs = computed<Tab[]>(() => {
   const result: Tab[] = [];
@@ -157,7 +156,8 @@ const filteredContent = computed(() => {
   let content = [...scannerStore.content];
 
   if (activeTab.value === "With Vulnerabilities") {
-    content = scannerStore.contentWithVulnerabilities;
+    // Copy so the in-place sort below doesn't mutate the computed's cached array.
+    content = [...scannerStore.contentWithVulnerabilities];
   }
 
   content = content.sort((a, b) => {
@@ -200,23 +200,28 @@ const userHeader = computed(() => {
 
   return `${name}'s Content on Connect`;
 });
+
+// Surface whose access the scan runs with. In the default view it acts as the
+// signed-in viewer through a Visitor API Key; in the admin "all content" view it
+// uses the administrator's own access to reach every published item.
+const identityNote = computed(() =>
+  showAllContent.value
+    ? "Showing all published content on this Connect server, using your administrator access."
+    : "Scanning as you through a Connect Visitor API Key, so you only see content you can access. No admin key is stored.",
+);
 </script>
 
 <template>
   <div class="mb-10 p-5 bg-white rounded-lg shadow-md">
-    <div v-if="contentStore.error">
+    <div v-if="!scannerStore.hasContent">
       <StatusMessage
-        type="error"
-        message="Error loading content"
-        :details="contentStore.error.message"
-      />
-    </div>
-
-    <div v-else-if="!scannerStore.hasContent">
-      <StatusMessage
-        type="warning"
-        message="No content found"
-        details="No published content was found on this Connect server."
+        type="info"
+        message="No content to scan"
+        :details="
+          showAllContent
+            ? 'No published content was found on this Connect server.'
+            : 'You have no published content to scan yet.'
+        "
       />
     </div>
 
@@ -242,6 +247,7 @@ const userHeader = computed(() => {
             <input
               type="checkbox"
               v-model="showAllContent"
+              aria-label="Show all content on Connect"
               class="sr-only peer"
             />
             <div
@@ -258,7 +264,15 @@ const userHeader = computed(() => {
         </label>
       </div>
 
-      <p class="text-gray-600">
+      <p class="text-sm text-gray-500">{{ identityNote }}</p>
+
+      <StatusMessage
+        v-if="scannerStore.scanFailed"
+        type="error"
+        message="Scan couldn't complete"
+        :details="scannerStore.scanError || undefined"
+      />
+      <p v-else class="text-gray-600">
         Found {{ scannerStore.content.length }} content items with
         <SkeletonText v-if="scannerStore.scanInProgress" class="h-6 w-[2ch]" />
         <span v-else>{{ scannerStore.totalVulnerabilities }}</span>

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -32,16 +32,29 @@ const scannerStore = useScannerStore();
 // Use store's showAllContent to persist state across remounts
 const { showAllContent } = storeToRefs(contentStore);
 
+// Refreshes run one at a time. Toggling twice in quick succession would
+// otherwise let the abandoned view's request finish last and report its result
+// over the newer one, leaving a failure on a view that loaded fine.
+let refreshes: Promise<unknown> = Promise.resolve();
+function refresh(work: () => Promise<unknown>) {
+  // Swallow at the tail, so a failed refresh neither breaks the chain for the
+  // next one nor strands an unhandled rejection. Both callers report their own
+  // errors already, and nothing awaits the result.
+  refreshes = refreshes.then(work).catch(() => {});
+}
+
 // Refetch the content list when the toggle changes. Packages already fetched
 // stay cached, so only newly visible content is loaded.
-watch(showAllContent, async () => {
-  try {
-    await contentStore.fetchContentList(true);
-    scanPackages();
-  } catch {
-    // The refetch failed; App surfaces contentStore.error, so nothing to do here.
-  }
-});
+watch(showAllContent, () =>
+  refresh(async () => {
+    try {
+      await contentStore.fetchContentList(true);
+      await scanPackages();
+    } catch {
+      // The refetch failed; App surfaces contentStore.error, so nothing to do here.
+    }
+  }),
+);
 
 // Load packages for the visible content in one batched request, then look up
 // vulnerabilities for the exact installed versions.
@@ -86,7 +99,7 @@ async function scanPackages() {
   }
 }
 
-scanPackages();
+refresh(scanPackages);
 
 const tabs = computed<Tab[]>(() => {
   const result: Tab[] = [];

--- a/extensions/package-vulnerability-scanner/src/components/ContentList.vue
+++ b/extensions/package-vulnerability-scanner/src/components/ContentList.vue
@@ -66,12 +66,13 @@ async function scanPackages() {
     }
   }
 
-  if (guidsToFetch.length > 0) {
-    try {
-      await packagesStore.fetchPackages(guidsToFetch, showAllContent.value);
-    } catch (err) {
-      console.error("Error fetching packages:", err);
-    }
+  // Called even with nothing to fetch, so that switching back to a view whose
+  // content already loaded retires the other view's failure instead of leaving
+  // the scan permanently reported as failed.
+  try {
+    await packagesStore.fetchPackages(guidsToFetch, showAllContent.value);
+  } catch (err) {
+    console.error("Error fetching packages:", err);
   }
 
   // Skip the vuln lookup on a plain remount where nothing new was fetched.

--- a/extensions/package-vulnerability-scanner/src/components/VulnerabilityChecker.vue
+++ b/extensions/package-vulnerability-scanner/src/components/VulnerabilityChecker.vue
@@ -28,7 +28,7 @@ const hasPackages = computed(() => {
 
 // Go back to content list
 function goBack() {
-  scannerStore.currentContent = undefined;
+  scannerStore.currentContentGuid = undefined;
   scrollTo({ top: 0, left: 0, behavior: "instant" });
 }
 

--- a/extensions/package-vulnerability-scanner/src/lib/collectInstalledPackages.test.ts
+++ b/extensions/package-vulnerability-scanner/src/lib/collectInstalledPackages.test.ts
@@ -19,7 +19,6 @@ function item(guid: string, packages: Package[]): ContentPackages {
     isLoading: false,
     error: null,
     isFetched: true,
-    lastFetchTime: null,
   };
 }
 

--- a/extensions/package-vulnerability-scanner/src/stores/packages.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/packages.ts
@@ -16,13 +16,11 @@ export interface ContentPackages {
   isLoading: boolean;
   error: Error | null;
   isFetched: boolean;
-  lastFetchTime: Date | null;
 }
 
 export const usePackagesStore = defineStore("packages", () => {
   // Map of content packages by GUID
   const contentItems = ref<Record<string, ContentPackages>>({});
-  const isLoading = ref(false);
   const error = ref<Error | null>(null);
 
   // Fetch packages for the given content in one request. The backend returns
@@ -43,7 +41,6 @@ export const usePackagesStore = defineStore("packages", () => {
           isLoading: true,
           error: null,
           isFetched: false,
-          lastFetchTime: null,
         };
       } else {
         contentItems.value[guid].isLoading = true;
@@ -79,7 +76,6 @@ export const usePackagesStore = defineStore("packages", () => {
           item.error = null;
         }
         item.isFetched = true;
-        item.lastFetchTime = new Date();
         item.isLoading = false;
       }
     } catch (err) {
@@ -111,14 +107,12 @@ export const usePackagesStore = defineStore("packages", () => {
       isLoading: false,
       error,
       isFetched: true,
-      lastFetchTime: new Date(),
     };
   }
 
   return {
     // State
     contentItems,
-    isLoading,
     error,
 
     // Actions

--- a/extensions/package-vulnerability-scanner/src/stores/packages.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/packages.ts
@@ -115,20 +115,6 @@ export const usePackagesStore = defineStore("packages", () => {
     };
   }
 
-  // Still called from ContentList.vue's not-yet-updated toggle handler; that
-  // caller goes away (the batched fetch keeps the cache across toggles instead)
-  // in the PR that rewrites ContentList.vue.
-  function clearAllPackages() {
-    contentItems.value = {};
-  }
-
-  // Thin compatibility wrapper for ContentList.vue's not-yet-updated per-item
-  // fetch loop; removed once that caller is rewritten to call fetchPackages
-  // directly with every guid it needs at once.
-  async function fetchPackagesForContent(guid: string) {
-    return fetchPackages([guid]);
-  }
-
   return {
     // State
     contentItems,
@@ -138,7 +124,5 @@ export const usePackagesStore = defineStore("packages", () => {
     // Actions
     fetchPackages,
     setPackagesForContent,
-    clearAllPackages,
-    fetchPackagesForContent,
   };
 });

--- a/extensions/package-vulnerability-scanner/src/stores/scanner.test.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/scanner.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+
+import { useScannerStore } from "./scanner";
+import { useContentStore } from "./content";
+import { usePackagesStore, type Package } from "./packages";
+import { useVulnsStore, type Vulnerability } from "./vulns";
+
+function pkg(name: string, version: string, language: string): Package {
+  return { name, version, language, hash: null };
+}
+
+function vuln(id: string, version: string): Vulnerability {
+  return {
+    id,
+    versions: { [version]: {} },
+    ranges: [],
+    summary: "",
+    details: "",
+    modified: "",
+    published: "",
+  };
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe("scanner store content", () => {
+  it("cross-references packages against vulns and counts them", () => {
+    const content = useContentStore();
+    const packages = usePackagesStore();
+    const vulns = useVulnsStore();
+    content.contentList = [{ guid: "g1", title: "A" }];
+    packages.setPackagesForContent("g1", [pkg("flask", "2.0", "python")]);
+    vulns.pypi = { flask: [vuln("CVE-1", "2.0")] };
+
+    const scanner = useScannerStore();
+
+    expect(scanner.content[0].vulnerabilityCount).toBe(1);
+    expect(scanner.totalVulnerabilities).toBe(1);
+    expect(scanner.contentWithVulnerabilities).toHaveLength(1);
+  });
+
+  it("marks content as loading packages while its entry is missing", () => {
+    const content = useContentStore();
+    content.contentList = [{ guid: "g1", title: "A" }];
+
+    const scanner = useScannerStore();
+
+    expect(scanner.content[0].isLoadingPackages).toBe(true);
+  });
+
+  it("ignores cached packages for content no longer in the list", () => {
+    const content = useContentStore();
+    const packages = usePackagesStore();
+    const vulns = useVulnsStore();
+    // g2 is cached and vulnerable but not shown, so it must not be counted.
+    content.contentList = [{ guid: "g1", title: "A" }];
+    packages.setPackagesForContent("g1", []);
+    packages.setPackagesForContent("g2", [pkg("flask", "2.0", "python")]);
+    vulns.pypi = { flask: [vuln("CVE-1", "2.0")] };
+
+    const scanner = useScannerStore();
+
+    expect(scanner.totalVulnerabilities).toBe(0);
+  });
+});
+
+describe("scanner store scan status", () => {
+  it("reports no error and a scan in progress until vulns are fetched", () => {
+    const scanner = useScannerStore();
+
+    expect(scanner.scanError).toBeNull();
+    expect(scanner.scanFailed).toBe(false);
+    expect(scanner.scanInProgress).toBe(true);
+  });
+
+  it("resolves scanInProgress once vulns are fetched and nothing is loading", () => {
+    const vulns = useVulnsStore();
+    vulns.isFetched = true;
+    vulns.isLoading = false;
+
+    const scanner = useScannerStore();
+
+    expect(scanner.scanInProgress).toBe(false);
+  });
+
+  it("surfaces a package failure and ends the scan", () => {
+    const packages = usePackagesStore();
+    packages.error = new Error("Couldn't fetch packages from Connect.");
+
+    const scanner = useScannerStore();
+
+    expect(scanner.scanFailed).toBe(true);
+    expect(scanner.scanError).toBe("Couldn't fetch packages from Connect.");
+    expect(scanner.scanInProgress).toBe(false);
+  });
+
+  it("surfaces a vulnerability-service failure", () => {
+    const vulns = useVulnsStore();
+    vulns.error = new Error(
+      "Couldn't fetch vulnerabilities from Package Manager.",
+    );
+
+    const scanner = useScannerStore();
+
+    expect(scanner.scanFailed).toBe(true);
+    expect(scanner.scanError).toBe(
+      "Couldn't fetch vulnerabilities from Package Manager.",
+    );
+  });
+
+  it("reports the package failure first when both fail", () => {
+    const packages = usePackagesStore();
+    const vulns = useVulnsStore();
+    packages.error = new Error("package error");
+    vulns.error = new Error("vuln error");
+
+    const scanner = useScannerStore();
+
+    expect(scanner.scanError).toBe("package error");
+  });
+});

--- a/extensions/package-vulnerability-scanner/src/stores/scanner.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/scanner.ts
@@ -18,7 +18,7 @@ export interface Content extends ContentListItem {
 }
 
 export const useScannerStore = defineStore("scanner", () => {
-  const currentContent = ref<Content>();
+  const currentContentGuid = ref<string>();
 
   const content = computed<Content[]>(() => {
     const contentStore = useContentStore();
@@ -54,6 +54,14 @@ export const useScannerStore = defineStore("scanner", () => {
     });
   });
 
+  // Resolve the selected item from the live `content` list by its guid, so the detail
+  // view tracks package and vulnerability updates instead of a snapshot taken at click.
+  const currentContent = computed<Content | undefined>(() =>
+    currentContentGuid.value === undefined
+      ? undefined
+      : content.value.find((item) => item.guid === currentContentGuid.value),
+  );
+
   const contentWithVulnerabilities = computed<Content[]>(() => {
     return content.value.filter((item) => item.vulnerabilityCount > 0);
   });
@@ -73,9 +81,24 @@ export const useScannerStore = defineStore("scanner", () => {
     return content.value.some((content) => content.isLoadingPackages);
   });
 
-  // True until both the packages and their vulnerabilities have loaded, so the
-  // vulnerability counts show a loading state rather than a premature zero.
+  // A failed package or vulnerability fetch ends the scan. Surface the reason the
+  // failing store reported, so the UI shows what actually went wrong instead of a
+  // misleading zero.
+  const scanError = computed<string | null>(() => {
+    const packagesError = usePackagesStore().error;
+    if (packagesError) return packagesError.message;
+    const vulnsError = useVulnsStore().error;
+    if (vulnsError) return vulnsError.message;
+    return null;
+  });
+
+  const scanFailed = computed<boolean>(() => scanError.value !== null);
+
+  // True until packages and their vulnerabilities have loaded, so the counts show
+  // a loading state rather than a premature zero. A failure ends the scan so the
+  // loading state can resolve to the error message.
   const scanInProgress = computed<boolean>(() => {
+    if (scanFailed.value) return false;
     const vulnsStore = useVulnsStore();
     return (
       anyContentLoadingPackages.value ||
@@ -85,6 +108,7 @@ export const useScannerStore = defineStore("scanner", () => {
   });
 
   return {
+    currentContentGuid,
     currentContent,
     content,
     contentWithVulnerabilities,
@@ -92,5 +116,7 @@ export const useScannerStore = defineStore("scanner", () => {
     totalVulnerabilities,
     anyContentLoadingPackages,
     scanInProgress,
+    scanFailed,
+    scanError,
   };
 });

--- a/extensions/package-vulnerability-scanner/src/stores/vulns.ts
+++ b/extensions/package-vulnerability-scanner/src/stores/vulns.ts
@@ -43,7 +43,6 @@ export const useVulnsStore = defineStore("vulns", () => {
 
   // Track fetch status
   const isFetched = ref(false);
-  const lastFetchTime = ref<Date | null>(null);
 
   // Actions
   // Look up vulnerabilities for the exact installed versions the caller gathered.
@@ -72,7 +71,6 @@ export const useVulnsStore = defineStore("vulns", () => {
       pypi.value = data.pypi || {};
       cran.value = data.cran || {};
       isFetched.value = true;
-      lastFetchTime.value = new Date();
     } catch (err) {
       console.error("Error fetching vulnerabilities:", err);
       error.value = err as Error;
@@ -166,7 +164,6 @@ export const useVulnsStore = defineStore("vulns", () => {
     isLoading,
     error,
     isFetched,
-    lastFetchTime,
 
     // Actions
     fetchVulns,


### PR DESCRIPTION
Split out of #428 into small, reviewable PRs (tracking issue #415). Stacked 7/10 — stacked on #458, merge bottom-up.

`ContentList.vue` now fetches packages for the visible content in one batched request instead of hand-rolled batches of 3, and keeps the package cache across the all-content toggle. Also fixes a sort bug where the "With Vulnerabilities" tab mutated the store's cached array in place, and reworks `scanner.ts` to track the selected item by guid (live) instead of a stored snapshot.

Two toggle bugs the caching introduced, both covered by tests in `ContentList.test.ts`:

- After a failed all-content scan, switching back to your own content left nothing new to fetch, so the failure was never retired: the error banner stayed up, the vulnerability total stayed hidden, and every card read "Not scanned" over data that had loaded fine.
- Toggling twice quickly let the abandoned view's request finish last and report over the newer one, leaving a failure on a view whose content loaded fine. Refreshes now run one at a time.

Also drops store state nothing reads: the packages store's own `isLoading` was never assigned, and `lastFetchTime` was written on every fetch but never read, in both the packages and vulns stores. Both predate this work. The per-item `isLoading` stays — `scanner.ts` reads it.
