### PR TITLE
docs(package-vulnerability-scanner): rewrite README, tidy CONTRIBUTING, release 3.0.7

### DIFF
--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to the Package Vulnerability Scanner extension will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.7] - 2026-07-29
+
+### Added
+
+- Show whose access the scan runs with: the signed-in viewer through a Connect Visitor API Key in the default view, or the administrator's own access in the "all content" view. (#415)
+
+### Changed
+
+- Read installed packages efficiently at scale: your own content is read a few items at a time concurrently, while an administrator's "all content" view reads every item in one server-wide pass, both retrying transient failures, so scanning thousands of items stays fast without overwhelming Connect or timing out. (#415)
+- Query Package Manager for vulnerabilities in parallel across chunks, and keep already-fetched packages cached when toggling between your content and all content. (#415)
+- Retry a transient Package Manager failure with a short backoff before surfacing an error, so a brief network or server blip doesn't fail the whole scan. (#415)
+
+### Fixed
+
+- Scan the signed-in viewer's own content instead of the publisher's. The app now makes Connect API calls with the viewer's session token, so each person sees the content they published and their own name in the header; previously everyone saw the content and name of whoever deployed the app. Requires a Connect Visitor API Key integration. (#415)
+- Require the viewer's Connect session before scanning: when the app can't read a session token (for example if OAuth integrations are disabled on the server), it prompts for setup instead of falling back to the deployer's client and showing the deployer's content. (#415)
+- Show an in-app setup message with the steps to add the required Connect Visitor API Key integration when it is missing, instead of hanging on the loading spinner. (#415)
+- Time out a Connect API call that never responds, so an unresponsive server fails with a message (retried the same as a 5xx) instead of hanging the scan indefinitely. (#415)
+- When a scan can't complete, show the specific reason instead of a misleading "0 vulnerabilities" or an endless "Loading" spinner. A failure loading your content, your account, a content item's packages, or the vulnerability data now surfaces the reason Connect or Posit Package Manager reported. (#415)
+- Continue the scan when a single content item's packages can't be read, reporting the reason on that item instead of failing the whole scan. (#415)
+- Keep a content item's detail view loading until its vulnerability lookup finishes, so it never briefly reports "0 vulnerabilities" while the scan is still running. (#415)
+- Show a "Not scanned" badge instead of a vulnerability verdict on a content item when the scan has failed, rather than an ambiguous loading state. (#415)
+- Track the selected content item by its guid instead of a snapshot taken at click, so its detail view reflects package and vulnerability updates instead of what was true when you clicked it. (#415)
+- Fix a sort bug: switching to the "With Vulnerabilities" tab sorted the store's cached list in place, so the tab's own filter order could leak into the "All" tab. (#415)
+- Fix a bug where a vulnerability's fixed version could be reported as unknown even when one of its ranges had a fix, because the first range with no fix ended the search instead of checking the rest. (#415)
+- Give the content-visibility toggle an accessible label so screen readers announce its purpose. (#415)
+- Set the browser tab title to "Package Vulnerability Scanner"; it was still the Vite scaffold default. (#415)
+- Remove the leftover Vite scaffold favicon reference (`/vite.svg`), which 404'd because the file isn't part of the bundle. (#415)
+
+### Security
+
+- Update frontend dependencies to clear known vulnerabilities flagged by npm audit, including a ReDoS advisory in the bundled markdown-it renderer. (#415)
+- Set `rel="noopener"` on links that open in a new tab, so a linked page can't reach back into the app through `window.opener`. (#415)
+
 ## [3.0.6] - 2026-06-26
 
 ### Fixed

--- a/extensions/package-vulnerability-scanner/CHANGELOG.md
+++ b/extensions/package-vulnerability-scanner/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Read installed packages efficiently at scale: your own content is read a few items at a time concurrently, while an administrator's "all content" view reads every item in one server-wide pass, both retrying transient failures, so scanning thousands of items stays fast without overwhelming Connect or timing out. (#415)
 - Query Package Manager for vulnerabilities in parallel across chunks, and keep already-fetched packages cached when toggling between your content and all content. (#415)
 - Retry a transient Package Manager failure with a short backoff before surfacing an error, so a brief network or server blip doesn't fail the whole scan. (#415)
+- Raise the minimum Python version to 3.11, matching the version this extension is actually tested against. (#415)
 
 ### Fixed
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Time out a Connect API call that never responds, so an unresponsive server fails with a message (retried the same as a 5xx) instead of hanging the scan indefinitely. (#415)
 - When a scan can't complete, show the specific reason instead of a misleading "0 vulnerabilities" or an endless "Loading" spinner. A failure loading your content, your account, a content item's packages, or the vulnerability data now surfaces the reason Connect or Posit Package Manager reported. (#415)
 - Continue the scan when a single content item's packages can't be read, reporting the reason on that item instead of failing the whole scan. (#415)
+- Continue the administrator "all content" scan when a single package record from Connect is malformed, instead of failing the whole scan. (#415)
 - Keep a content item's detail view loading until its vulnerability lookup finishes, so it never briefly reports "0 vulnerabilities" while the scan is still running. (#415)
 - Show a "Not scanned" badge instead of a vulnerability verdict on a content item when the scan has failed, rather than an ambiguous loading state. (#415)
 - Track the selected content item by its guid instead of a snapshot taken at click, so its detail view reflects package and vulnerability updates instead of what was true when you clicked it. (#415)

--- a/extensions/package-vulnerability-scanner/CONTRIBUTING.md
+++ b/extensions/package-vulnerability-scanner/CONTRIBUTING.md
@@ -22,7 +22,7 @@ to manage Node.js versions.
 ## Tests
 
 - Backend: `uv run pytest` runs the FastAPI API tests in `test_main.py`.
-- Frontend: `npm test` runs the store tests with [Vitest](https://vitest.dev/).
+- Frontend: `npm test` runs the store, component, and utility tests with [Vitest](https://vitest.dev/).
 
 Both suites also run in CI on every change: `npm test` before the frontend build
 and `uv run pytest` after.

--- a/extensions/package-vulnerability-scanner/CONTRIBUTING.md
+++ b/extensions/package-vulnerability-scanner/CONTRIBUTING.md
@@ -19,6 +19,14 @@ to manage Node.js versions.
 1. Run `uv run fastapi dev main.py` to start the FastAPI server.
 2. Run the frontend development server with `npm run dev`.
 
+## Tests
+
+- Backend: `uv run pytest` runs the FastAPI API tests in `test_main.py`.
+- Frontend: `npm test` runs the store tests with [Vitest](https://vitest.dev/).
+
+Both suites also run in CI on every change: `npm test` before the frontend build
+and `uv run pytest` after.
+
 ## Deploy
 
 Run `npm run build` to generate the frontend JS and CSS files in the `dist`
@@ -26,22 +34,12 @@ directory.
 
 From there the required files to be sent in the bundle are:
 
-- `main.py',
-- 'requirements.txt'
+- `main.py`
+- `requirements.txt`
 - `dist/**`
 
 ## Changelog
 
-We use the [CHANGELOG](./CHANGELOG.md) to document all notable changes to the
-Package Vulnerability Scanner. When contributing, update the changelog as
-follows:
-
-1. For unreleased changes:
-   - Add your changes to the "Unreleased" section
-   - Include a brief description under the appropriate subsection
-     using the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
-   - Reference any PR or issue number (e.g., #123)
-
-2. For releases:
-   - A new version section will be created during the release process
-   - Follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) guidelines
+Update the [CHANGELOG](./CHANGELOG.md) using the
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, referencing the
+PR number, and bump `extension.version` in `manifest.json` to trigger a release.

--- a/extensions/package-vulnerability-scanner/README.md
+++ b/extensions/package-vulnerability-scanner/README.md
@@ -1,4 +1,61 @@
 # Package Vulnerability Scanner
 
-Shows the vulnerabilities affecting the content you have published to Posit
-Connect.
+## About this extension
+
+The Package Vulnerability Scanner checks the content you have published to Posit
+Connect for known security vulnerabilities in its installed Python and R packages,
+using [Posit Package Manager](https://packagemanager.posit.co) as the
+vulnerability source. You get an overview of how many vulnerabilities affect your
+content, and a per-item view showing each affected package, the Common
+Vulnerabilities and Exposures (CVEs) reported against it, and the version to
+upgrade to. Administrators can switch to a server-wide view covering all content
+on Connect.
+
+## How it works
+
+The app calls the Connect API with the viewer's own identity, through a Connect
+Visitor API Key integration, so each person sees the content they published;
+administrators can toggle to all content on the server. It fetches the installed
+packages for your content concurrently rather than one item at a time, so a
+server with thousands of items scans quickly.
+
+Each package is checked against Posit Package Manager at the version actually
+installed in your content, so the scan catches vulnerabilities in older deployed
+versions that were fixed in a later release, not only packages whose latest
+version is vulnerable. The main view summarizes vulnerable content; selecting an
+item lists its packages (all, Python, R, or only vulnerable), each CVE's details,
+and the latest fixed version to upgrade to.
+
+## Deploy it
+
+Deploy it straight from the Connect Gallery to get a copy running, then configure
+it (below). To run a customized version, get the
+[extension source](https://github.com/posit-dev/connect-extensions/tree/main/extensions/package-vulnerability-scanner),
+make your changes, and publish with
+[`rsconnect deploy fastapi`](https://docs.posit.co/rsconnect-python/) or a
+[git-backed deployment](https://docs.posit.co/connect/user/git-backed/). Requires
+Connect 2025.04.0 or newer with API Publishing and OAuth Integrations enabled.
+
+## Setup
+
+The scanner runs as the signed-in viewer, so it needs a Visitor API Key
+integration to call the Connect API with that person's identity.
+
+After deploying, open the content's settings and, on the **Access** tab, add a
+"Connect Visitor API Key" integration under **Integrations**. Until it is added,
+the app shows a setup message instead of your content. If it isn't listed, an
+administrator must first create a **Connect API** integration on your server. See
+the [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
+
+## Customize it
+
+By default the scanner checks packages against the public
+[Posit Package Manager](https://packagemanager.posit.co). To scan against your own
+Package Manager instead, point `PPM_URL` in `main.py` at your instance's
+`/__api__/filter/packages` endpoint and redeploy.
+
+## Learn more
+
+- [Posit Package Manager](https://packagemanager.posit.co)
+- [Posit Connect OAuth integrations](https://docs.posit.co/connect/user/oauth-integrations/)
+- [FastAPI](https://fastapi.tiangolo.com/)

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -23,17 +23,17 @@
     "dist/assets/index-CKUnK_gI.css": {
       "checksum": "910900dfbf81f7ac4caf125b844a495c"
     },
-    "dist/assets/index-CxxyJVg-.js": {
-      "checksum": "f13af4f54ba15d0c3138dd15050db98f"
+    "dist/assets/index-Cxb4abnE.js": {
+      "checksum": "1e45dd3ef88afea0d9a2c142a00e9fa5"
     },
     "dist/index.html": {
-      "checksum": "d2882e6f8e6773053d99b9abd775c023"
+      "checksum": "fffb21756b16fc68105d1d89b0193708"
     },
     "main.py": {
-      "checksum": "1ab6ae2cab0ce713ca9e7bee9bfc7b1e"
+      "checksum": "7c0f15d77e26ef10ea631f1e7845f7c5"
     },
     "requirements.txt": {
-      "checksum": "9fc5cc5fb559eded1f323793b73e82c5"
+      "checksum": "706c2d25cc953fdd8f23fb51728e5da1"
     }
   },
   "extension": {

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -30,7 +30,7 @@
       "checksum": "d2882e6f8e6773053d99b9abd775c023"
     },
     "main.py": {
-      "checksum": "ea913b00aaac84531ee46021969f4eaa"
+      "checksum": "1ab6ae2cab0ce713ca9e7bee9bfc7b1e"
     },
     "requirements.txt": {
       "checksum": "9fc5cc5fb559eded1f323793b73e82c5"

--- a/extensions/package-vulnerability-scanner/manifest.json
+++ b/extensions/package-vulnerability-scanner/manifest.json
@@ -39,11 +39,11 @@
   "extension": {
     "name": "package-vulnerability-scanner",
     "title": "Package Vulnerability Scanner",
-    "description": "Scan for security vulnerabilities in your published content on Connect using Posit Package Manager. View an overview of CVEs (Common Vulnerabilities and Exposures) across all your apps, and get guidance on upgrading affected packages.",
+    "description": "Scan your published content on Connect for known security vulnerabilities in its Python and R packages, using Posit Package Manager. Get an overview of the CVEs (Common Vulnerabilities and Exposures) across your content, then open any item to see the affected packages and the version to upgrade to.",
     "homepage": "https://github.com/posit-dev/connect-extensions/tree/main/extensions/package-vulnerability-scanner",
     "category": "extension",
     "minimumConnectVersion": "2025.04.0",
     "requiredFeatures": ["API Publishing", "OAuth Integrations"],
-    "version": "3.0.6"
+    "version": "3.0.7"
   }
 }


### PR DESCRIPTION
Split out of #428 into small, reviewable PRs (tracking issue #415). Stacked 10/10 (top) — stacked on #461, merge bottom-up.

Rewrites the README to the gallery standard, adds a Tests section to CONTRIBUTING, and bumps `extension.version` to 3.0.7 to trigger the release once the stack merges.