### PR TITLE
fix: point settings instructions at the Runtime tab

### DIFF
--- a/extensions/simple-mcp-server/CHANGELOG.md
+++ b/extensions/simple-mcp-server/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the FastAPI: MCP Server extension will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9] - 2026-09-11
+
+### Changed
+
+- Updated the setup instructions in the README, the landing page, and the
+  `connect_whoami` error message for the content settings panel Connect 2026.08.0
+  introduced: Integrations and Process Settings are on the **Runtime** tab, which was
+  named **Advanced** (and, for Integrations, **Access**) on earlier versions. (#469)
+- Reframed the "keep the server warm" note: Connect 2026.05.0 and newer detect MCP
+  content and set **Min processes** to 1 on first deploy, so setting it by hand is only
+  needed on older versions. (#469)
+
 ## [0.0.8] - 2026-07-21
 
 ### Security

--- a/extensions/simple-mcp-server/README.md
+++ b/extensions/simple-mcp-server/README.md
@@ -47,10 +47,11 @@ Connect 2025.04.0 or newer with API Publishing and OAuth Integrations enabled.
 After deploying, configure it for how you'll use it:
 
 - As the signed-in viewer (the paired chat, or any Connect content): in the
-  content's settings, on the **Access** tab, add a "Connect Visitor API Key"
-  integration under **Integrations**. If it isn't listed, an administrator must
-  first create a **Connect API** integration on your server. This lets
-  `connect_whoami` identify who's calling. See the
+  content's settings, on the **Runtime** tab (**Access** before Connect
+  2026.08.0), add a "Connect Visitor API Key" integration under
+  **Integrations**. If it isn't listed, an administrator must first create a
+  **Connect API** integration on your server. This lets `connect_whoami`
+  identify who's calling. See the
   [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
 - From your own MCP client (Claude Code, Cursor, ...): point it at `{content-url}/mcp`
   and authenticate with a Connect API key (`Authorization: Key <API_KEY>`); the landing page
@@ -58,8 +59,10 @@ After deploying, configure it for how you'll use it:
   the API key; `connect_whoami` also requires the "Connect Visitor API Key" integration above,
   and then reports the identity tied to that API key (the per-viewer identity demo is clearest
   from the companion chat).
-- Keep it responsive (optional): on the **Advanced** tab, set **Min processes** to 1 or
-  more under **Process Settings** so the server doesn't cold-start. See the
+- Keep it responsive: Connect 2026.05.0 and newer recognize this as an MCP server
+  and set **Min processes** to 1 on first deploy, so it doesn't cold-start. To check
+  or change it, or to set it yourself on an older Connect, see **Process Settings**
+  on the **Runtime** tab (**Advanced** before Connect 2026.08.0). See the
   [process configuration documentation](https://docs.posit.co/connect/user/content-settings/index.html#process-configurations).
 
 ## Customize it

--- a/extensions/simple-mcp-server/index.html.jinja
+++ b/extensions/simple-mcp-server/index.html.jinja
@@ -182,9 +182,11 @@
             <span id="copyStatus"></span>
         </div>
 
-        <p><strong>Whichever way you use it, keep the server warm:</strong> in the content's settings, on
-        the "Advanced" tab, set "Min Processes" to 1 or more under "Process Settings", so it responds
-        without a cold-start delay. For more information, see the
+        <p><strong>Whichever way you use it, the server stays warm:</strong> Connect 2026.05.0 and newer
+        recognize this as an MCP server and set "Min Processes" to 1 on first deploy, so it responds
+        without a cold-start delay. To check or change it, or to set it yourself on an older Connect,
+        see "Process Settings" on the "Runtime" tab of the content's settings ("Advanced" before
+        Connect 2026.08.0). For more information, see the
         <a href="https://docs.posit.co/connect/user/content-settings/index.html#process-configurations" target="_blank" rel="noopener">content process configuration documentation</a>.</p>
 
         <h2>1. Use it from the companion chat</h2>
@@ -202,7 +204,8 @@
         {% else %}
         <div class="info-box">
             <strong>"Connect Visitor API Key" integration required.</strong> In the content's settings, on
-            the "Access" tab, add a "Connect Visitor API Key" integration under "Integrations". The
+            the "Runtime" tab ("Access" before Connect 2026.08.0), add a "Connect Visitor API Key"
+            integration under "Integrations". The
             <code>connect_whoami</code> tool needs it to identify the viewer. Once it's added, you can confirm
             that it works here: this page will greet you by name, resolved from your session token with no API
             key. For more information, see the

--- a/extensions/simple-mcp-server/main.py
+++ b/extensions/simple-mcp-server/main.py
@@ -118,7 +118,7 @@ async def connect_whoami(context: Context) -> str:
         if e.error_code == 212:
             raise ToolError(
                 'No "Connect Visitor API Key" integration configured. In the content '
-                'settings, on the "Access" tab, add a "Connect Visitor API Key" '
+                'settings, on the "Runtime" tab, add a "Connect Visitor API Key" '
                 'integration under "Integrations".'
             )
         raise ToolError(f"Error calling Connect API: {str(e)}")

--- a/extensions/simple-mcp-server/manifest.json
+++ b/extensions/simple-mcp-server/manifest.json
@@ -27,17 +27,17 @@
     "tags": ["python", "fastapi", "mcp"],
     "requiredFeatures": ["API Publishing", "OAuth Integrations"],
     "minimumConnectVersion": "2025.04.0",
-    "version": "0.0.8"
+    "version": "0.0.9"
   },
   "files": {
     "requirements.txt": {
       "checksum": "1706532b05f4f9ed11d98f990134e15f"
     },
     "main.py": {
-      "checksum": "f251569a4d149959815befd3f69d73f4"
+      "checksum": "5f5b1bcd4ecd3380780a14ee9baf8cfd"
     },
     "index.html.jinja": {
-      "checksum": "dda978e56248215b690216664eb5f8e8"
+      "checksum": "14976145b154d9be17b13057c715a8a1"
     }
   }
 }

--- a/extensions/simple-shiny-chat-with-mcp/CHANGELOG.md
+++ b/extensions/simple-shiny-chat-with-mcp/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Python Shiny: AI Chat with MCP Tools extension will b
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9] - 2026-09-11
+
+### Changed
+
+- Updated the setup instructions in the README and on the setup screen for the content
+  settings panel Connect 2026.08.0 introduced: Environment Variables and Integrations are
+  on the **Runtime** tab, which was named **Advanced** (and, for Integrations, **Access**)
+  on earlier versions. (#469)
+
 ## [0.0.8] - 2026-07-20
 
 ### Changed

--- a/extensions/simple-shiny-chat-with-mcp/README.md
+++ b/extensions/simple-shiny-chat-with-mcp/README.md
@@ -44,9 +44,10 @@ Connect 2025.04.0 or newer with OAuth Integrations enabled.
 
 After deploying, in the content's settings:
 
-- Set an LLM provider and its API key on the **Advanced** tab, under
-  **Environment Variables**: set `CHATLAS_CHAT_PROVIDER_MODEL` plus the matching
-  key. For example, to use OpenAI's GPT-4o:
+- Set an LLM provider and its API key on the **Runtime** tab (**Advanced**
+  before Connect 2026.08.0), under **Environment Variables**: set
+  `CHATLAS_CHAT_PROVIDER_MODEL` plus the matching key. For example, to use
+  OpenAI's GPT-4o:
 
   ```
   CHATLAS_CHAT_PROVIDER_MODEL = openai/gpt-4o
@@ -60,8 +61,9 @@ After deploying, in the content's settings:
   detected automatically and no variables are needed. (The older
   `CHATLAS_CHAT_PROVIDER` and `CHATLAS_CHAT_ARGS` still work but are deprecated.)
 - Add a "Connect Visitor API Key" integration so tools run as the viewer: on the
-  **Access** tab, add it under **Integrations**. If it isn't listed, an
-  administrator must first create a **Connect API** integration on your server.
+  **Runtime** tab (**Access** before Connect 2026.08.0), add it under
+  **Integrations**. If it isn't listed, an administrator must first create a
+  **Connect API** integration on your server.
   See the
   [OAuth Integrations documentation](https://docs.posit.co/connect/user/oauth-integrations/).
 

--- a/extensions/simple-shiny-chat-with-mcp/app.py
+++ b/extensions/simple-shiny-chat-with-mcp/app.py
@@ -139,7 +139,8 @@ _LLM_SETUP_SECTION = (
         ui.HTML(
             "This app needs the <code>CHATLAS_CHAT_PROVIDER_MODEL</code> environment variable "
             "and a matching LLM API key. In the content settings, on the "
-            "<strong>Advanced</strong> tab, add both of them under <strong>Environment Variables</strong>. "
+            "<strong>Runtime</strong> tab (<strong>Advanced</strong> before Connect 2026.08.0), "
+            "add both of them under <strong>Environment Variables</strong>. "
             "On AWS Bedrock with an instance role, credentials are detected automatically and no variables are needed. "
             "For more information, "
             '<a href="https://posit-dev.github.io/chatlas/reference/ChatAuto.html" class="setup-link" target="_blank" rel="noopener">see the chatlas documentation</a>.'
@@ -163,7 +164,8 @@ _INTEGRATION_SETUP_SECTION = (
         ui.HTML(
             "This app needs a \"Connect Visitor API Key\" integration so its tools run "
             "as the signed-in viewer. In the content settings, on the "
-            "<strong>Access</strong> tab, add the \"Connect Visitor API Key\" integration under "
+            "<strong>Runtime</strong> tab (<strong>Access</strong> before Connect 2026.08.0), "
+            "add the \"Connect Visitor API Key\" integration under "
             "<strong>Integrations</strong>. "
             "For more information, "
             '<a href="https://docs.posit.co/connect/user/oauth-integrations/" class="setup-link" target="_blank" rel="noopener">see the OAuth Integrations documentation</a>.'

--- a/extensions/simple-shiny-chat-with-mcp/manifest.json
+++ b/extensions/simple-shiny-chat-with-mcp/manifest.json
@@ -34,14 +34,14 @@
       "OAuth Integrations"
     ],
     "minimumConnectVersion": "2025.04.0",
-    "version": "0.0.8"
+    "version": "0.0.9"
   },
   "files": {
     "requirements.txt": {
       "checksum": "6d5f6221f547d843153e65cb81b5206c"
     },
     "app.py": {
-      "checksum": "2559ded4a34e3bdbaa602d6e9afbc852"
+      "checksum": "c9f04c9e48d7e128fd658b3d1540fdb3"
     }
   }
 }


### PR DESCRIPTION
Connect 2026.08.0 renamed the content settings **Advanced** tab to **Runtime** and moved Integrations there from **Access**, so the setup instructions in both MCP examples pointed at tabs that no longer exist. This updates the two READMEs, the MCP server's landing page and its `connect_whoami` error message, and the chat app's setup screen. Each one names the old tab in parentheses, since both examples still support Connect 2025.04.0 and newer.

Also reframes the "keep it warm" note: Connect 2026.05.0 and newer detect MCP content and set Min processes to 1 on first deploy, so setting it by hand is only needed on older versions.

Both extensions bump to 0.0.9, with refreshed manifest checksums for the edited files, so the new text actually ships to the gallery.

Let me know if the wording isn't right for these! I wasn't sure if we should reference specific settings from specific Connect versions or not.

Closes #464